### PR TITLE
Function rename & MunicipalityGeo improvement

### DIFF
--- a/BerlinMOD/berlinmod_datagenerator.sql
+++ b/BerlinMOD/berlinmod_datagenerator.sql
@@ -1089,7 +1089,7 @@ SELECT berlinmod_createTrips(2, 2, '2020-05-10', 'Fastest Path', false, 'C');
 -- Main Function
 -------------------------------------------------------------------------------
 
-CREATE OR REPLACE FUNCTION berlinmod_datagenerator(
+CREATE OR REPLACE FUNCTION berlinmod_generate(
   scaleFactor float DEFAULT NULL,
   noVehicles int DEFAULT NULL, noDays int DEFAULT NULL,
   startDay date DEFAULT NULL, pathMode text DEFAULT NULL,

--- a/BerlinMOD/brussels_creategraph.sql
+++ b/BerlinMOD/brussels_creategraph.sql
@@ -95,7 +95,7 @@ BEGIN
   DROP TABLE Merge;
   DROP TABLE DeletedRoads;
   RETURN;
-END; $$
+END; $$;
 
 /*-----------------------------------------------------------------------------
 The following function creates the Roads table from which the network topology

--- a/BerlinMOD/brussels_preparedata.sql
+++ b/BerlinMOD/brussels_preparedata.sql
@@ -95,22 +95,15 @@ INSERT INTO Municipalities VALUES
 (18,'Woluwe-Saint-Lambert - Sint-Lambrechts-Woluwe',55216,0.05,7669,3590,0.04),
 (19,'Woluwe-Saint-Pierre - Sint-Pieters-Woluwe',41217,0.03,4631,2859,0.04);
 
--- Compute the geometry of the Municipalities from the boundaries in planet_osm_line
+-- Compute the geometry of the Municipalities from the boundaries in planet_osm_polygon
 
 DROP TABLE IF EXISTS MunicipalitiesGeo;
-CREATE TABLE MunicipalitiesGeo(MunicipalityName, Geom) AS
+CREATE TABLE MunicipalitiesGeo(MunicipalityName, GeomPoly) AS
 SELECT name, way
-FROM planet_osm_line
+FROM planet_osm_polygon
 WHERE name IN ( SELECT MunicipalityName FROM Municipalities );
 
--- The geometries of the Municipalities are of type Linestring. They need to be
--- converted into polygons.
-
-ALTER TABLE MunicipalitiesGeo ADD COLUMN GeomPoly geometry;
-UPDATE MunicipalitiesGeo
-SET GeomPoly = ST_MakePolygon(Geom);
-
--- Disjoint components of Ixelles and Saint-Gilles are encoded as two different
+-- Disjoint components of some municipalities which are encoded as two or more different
 -- features. For this reason ST_Union is needed to make a multipolygon
 ALTER TABLE Municipalities ADD COLUMN MunicipalityGeo geometry;
 UPDATE Municipalities m


### PR DESCRIPTION
- Rename function from **berlinmod_datagenerator** to **berlinmod_generate** in **berlinmod_datagenerator.sql** to synchronize with manual documentation. 
- Fix a minor syntax error in **brussels_creategraph.sql**. 
- Switch from using **planet_osm_line** + **ST_MakePolygon** to **planet_osm_polygon** for constructing **MunicipalityGeo** to avoid unclosed lines issue.