### PR TITLE
Fix Ignoring that doesnt work for big scale factor

### DIFF
--- a/BerlinMOD/deliveries_datagenerator.sql
+++ b/BerlinMOD/deliveries_datagenerator.sql
@@ -156,6 +156,9 @@ BEGIN
             RAISE INFO '       Source node: %, target node: %, k: %, noSegments: %',
               sourceNode, targetNode, k, noSegments;
             RAISE INFO '       The trip of vehicle % for day % is ignored', j, aDay;
+            DELETE FROM Segments where deliveryId = delivId;
+            alltrips = '{}';
+            delivId = delivId + 1;
             CONTINUE vehicles_loop;
           END IF;
           startTime = t;
@@ -163,6 +166,9 @@ BEGIN
           IF trip IS NULL THEN
             RAISE INFO 'ERROR: A trip cannot be NULL';
             RAISE INFO '  The trip of vehicle % for day % is ignored', j, aDay;
+            DELETE FROM Segments where deliveryId = delivId;
+            alltrips = '{}';
+            delivId = delivId + 1;
             CONTINUE vehicles_loop;
           END IF;
           t = endTimestamp(trip);


### PR DESCRIPTION
I had this error during the data generation  ;

```
INFO:  ERROR: The path of a trip cannot be NULL.
INFO:         Source node: 58244, target node: 40809, k: 3, noSegments: 8
INFO:         The trip of vehicle 1361 for day 2020-06-09 is ignored
ERROR:  duplicate key value violates unique constraint "segments_pkey"
DETAIL:  Key (deliveryid, seq)=(15361, 1) already exists.
CONTEXT:  SQL statement "INSERT INTO Segments(deliveryId, seq, source, target, trip, trajectory, sourceGeom)
VALUES (delivId, k, sourceNode, targetNode, trip, trajectory(trip), sourceGeom)"
PL/pgSQL function deliveries_createdeliveries(integer,integer,date,boolean,text) line 117 at SQL statement
```

I found that was because when the trip is null we do not remove them from segments table and after doing that i found out another error

```
ERROR:  The temporal values cannot overlap on time: 2020-06-09 09:07:14.346589+02, 2020-06-09 08:44:32.065+02
```

I found out that was because of the variable alltrips that wasnt reinitialised after we found a bad trip