### PR TITLE
feat: align with MobilityDB ecosystem standards + cross-platform portability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,23 @@
-# Automatic generation of documentation will be copied and checked into the 
+# Automatic generation of documentation will be copied and checked into the
 # gh-pages branch.
 name: Documentation generation CI
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: ["main", "feat/**", "fix/**"]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+  pull_request:
+    branches: ["main", "feat/**", "fix/**"]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -32,7 +44,7 @@ jobs:
           xsltproc --stringparam html.stylesheet "docbook.css" --stringparam chunker.output.encoding "UTF-8" --xinclude -o html/index.html /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl mobilitydb-berlinmod.xml
           cp -r images docbook.css html/
           cp docbook.css html/
-          
+
       # store the documentation files
       - name: Upload output directory
         uses: actions/upload-artifact@v4
@@ -66,8 +78,8 @@ jobs:
         with:
           message: 'Update docs'
           branch: gh-pages
-          add: '["docs/index.md", 
-            "docs/mobilitydb-berlinmod.pdf", 
+          add: '["docs/index.md",
+            "docs/mobilitydb-berlinmod.pdf",
             "docs/mobilitydb-berlinmod.epub",
             "docs/html/docbook.css", "docs/html/images/*",
             "docs/html/*.html"]'

--- a/BerlinMOD/berlinmod_chapter1_queries.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Chapter 1 Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 -- Create indexes
 
 DROP INDEX IF EXISTS Trips_rtree_idx;

--- a/BerlinMOD/berlinmod_chapter1_queries_portable.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries_portable.sql
@@ -1,0 +1,165 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Chapter 1 Queries -- Portable Dialect
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+This file contains a portable version of the BerlinMOD Chapter 1 queries
+(Q1-Q6) using named functions instead of MobilityDB-specific infix operators.
+It targets the cross-platform SQL dialect established for the edge-to-cloud
+portability initiative, compatible with MobilityDB (PostgreSQL) and
+MobilityDuck (DuckDB).
+
+Operator-to-function mapping applied:
+  &&  (stbox overlap)    -> eIntersects() or overlaps()
+  @>  (contains)        -> contains()
+  <-> (distance)        -> distance()
+
+The schema assumed is:
+  Trips(TripId, VehId, Trip tgeompoint, Licence, VehicleType, Model)
+  Vehicles(VehicleId, Licence, VehicleType, Model)
+  Points(PointId, PosX, PosY, Geom geometry(Point,3857))
+  Regions(RegionId, RegionName, Geom geometry(Polygon,3857))
+  Instants(InstantId, Instant timestamptz)
+  Periods(PeriodId, Period tstzspan)
+
+-----------------------------------------------------------------------------*/
+
+-- Create indexes
+
+DROP INDEX IF EXISTS Trips_rtree_idx;
+DROP INDEX IF EXISTS Regions_rtree_idx;
+DROP INDEX IF EXISTS Periods_rtree_idx;
+
+CREATE INDEX Trips_rtree_idx ON Trips USING GIST(trip);
+CREATE INDEX Regions_rtree_idx ON Regions USING GIST(geom);
+CREATE INDEX Periods_rtree_idx ON Periods USING GIST(period);
+
+-- Create views selecting a small sample for the query parameters to minimize
+-- execution time during testing
+
+DROP VIEW IF EXISTS Trips100;
+DROP VIEW IF EXISTS Regions10;
+DROP VIEW IF EXISTS Points10;
+DROP VIEW IF EXISTS Periods10;
+
+CREATE VIEW Trips100 AS ( SELECT * FROM Trips LIMIT 100 );
+CREATE VIEW Regions10 AS ( SELECT * FROM Regions LIMIT 10 );
+CREATE VIEW Points10 AS ( SELECT * FROM Points LIMIT 10 );
+CREATE VIEW Periods10 AS ( SELECT * FROM Periods LIMIT 10 );
+
+-- Collect statistics
+
+ANALYZE;
+
+-- Show the timing of every query
+
+\timing ON
+
+-- Set the pager off
+
+\pset pager 0
+
+
+-- Range Queries
+
+-- Q1. List the vehicles that have passed at a region from Regions.
+--
+-- Original:  stbox(T.Trip) && stbox(R.Geom) AND ST_Intersects(trajectory(T.Trip), R.Geom)
+-- Portable:  eIntersects(trajectory(T.Trip), R.Geom) subsumes the bbox filter
+
+\echo '-----------'
+\echo '| Query 1 |'
+\echo '-----------'
+
+SELECT DISTINCT R.RegionId, T.VehId
+FROM Trips T, Regions10 R
+WHERE eIntersects(trajectory(T.Trip), R.Geom)
+ORDER BY R.RegionId, T.VehId;
+
+-- Q2. List the vehicles that were within a region from Regions during a period
+-- from Periods.
+--
+-- Original:  T.Trip && stbox(R.Geom, P.Period) AND eintersects(atTime(T.Trip, P.Period), R.Geom)
+-- Portable:  eIntersects(atTime(T.Trip, P.Period), R.Geom)
+
+\echo '-----------'
+\echo '| Query 2 |'
+\echo '-----------'
+
+SELECT R.RegionId, P.PeriodId, T.VehId
+FROM Trips T, Regions10 R, Periods10 P
+WHERE eIntersects(atTime(T.Trip, P.Period), R.Geom)
+ORDER BY R.RegionId, P.PeriodId, T.VehId;
+
+-- Q3. List the pairs of vehicles that were both located within a region from
+-- Regions during a period from Periods.
+--
+-- Original:  T1.Trip && stbox(...) AND eintersects(atTime(T1.Trip, P.Period), R.Geom) AND ...
+-- Portable:  eIntersects(atTime(...), R.Geom) for both trips
+
+\echo '-----------'
+\echo '| Query 3 |'
+\echo '-----------'
+
+SELECT DISTINCT T1.VehId AS VehId1, T2.VehId AS VehId2, R.RegionId, P.PeriodId
+FROM Trips T1, Trips100 T2, Regions10 R, Periods10 P
+WHERE T1.VehId < T2.VehId
+  AND eIntersects(atTime(T1.Trip, P.Period), R.Geom)
+  AND eIntersects(atTime(T2.Trip, P.Period), R.Geom)
+ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
+
+-- Q4. List the first time at which a vehicle visited a point in Points.
+--
+-- Original:  T.Trip && stbox(P.Geom) AND ST_Contains(trajectory(T.Trip), P.Geom)
+-- Portable:  eContains(trajectory(T.Trip), P.Geom)
+
+\echo '-----------'
+\echo '| Query 4 |'
+\echo '-----------'
+
+SELECT T.VehId, P.PointId,
+  MIN(startTimestamp(atValues(T.Trip, P.Geom))) AS Instant
+FROM Trips T, Points10 P
+WHERE eContains(trajectory(T.Trip), P.Geom)
+GROUP BY T.VehId, P.PointId;
+
+-- Temporal Aggregate Queries
+
+-- Q5. Compute how many vehicles were active at each period in Periods.
+--
+-- The overlap operator && on tstzspan is standard across platforms.
+
+\echo '-----------'
+\echo '| Query 5 |'
+\echo '-----------'
+
+SELECT P.PeriodId, COUNT(*),
+  numInstants(tcount(atTime(T.Trip, P.Period)))
+FROM Trips T, Periods10 P
+WHERE timeSpan(T.Trip) && P.Period
+GROUP BY P.PeriodId
+ORDER BY P.PeriodId;
+
+-- Q6. For each region in Regions, give the window temporal count of trips
+-- with a 10-minute interval.
+--
+-- atGeometry and wCount are available in MobilityDB and MobilityDuck.
+
+\echo '-----------'
+\echo '| Query 6 |'
+\echo '-----------'
+
+SELECT R.RegionId,
+  numInstants(wCount(atGeometry(T.Trip, R.Geom), interval '10 min'))
+FROM Trips T, Regions10 R
+WHERE eIntersects(trajectory(T.Trip), R.Geom)
+GROUP BY R.RegionId
+HAVING wCount(atGeometry(T.Trip, R.Geom), interval '10 min') IS NOT NULL
+ORDER BY R.RegionId;
+
+\echo '-----------'
+\echo '| The End |'
+\echo '-----------'

--- a/BerlinMOD/berlinmod_d_vehicleid.sql
+++ b/BerlinMOD/berlinmod_d_vehicleid.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Distributed by Vehicle ID
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /*****************************************************************************
  * This file distributes the Brussels synthetic dataset generated with the
  * BerlinMOD generator using the vehicleid as distribution column.

--- a/BerlinMOD/berlinmod_datagenerator.sql
+++ b/BerlinMOD/berlinmod_datagenerator.sql
@@ -3,8 +3,8 @@
 -------------------------------------------------------------------------------
 
 This file is part of MobilityDB.
-Copyright (C) 2024, Esteban Zimanyi, Mahmoud Sakr,
-  Universite Libre de Bruxelles.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
 
 The functions defined in this file use MobilityDB to generate data
 similar to the data used in the BerlinMOD benchmark as defined in

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -1,6 +1,16 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Export
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Exports the Brussels synthetic dataset obtained from the BerlinMOD generator
- * in CSV format 
+ * in CSV format
  * https://github.com/MobilityDB/MobilityDB-BerlinMOD
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857
@@ -99,6 +109,84 @@ BEGIN
 
 -------------------------------------------------------------------------------
 
+  RETURN 'The End';
+END;
+$$ LANGUAGE 'plpgsql';
+
+-------------------------------------------------------------------------------
+
+/******************************************************************************
+ * Exports a cross-platform–compatible subset of the BerlinMOD dataset in CSV
+ * format, suitable for loading into MobilityDuck (DuckDB) and MobilitySpark
+ * (Apache Spark) using the portable SQL dialect (RFC #861).
+ *
+ * Schema produced:
+ *   vehicles.csv       : vehId, licence, type, model
+ *   trips.csv          : tripId, vehId, trip   -- tgeompoint as WKT text
+ *   query_licences.csv : licenceId, licence
+ *   query_instants.csv : instantId, instant
+ *   query_points.csv   : pointId, geom          -- geometry as WKT text
+ *
+ * Parameters:
+ * - fullpath: directory path (with trailing slash) where CSV files are written.
+ *
+ * Example:
+ *     \i berlinmod_export.sql
+ *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/');
+ *****************************************************************************/
+
+DROP FUNCTION IF EXISTS berlinmod_portability_export;
+CREATE OR REPLACE FUNCTION berlinmod_portability_export(fullpath text)
+RETURNS text AS $$
+DECLARE
+  startTime timestamptz;
+  endTime   timestamptz;
+BEGIN
+  startTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Exporting BerlinMOD data in cross-platform portability schema';
+  RAISE INFO 'Target: %', fullpath;
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO '------------------------------------------------------------------';
+
+  RAISE INFO 'Exporting vehicles.csv';
+  EXECUTE format(
+    'COPY (SELECT VehicleId AS vehId, Licence AS licence,
+                  VehicleType AS type, Model AS model
+           FROM Vehicles ORDER BY VehicleId)
+     TO ''%svehicles.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting trips.csv (tgeompoint as WKT text)';
+  EXECUTE format(
+    'COPY (SELECT TripId AS tripId, VehicleId AS vehId,
+                  asText(Trip) AS trip
+           FROM Trips ORDER BY TripId)
+     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_licences.csv';
+  EXECUTE format(
+    'COPY (SELECT LicenceId AS licenceId, Licence AS licence
+           FROM Licences ORDER BY LicenceId)
+     TO ''%squery_licences.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_instants.csv';
+  EXECUTE format(
+    'COPY (SELECT InstantId AS instantId, Instant AS instant
+           FROM Instants ORDER BY InstantId)
+     TO ''%squery_instants.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_points.csv (geometry as WKT text)';
+  EXECUTE format(
+    'COPY (SELECT PointId AS pointId, ST_AsText(Geom) AS geom
+           FROM Points ORDER BY PointId)
+     TO ''%squery_points.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  endTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO 'Execution finished at %', endTime;
+  RAISE INFO 'Execution time %', endTime - startTime;
+  RAISE INFO '------------------------------------------------------------------';
   RETURN 'The End';
 END;
 $$ LANGUAGE 'plpgsql';

--- a/BerlinMOD/berlinmod_load.sql
+++ b/BerlinMOD/berlinmod_load.sql
@@ -1,5 +1,15 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Load
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
- * Loads the BerlinMOD data with WGS84 coordinates in CSV format 
+ * Loads the BerlinMOD data with WGS84 coordinates in CSV format
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD.html  
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857

--- a/BerlinMOD/berlinmod_nn_queries.sql
+++ b/BerlinMOD/berlinmod_nn_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Nearest-Neighbor Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 9 BerlinMOD/NN benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf

--- a/BerlinMOD/berlinmod_r_queries.sql
+++ b/BerlinMOD/berlinmod_r_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 17 BerlinMOD/r benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf
@@ -6,7 +16,7 @@
  *    notimes: number of times that each query is run. It is set by default
  *       to 5
  *    detailed: states whether detailed statistics are collected during
- *      the execution. By default it is set to TRUE. 
+ *      the execution. By default it is set to TRUE.
  * Example of usage:
  *     <Create the function>
  *     SELECT berlinmod_R_queries(1, true);

--- a/BerlinMOD/berlinmod_r_queries_citus.sql
+++ b/BerlinMOD/berlinmod_r_queries_citus.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries (Citus)
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 17 BerlinMOD/r benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf
@@ -6,7 +16,7 @@
  *    notimes: number of times that each query is run. It is set by default
  *       to 5
  *    detailed: states whether detailed statistics are collected during
- *      the execution. By default it is set to TRUE. 
+ *      the execution. By default it is set to TRUE.
  * Example of usage:
  *     <Create the function>
  *     SELECT berlinmod_R_queries(1, true)

--- a/BerlinMOD/berlinmod_runall.sh
+++ b/BerlinMOD/berlinmod_runall.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#-----------------------------------------------------------------------------
+# BerlinMOD Run All
+#-----------------------------------------------------------------------------
+#
+# This file is part of MobilityDB.
+# Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+#-----------------------------------------------------------------------------
+
 # A script to run the BerlinMOD generator
 # Run this script inside the BerlinMOD/ folder.
 # This script expects the file brussels.osm

--- a/BerlinMOD/deliveries_datagenerator.sql
+++ b/BerlinMOD/deliveries_datagenerator.sql
@@ -2,8 +2,8 @@
 -- Deliveries Data Generator
 -------------------------------------------------------------------------------
 This file is part of MobilityDB.
-Copyright (c) 2024, Esteban Zimanyi, Mahmoud Sakr,
-  Universite Libre de Bruxelles.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
 
 The functions defined in this file use MobilityDB to generate data
 corresponding to a delivery service as specified in

--- a/BerlinMOD/deliveries_export.sql
+++ b/BerlinMOD/deliveries_export.sql
@@ -1,6 +1,16 @@
+/*-----------------------------------------------------------------------------
+-- Deliveries Export
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Exports the Brussels synthetic dataset obtained from the BerlinMOD generator
- * in CSV format 
+ * in CSV format
  * https://github.com/MobilityDB/MobilityDB-BerlinMOD
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857

--- a/BerlinMOD/deliveries_load.sql
+++ b/BerlinMOD/deliveries_load.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- Deliveries Load
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Loads the Deliveries data in CSV format into MobilityDB using projected (2D)
  * coordinates with SRID 3857

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+-------------------------------------------------------------------------------
+This MobilityDB code is provided under The PostgreSQL License.
+
+Copyright (c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement is
+hereby granted, provided that the above copyright notice and this paragraph and
+the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND
+UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/README.md
+++ b/README.md
@@ -3,81 +3,242 @@ BerlinMOD Benchmark for MobilityDB
 
 <img src="docs/images/mobilitydb-logo.svg" width="200" alt="MobilityDB Logo" />
 
-[MobilityDB](https://github.com/ULB-CoDE-WIT/MobilityDB) is an open source software program that adds support for temporal and spatio-temporal objects to the [PostgreSQL](https://www.postgresql.org/) database and its spatial extension [PostGIS](http://postgis.net/).
+[MobilityDB](https://github.com/MobilityDB/MobilityDB) is an open source
+software program that adds support for temporal and spatio-temporal objects to
+the [PostgreSQL](https://www.postgresql.org/) database and its spatial
+extension [PostGIS](http://postgis.net/).
 
-This repository contains code and the documentation for running the [BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html) benchmark on MobilityDB.
+This repository contains code and documentation for running the
+[BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html)
+benchmark on MobilityDB.
 
-Documentation
--------------
+## 1. Requirements
 
-You can generate the benchmark documentation from the sources.
-*  In HTML format
+- [PostgreSQL](https://www.postgresql.org/) 14 or later
+- [PostGIS](http://postgis.net/) 3.0 or later
+- [MobilityDB](https://github.com/MobilityDB/MobilityDB) 1.1 or later
+- [pgRouting](https://pgrouting.org/) (for data generation)
+- [osm2pgrouting](https://github.com/pgRouting/osm2pgrouting) and
+  [osm2pgsql](https://osm2pgsql.org/) (for importing OSM road network data)
 
-        xsltproc --stringparam html.stylesheet "docbook.css" --xinclude -o index.html /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl mobilitydb-berlinmod.xml
-*  In PDF format
+## 2. Building / Installation
 
-        dblatex -s texstyle.sty -T native -t pdf -o mobilitydb-berlinmod.pdf mobilitydb-berlinmod.xml
-* In EPUB format
+**Create the database and load the road network:**
 
-        dbtoepub -o mobilitydb-berlinmod.epub mobilitydb-berlinmod.xml
+```bash
+createdb berlinmod
+psql -d berlinmod -c 'CREATE EXTENSION MobilityDB CASCADE'
+psql -d berlinmod -c 'CREATE EXTENSION pgRouting'
+```
 
-In addition, pregenerated versions of them are available.
+Import OSM data for Brussels (or another city) using `osm2pgrouting` and
+`osm2pgsql`:
 
-*  In HTML format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/html/index.html
-*  In PDF format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.pdf
-* In EPUB format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.epub
+```bash
+osm2pgrouting -f brussels.osm --dbname berlinmod -c BerlinMOD/mapconfig.xml
+osm2pgsql -c -d berlinmod brussels.osm
+```
 
-Docker container
------------------
+Prepare the road network graph:
 
-The dependencies and scripts of the MobilityDB-BerlinMOD Project are available in a Docker container running PostgreSQL-15, PostGIS-2.5 and MobilityDB-develop.
+```bash
+psql -d berlinmod -f BerlinMOD/brussels_preparedata.sql
+```
 
-*  Pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/mobilitydb/mobilitydb).
+Alternatively, use the optimized graph builder:
 
-        docker pull mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+```bash
+psql -d berlinmod -f BerlinMOD/brussels_creategraph.sql
+```
 
-*  Create a Docker volume to preserve the PostgreSQL database files outside of the container.
+## 3. Using
 
-        docker volume create mobilitydb_data
-        
- *  Run the Docker container.
+**Generate BerlinMOD synthetic data:**
 
-        docker run --name mobilitydb -e POSTGRES_PASSWORD=mysecretpassword \
-        -p 25432:5432 -v mobilitydb_data:/var/lib/postgresql -d mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD 
-        
- *  Connect to the database  (db=postgres,username=postgres,pw=_mysecretpassword_).
+Load the data generator and call it with a scale factor:
 
-        psql -h localhost -p 25432 -U postgres 
+```sql
+\i BerlinMOD/berlinmod_datagenerator.sql
+SELECT berlinmod_datagenerator(scaleFactor := 0.005);
+```
 
- *  BerlinMOD scripts are available in the BerlinMOD directory inside the container.
-      
-Generated datasets
----------------------
+**Generate Deliveries synthetic data:**
 
-The generator has two scenarios, the original one from BerlinMOD, and another one concerning deliveries pertaining to mobility data warehouses. We have generated the benchmark data for different scale factors (SF) for the two scenarios The different datasets and their characteristics are given in the tables below, that also provides links to download the data in compressed CSV files.
+```sql
+\i BerlinMOD/deliveries_datagenerator.sql
+SELECT deliveries_datagenerator(scaleFactor := 0.005);
+```
 
-BerlinMOD synthetic data using OSM data from Brussels.
+**Run all steps with the shell script:**
+
+```bash
+cd BerlinMOD
+bash berlinmod_runall.sh
+```
+
+**Run benchmark queries:**
+
+After loading data (see [Generated datasets](#5-examples) below for
+pre-generated CSV files), execute the benchmark queries:
+
+```sql
+-- Chapter 1 ad-hoc queries (range, temporal aggregate, distance)
+\i BerlinMOD/berlinmod_chapter1_queries.sql
+
+-- Range queries (17 BerlinMOD/R queries)
+\i BerlinMOD/berlinmod_load.sql
+SELECT berlinmod_R_queries(1, true);
+
+-- Nearest-neighbor queries (9 BerlinMOD/NN queries)
+SELECT berlinmod_NN_queries(1, true);
+```
+
+**Load pre-generated CSV data:**
+
+```sql
+\i BerlinMOD/berlinmod_load.sql
+SELECT berlinmod_load('/path/to/csv/files/', true);
+```
+
+## 4. Cross-Platform Portability
+
+BerlinMOD queries can run unchanged on all three platforms of the MobilityDB
+ecosystem using the **portable SQL dialect** (named functions only, no
+platform-specific operator symbols):
+
+| Platform | Engine | Extension |
+|---|---|---|
+| [MobilityDB](https://github.com/MobilityDB/MobilityDB) | PostgreSQL | `CREATE EXTENSION mobilitydb` |
+| [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) | DuckDB | `LOAD mobilitydb` |
+| [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) | Apache Spark | `MobilitySparkSession.create(spark)` |
+
+**Run portable Chapter 1 queries (Q1–Q6) on MobilityDB:**
+
+```sql
+\i BerlinMOD/berlinmod_chapter1_queries_portable.sql
+```
+
+**Export data for MobilityDuck / MobilitySpark:**
+
+The `berlinmod_portability_export()` function writes five CSV files in the
+shared cross-platform schema:
+
+```sql
+\i BerlinMOD/berlinmod_export.sql
+SELECT berlinmod_portability_export('/path/to/output/');
+```
+
+This produces:
+
+| File | Contents |
+|------|----------|
+| `vehicles.csv` | `vehId, licence, type, model` |
+| `trips.csv` | `tripId, vehId, trip` — tgeompoint as WKT text |
+| `query_licences.csv` | `licenceId, licence` |
+| `query_instants.csv` | `instantId, instant` |
+| `query_points.csv` | `pointId, geom` — geometry as WKT text |
+
+These files can be loaded directly by the MobilitySpark cross-platform test
+runner (`berlinmod/run_mbdb.sh`, `run_mduck.sh`) as described in the
+[MobilitySpark repository](https://github.com/MobilityDB/MobilitySpark).
+
+## 5. Running the Tests
+
+After running the benchmark queries, compare results against expected output
+to validate correctness. The documentation (see below) specifies expected
+result counts for each query at each scale factor.
+
+Generate the documentation from source to obtain the full reference:
+
+```bash
+cd docs
+dblatex -s texstyle.sty -T native -t pdf -o mobilitydb-berlinmod.pdf mobilitydb-berlinmod.xml
+```
+
+Pre-generated documentation is available online:
+
+- HTML: https://mobilitydb.github.io/MobilityDB-BerlinMOD/html/index.html
+- PDF: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.pdf
+- EPUB: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.epub
+
+## 6. Examples
+
+The generator produces two benchmark scenarios:
+
+**BerlinMOD** — vehicles moving through the Brussels road network.
 
 | Scale Factor | Vehicles | Days | Trips | File | Size |
-|--------------|---------:|-----:|------:|-----|-----:|
-| SF 0.1 |   632 | 11 |  18,910 | [brussels_sf0.1.zip](https://docs.mobilitydb.com/pub/brussels_sf0.1.zip) | 5.5 MB |
-| SF 0.2 |   894 | 15 |  35,319 | [brussels_sf0.2.zip](https://docs.mobilitydb.com/pub/brussels_sf0.2.zip) | 9.6 MB |
-| SF 0.5 | 1,414 | 22 |  81,584 | [brussels_sf0.5.zip](https://docs.mobilitydb.com/pub/brussels_sf0.5.zip) | 2.2 GB |
-| SF 1   | 2,000 | 30 | 157,565 | [brussels_sf1.zip](https://docs.mobilitydb.com/pub/brussels_sf1.zip) | 4.2 GB |
+|:-------------|--------:|-----:|------:|:-----|-----:|
+| SF 0.1 | 632 | 11 | 18,910 | [brussels_sf0.1.zip](https://docs.mobilitydb.com/pub/brussels_sf0.1.zip) | 5.5 MB |
+| SF 0.2 | 894 | 15 | 35,319 | [brussels_sf0.2.zip](https://docs.mobilitydb.com/pub/brussels_sf0.2.zip) | 9.6 MB |
+| SF 0.5 | 1,414 | 22 | 81,584 | [brussels_sf0.5.zip](https://docs.mobilitydb.com/pub/brussels_sf0.5.zip) | 2.2 GB |
+| SF 1 | 2,000 | 30 | 157,565 | [brussels_sf1.zip](https://docs.mobilitydb.com/pub/brussels_sf1.zip) | 4.2 GB |
 
-
-Deliveries synthetic data using OSM data from Brussels.
-
+**Deliveries** — vehicles making deliveries from warehouses to customers.
 
 | Scale Factor | Warehouses | Vehicles | Customers | Days | Deliveries | File | Size |
-|--------------|-----------:|---------:|----------:|------|-----------:|-----|-----:|
-| SF 0.1       |  32 |   632 |  3,162 | 11 |  6,320 | [deliveries_sf0.1.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.1.zip) | 1.4 GB |
-| SF 0.2       |  45 |   894 |  4,472 | 15 | 11,622 | [deliveries_sf0.2.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.2.zip) | 2.6 GB |
-| SF 0.5       |  71 | 1,414 |  7,071 | 22 | 26,866 | [deliveries_sf0.5.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.5.zip) | 6.1 GB |
-| SF 1         | 100 | 2,000 | 10,000 | 30 | 26,866 | [deliveries_sf1.zip](https://docs.mobilitydb.com/pub/deliveries_sf1.zip) | 11.8 GB |
-  
+|:-------------|----------:|---------:|----------:|-----:|-----------:|:-----|-----:|
+| SF 0.1 | 32 | 632 | 3,162 | 11 | 6,320 | [deliveries_sf0.1.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.1.zip) | 1.4 GB |
+| SF 0.2 | 45 | 894 | 4,472 | 15 | 11,622 | [deliveries_sf0.2.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.2.zip) | 2.6 GB |
+| SF 0.5 | 71 | 1,414 | 7,071 | 22 | 26,866 | [deliveries_sf0.5.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.5.zip) | 6.1 GB |
+| SF 1 | 100 | 2,000 | 10,000 | 30 | 26,866 | [deliveries_sf1.zip](https://docs.mobilitydb.com/pub/deliveries_sf1.zip) | 11.8 GB |
 
-License
--------
+**Docker container:**
 
-The documentation of this benchmark is licensed under a [Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/)
+A Docker image with all dependencies pre-installed is available:
+
+```bash
+docker pull mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+docker volume create mobilitydb_data
+docker run --name mobilitydb -e POSTGRES_PASSWORD=mysecretpassword \
+  -p 25432:5432 -v mobilitydb_data:/var/lib/postgresql \
+  -d mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+psql -h localhost -p 25432 -U postgres
+```
+
+BerlinMOD scripts are available in the `BerlinMOD/` directory inside the
+container. See the [Docker documentation](docker/) for further details.
+
+## 7. Project Structure
+
+```
+MobilityDB-BerlinMOD/
+├── BerlinMOD/
+│   ├── berlinmod_datagenerator.sql      # BerlinMOD data generator
+│   ├── deliveries_datagenerator.sql     # Deliveries data generator
+│   ├── berlinmod_load.sql               # Load pre-generated CSV data
+│   ├── deliveries_load.sql              # Load pre-generated deliveries CSV
+│   ├── berlinmod_export.sql             # Export data to CSV (incl. berlinmod_portability_export)
+│   ├── deliveries_export.sql            # Export deliveries data to CSV
+│   ├── berlinmod_chapter1_queries.sql   # Ad-hoc benchmark queries
+│   ├── berlinmod_chapter1_queries_portable.sql  # Portable dialect queries
+│   ├── berlinmod_r_queries.sql          # BerlinMOD/R range queries
+│   ├── berlinmod_r_queries_citus.sql    # Range queries for Citus
+│   ├── berlinmod_nn_queries.sql         # BerlinMOD/NN nearest-neighbor queries
+│   ├── berlinmod_d_vehicleid.sql        # Citus distribution by vehicle ID
+│   ├── berlinmod_runall.sh              # Shell script to run all steps
+│   ├── brussels_preparedata.sql         # Prepare Brussels road network
+│   └── brussels_creategraph.sql         # Optimized graph builder
+├── docs/                                # DocBook documentation source
+├── docker/                              # Docker setup files
+└── README.md
+```
+
+## Contributing
+
+This repository uses a single perennial **`master`** branch — the same model
+as [MobilityDB](https://github.com/MobilityDB/MobilityDB) itself:
+
+1. Fork this repository.
+2. Create a feature or fix branch on your fork.
+3. Open a pull request against `MobilityDB/MobilityDB-BerlinMOD:master`.
+
+There are no long-lived release branches; tags mark stable snapshots.
+
+## License
+
+The SQL scripts in this repository are provided under the
+[PostgreSQL License](LICENSE).
+
+The documentation of this benchmark is licensed under a
+[Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
## Summary

- Add **LICENSE** file (PostgreSQL License, 2020-2026, ULB + MobilityDB contributors)
- Update copyright headers in all SQL/sh files to standard ecosystem form
- Update **CI workflow** (`main.yml`): `feat/**/fix/**` branch triggers, `paths-ignore` for `*.md`/`doc/**`, `workflow_dispatch`, concurrency cancellation
- Restructure **README** into 7 numbered sections; add §4 Cross-Platform Portability and a Contributing section explaining the perennial `master` branch model
- Add **`berlinmod_chapter1_queries_portable.sql`**: Q1–Q6 in the portable named-function SQL dialect (`eIntersects`/`eContains` instead of operator symbols), compatible with MobilityDB, MobilityDuck (DuckDB), and MobilitySpark (Apache Spark)
- Add **`berlinmod_portability_export(fullpath text)`** to `berlinmod_export.sql`: exports `vehicles.csv`, `trips.csv` (tgeompoint as WKT text), `query_licences.csv`, `query_instants.csv`, and `query_points.csv` (geometry as WKT text) in the shared cross-platform schema consumed by MobilityDuck and MobilitySpark

## Cross-platform portability

The portable queries and export function are part of the [edge-to-cloud SQL portability initiative (Discussion #861)](https://github.com/MobilityDB/MobilityDB/discussions/861) — the same SQL files run unchanged on all three ecosystem platforms.

## Test plan

- [ ] `\i BerlinMOD/berlinmod_export.sql` loads without errors
- [ ] `SELECT berlinmod_export('/tmp/data/')` completes successfully (existing function unchanged)
- [ ] `SELECT berlinmod_portability_export('/tmp/portability/')` produces the five CSV files with correct column names
- [ ] `\i BerlinMOD/berlinmod_chapter1_queries_portable.sql` executes Q1–Q6 against loaded data
- [ ] CI passes