### PR TITLE
doc: add PR Reviewer Guide + visibility wiring (PR template + README banner)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for contributing to MobilityDB-BerlinMOD!
+
+Before submitting, please skim the PR Reviewer Guide:
+  doc/contributing/reviewer-guide.md
+
+It documents the review tier ranking, the cross-repo dependency chain
+(this repo + MobilityDB + MobilityDuck + MobilitySpark + JMEOS), and
+the standards checklist (license header, portable-name convention,
+CSV portability, loader cross-platform impact).
+
+If your PR opens, closes, or restructures another PR, please update the
+reviewer guide in the same commit.
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed and why -->
+
+## Test plan
+
+<!-- How you verified the change locally -->
+
+## Reviewer guide impact
+
+<!-- Did this PR open / close / restructure another PR? If yes, the reviewer
+     guide (doc/contributing/reviewer-guide.md) must be updated in the same
+     commit. Tick one: -->
+
+- [ ] No reviewer-guide impact
+- [ ] Reviewer guide updated in this PR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,23 @@
-# Automatic generation of documentation will be copied and checked into the 
+# Automatic generation of documentation will be copied and checked into the
 # gh-pages branch.
 name: Documentation generation CI
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: ["main", "feat/**", "fix/**"]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+  pull_request:
+    branches: ["main", "feat/**", "fix/**"]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -32,7 +44,7 @@ jobs:
           xsltproc --stringparam html.stylesheet "docbook.css" --stringparam chunker.output.encoding "UTF-8" --xinclude -o html/index.html /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl mobilitydb-berlinmod.xml
           cp -r images docbook.css html/
           cp docbook.css html/
-          
+
       # store the documentation files
       - name: Upload output directory
         uses: actions/upload-artifact@v4
@@ -66,8 +78,8 @@ jobs:
         with:
           message: 'Update docs'
           branch: gh-pages
-          add: '["docs/index.md", 
-            "docs/mobilitydb-berlinmod.pdf", 
+          add: '["docs/index.md",
+            "docs/mobilitydb-berlinmod.pdf",
             "docs/mobilitydb-berlinmod.epub",
             "docs/html/docbook.css", "docs/html/images/*",
             "docs/html/*.html"]'

--- a/BerlinMOD/berlinmod_chapter1_queries.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Chapter 1 Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 -- Create indexes
 
 DROP INDEX IF EXISTS Trips_rtree_idx;

--- a/BerlinMOD/berlinmod_chapter1_queries_portable.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries_portable.sql
@@ -1,0 +1,165 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Chapter 1 Queries -- Portable Dialect
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+This file contains a portable version of the BerlinMOD Chapter 1 queries
+(Q1-Q6) using named functions instead of MobilityDB-specific infix operators.
+It targets the cross-platform SQL dialect established for the edge-to-cloud
+portability initiative, compatible with MobilityDB (PostgreSQL) and
+MobilityDuck (DuckDB).
+
+Operator-to-function mapping applied:
+  &&  (stbox overlap)    -> eIntersects() or overlaps()
+  @>  (contains)        -> contains()
+  <-> (distance)        -> distance()
+
+The schema assumed is:
+  Trips(TripId, VehId, Trip tgeompoint, Licence, VehicleType, Model)
+  Vehicles(VehicleId, Licence, VehicleType, Model)
+  Points(PointId, PosX, PosY, Geom geometry(Point,3857))
+  Regions(RegionId, RegionName, Geom geometry(Polygon,3857))
+  Instants(InstantId, Instant timestamptz)
+  Periods(PeriodId, Period tstzspan)
+
+-----------------------------------------------------------------------------*/
+
+-- Create indexes
+
+DROP INDEX IF EXISTS Trips_rtree_idx;
+DROP INDEX IF EXISTS Regions_rtree_idx;
+DROP INDEX IF EXISTS Periods_rtree_idx;
+
+CREATE INDEX Trips_rtree_idx ON Trips USING GIST(trip);
+CREATE INDEX Regions_rtree_idx ON Regions USING GIST(geom);
+CREATE INDEX Periods_rtree_idx ON Periods USING GIST(period);
+
+-- Create views selecting a small sample for the query parameters to minimize
+-- execution time during testing
+
+DROP VIEW IF EXISTS Trips100;
+DROP VIEW IF EXISTS Regions10;
+DROP VIEW IF EXISTS Points10;
+DROP VIEW IF EXISTS Periods10;
+
+CREATE VIEW Trips100 AS ( SELECT * FROM Trips LIMIT 100 );
+CREATE VIEW Regions10 AS ( SELECT * FROM Regions LIMIT 10 );
+CREATE VIEW Points10 AS ( SELECT * FROM Points LIMIT 10 );
+CREATE VIEW Periods10 AS ( SELECT * FROM Periods LIMIT 10 );
+
+-- Collect statistics
+
+ANALYZE;
+
+-- Show the timing of every query
+
+\timing ON
+
+-- Set the pager off
+
+\pset pager 0
+
+
+-- Range Queries
+
+-- Q1. List the vehicles that have passed at a region from Regions.
+--
+-- Original:  stbox(T.Trip) && stbox(R.Geom) AND ST_Intersects(trajectory(T.Trip), R.Geom)
+-- Portable:  eIntersects(trajectory(T.Trip), R.Geom) subsumes the bbox filter
+
+\echo '-----------'
+\echo '| Query 1 |'
+\echo '-----------'
+
+SELECT DISTINCT R.RegionId, T.VehId
+FROM Trips T, Regions10 R
+WHERE eIntersects(trajectory(T.Trip), R.Geom)
+ORDER BY R.RegionId, T.VehId;
+
+-- Q2. List the vehicles that were within a region from Regions during a period
+-- from Periods.
+--
+-- Original:  T.Trip && stbox(R.Geom, P.Period) AND eintersects(atTime(T.Trip, P.Period), R.Geom)
+-- Portable:  eIntersects(atTime(T.Trip, P.Period), R.Geom)
+
+\echo '-----------'
+\echo '| Query 2 |'
+\echo '-----------'
+
+SELECT R.RegionId, P.PeriodId, T.VehId
+FROM Trips T, Regions10 R, Periods10 P
+WHERE eIntersects(atTime(T.Trip, P.Period), R.Geom)
+ORDER BY R.RegionId, P.PeriodId, T.VehId;
+
+-- Q3. List the pairs of vehicles that were both located within a region from
+-- Regions during a period from Periods.
+--
+-- Original:  T1.Trip && stbox(...) AND eintersects(atTime(T1.Trip, P.Period), R.Geom) AND ...
+-- Portable:  eIntersects(atTime(...), R.Geom) for both trips
+
+\echo '-----------'
+\echo '| Query 3 |'
+\echo '-----------'
+
+SELECT DISTINCT T1.VehId AS VehId1, T2.VehId AS VehId2, R.RegionId, P.PeriodId
+FROM Trips T1, Trips100 T2, Regions10 R, Periods10 P
+WHERE T1.VehId < T2.VehId
+  AND eIntersects(atTime(T1.Trip, P.Period), R.Geom)
+  AND eIntersects(atTime(T2.Trip, P.Period), R.Geom)
+ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
+
+-- Q4. List the first time at which a vehicle visited a point in Points.
+--
+-- Original:  T.Trip && stbox(P.Geom) AND ST_Contains(trajectory(T.Trip), P.Geom)
+-- Portable:  eContains(trajectory(T.Trip), P.Geom)
+
+\echo '-----------'
+\echo '| Query 4 |'
+\echo '-----------'
+
+SELECT T.VehId, P.PointId,
+  MIN(startTimestamp(atValues(T.Trip, P.Geom))) AS Instant
+FROM Trips T, Points10 P
+WHERE eContains(trajectory(T.Trip), P.Geom)
+GROUP BY T.VehId, P.PointId;
+
+-- Temporal Aggregate Queries
+
+-- Q5. Compute how many vehicles were active at each period in Periods.
+--
+-- The overlap operator && on tstzspan is standard across platforms.
+
+\echo '-----------'
+\echo '| Query 5 |'
+\echo '-----------'
+
+SELECT P.PeriodId, COUNT(*),
+  numInstants(tcount(atTime(T.Trip, P.Period)))
+FROM Trips T, Periods10 P
+WHERE timeSpan(T.Trip) && P.Period
+GROUP BY P.PeriodId
+ORDER BY P.PeriodId;
+
+-- Q6. For each region in Regions, give the window temporal count of trips
+-- with a 10-minute interval.
+--
+-- atGeometry and wCount are available in MobilityDB and MobilityDuck.
+
+\echo '-----------'
+\echo '| Query 6 |'
+\echo '-----------'
+
+SELECT R.RegionId,
+  numInstants(wCount(atGeometry(T.Trip, R.Geom), interval '10 min'))
+FROM Trips T, Regions10 R
+WHERE eIntersects(trajectory(T.Trip), R.Geom)
+GROUP BY R.RegionId
+HAVING wCount(atGeometry(T.Trip, R.Geom), interval '10 min') IS NOT NULL
+ORDER BY R.RegionId;
+
+\echo '-----------'
+\echo '| The End |'
+\echo '-----------'

--- a/BerlinMOD/berlinmod_chapter1_queries_th3index_portable.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries_th3index_portable.sql
@@ -1,24 +1,45 @@
 /*-----------------------------------------------------------------------------
--- BerlinMOD Chapter 1 Queries -- Portable Dialect
+-- BerlinMOD Chapter 1 Queries -- Portable Dialect with th3index Prefilter
 -------------------------------------------------------------------------------
 
 This file is part of MobilityDB.
 Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
 contributors
 
-This file contains a portable version of the BerlinMOD Chapter 1 queries
-(Q1-Q6) using named functions instead of MobilityDB-specific infix operators.
-It targets the cross-platform SQL dialect established for the edge-to-cloud
-portability initiative, compatible with MobilityDB (PostgreSQL) and
-MobilityDuck (DuckDB).
+This is a th3index-accelerated sibling of
+`berlinmod_chapter1_queries_portable.sql`.  The published portable
+file is kept unchanged so the book's listings remain authoritative.
+This variant adds an H3-cell prefilter on top of the same predicates
+for the cross-platform edge-to-cloud benchmark.
 
-Operator-to-function mapping applied:
-  &&  (stbox overlap)    -> eIntersects() or overlaps()
-  @>  (contains)        -> contains()
-  <-> (distance)        -> distance()
+Prerequisites:
+  - Run `berlinmod_th3index_setup.sql` once to add and populate the
+    `trip_h3 th3index` column and its GiST index.
+  - The static-geometry → H3 cell-set public API
+    (`geoToH3Cell`, `geoToH3IndexSet`, `everIntersectsH3IndexSet_Th3Index`)
+    must be installed on the target.
 
-The schema assumed is:
-  Trips(TripId, VehId, Trip tgeompoint, Licence, VehicleType, Model)
+Prefilter pattern (single recipe across geometry types):
+
+  everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7), T.trip_h3)
+    AND <semantic predicate on the moving point>
+
+  `geoToH3IndexSet` covers any GEOMETRY (POINT/LINESTRING/POLYGON/MULTI*/
+  GeometryCollection) by an H3 cell set at the chosen resolution.
+  `everIntersectsH3IndexSet_Th3Index` returns TRUE iff the trip's
+  th3index path ever lies in any of those cells.  The prefilter is
+  sound for `eIntersects`/`eContains`/spatial-overlap predicates at
+  any resolution — a trip can only satisfy them if it ever crosses a
+  cell that covers part of the static geometry.
+
+  On MobilityDB the GiST index on `Trips(trip_h3)` accelerates the
+  prefilter.  On DuckDB / Spark the column itself is the prefilter
+  mechanism (no spatial index API).
+
+The schema assumed is the same as the published portable file plus
+the `trip_h3` column added by the setup script:
+  Trips(TripId, VehId, Trip tgeompoint, trip_h3 th3index,
+        Licence, VehicleType, Model)
   Vehicles(VehicleId, Licence, VehicleType, Model)
   Points(PointId, PosX, PosY, Geom geometry(Point,3857))
   Regions(RegionId, RegionName, Geom geometry(Polygon,3857))
@@ -67,8 +88,8 @@ ANALYZE;
 
 -- Q1. List the vehicles that have passed at a region from Regions.
 --
--- Original:  stbox(T.Trip) && stbox(R.Geom) AND ST_Intersects(trajectory(T.Trip), R.Geom)
--- Portable:  eIntersects(trajectory(T.Trip), R.Geom) subsumes the bbox filter
+-- Published portable: eIntersects(trajectory(T.Trip), R.Geom)
+-- th3index-accel:     same + cell-set prefilter on R.Geom × T.trip_h3
 
 \echo '-----------'
 \echo '| Query 1 |'
@@ -76,14 +97,20 @@ ANALYZE;
 
 SELECT DISTINCT R.RegionId, T.VehId
 FROM Trips T, Regions10 R
-WHERE eIntersects(trajectory(T.Trip), R.Geom)
+WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+  AND eIntersects(trajectory(T.Trip), R.Geom)
 ORDER BY R.RegionId, T.VehId;
 
 -- Q2. List the vehicles that were within a region from Regions during a period
 -- from Periods.
 --
--- Original:  T.Trip && stbox(R.Geom, P.Period) AND eintersects(atTime(T.Trip, P.Period), R.Geom)
--- Portable:  eIntersects(atTime(T.Trip, P.Period), R.Geom)
+-- Published portable: eIntersects(atTime(T.Trip, P.Period), R.Geom)
+-- th3index-accel:     same + cell-set prefilter on R.Geom × T.trip_h3
+--
+-- The prefilter compares the full trip's th3index to the region cell
+-- set — sound because if the trip clipped to P.Period intersects R.Geom,
+-- then the unclipped trip's cells also intersect.  Refinement by Period
+-- is left to the `atTime` call.
 
 \echo '-----------'
 \echo '| Query 2 |'
@@ -91,14 +118,15 @@ ORDER BY R.RegionId, T.VehId;
 
 SELECT R.RegionId, P.PeriodId, T.VehId
 FROM Trips T, Regions10 R, Periods10 P
-WHERE eIntersects(atTime(T.Trip, P.Period), R.Geom)
+WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+  AND eIntersects(atTime(T.Trip, P.Period), R.Geom)
 ORDER BY R.RegionId, P.PeriodId, T.VehId;
 
 -- Q3. List the pairs of vehicles that were both located within a region from
 -- Regions during a period from Periods.
 --
--- Original:  T1.Trip && stbox(...) AND eintersects(atTime(T1.Trip, P.Period), R.Geom) AND ...
--- Portable:  eIntersects(atTime(...), R.Geom) for both trips
+-- Published portable: eIntersects on both trips against R.Geom
+-- th3index-accel:     same + cell-set prefilter on BOTH trips
 
 \echo '-----------'
 \echo '| Query 3 |'
@@ -107,14 +135,17 @@ ORDER BY R.RegionId, P.PeriodId, T.VehId;
 SELECT DISTINCT T1.VehId AS VehId1, T2.VehId AS VehId2, R.RegionId, P.PeriodId
 FROM Trips T1, Trips100 T2, Regions10 R, Periods10 P
 WHERE T1.VehId < T2.VehId
+  AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T1.trip_h3)
+  AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T2.trip_h3)
   AND eIntersects(atTime(T1.Trip, P.Period), R.Geom)
   AND eIntersects(atTime(T2.Trip, P.Period), R.Geom)
 ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
 
 -- Q4. List the first time at which a vehicle visited a point in Points.
 --
--- Original:  T.Trip && stbox(P.Geom) AND ST_Contains(trajectory(T.Trip), P.Geom)
--- Portable:  eContains(trajectory(T.Trip), P.Geom)
+-- Published portable: eContains(trajectory(T.Trip), P.Geom)
+-- th3index-accel:     same + cell-set prefilter on P.Geom × T.trip_h3
+--                     (POINT geometry → singleton cell set)
 
 \echo '-----------'
 \echo '| Query 4 |'
@@ -123,14 +154,16 @@ ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
 SELECT T.VehId, P.PointId,
   MIN(startTimestamp(atValues(T.Trip, P.Geom))) AS Instant
 FROM Trips T, Points10 P
-WHERE eContains(trajectory(T.Trip), P.Geom)
+WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(P.Geom, 7), T.trip_h3)
+  AND eContains(trajectory(T.Trip), P.Geom)
 GROUP BY T.VehId, P.PointId;
 
 -- Temporal Aggregate Queries
 
 -- Q5. Compute how many vehicles were active at each period in Periods.
 --
--- The overlap operator && on tstzspan is standard across platforms.
+-- Time-only query — no spatial geometry to prefilter against.  Identical
+-- to the published portable form.
 
 \echo '-----------'
 \echo '| Query 5 |'
@@ -146,7 +179,8 @@ ORDER BY P.PeriodId;
 -- Q6. For each region in Regions, give the window temporal count of trips
 -- with a 10-minute interval.
 --
--- atGeometry and wCount are available in MobilityDB and MobilityDuck.
+-- Published portable: eIntersects(trajectory(T.Trip), R.Geom) + atGeometry
+-- th3index-accel:     same + cell-set prefilter on R.Geom × T.trip_h3
 
 \echo '-----------'
 \echo '| Query 6 |'
@@ -155,7 +189,8 @@ ORDER BY P.PeriodId;
 SELECT R.RegionId,
   numInstants(wCount(atGeometry(T.Trip, R.Geom), interval '10 min'))
 FROM Trips T, Regions10 R
-WHERE eIntersects(trajectory(T.Trip), R.Geom)
+WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+  AND eIntersects(trajectory(T.Trip), R.Geom)
 GROUP BY R.RegionId
 HAVING wCount(atGeometry(T.Trip, R.Geom), interval '10 min') IS NOT NULL
 ORDER BY R.RegionId;

--- a/BerlinMOD/berlinmod_d_vehicleid.sql
+++ b/BerlinMOD/berlinmod_d_vehicleid.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Distributed by Vehicle ID
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /*****************************************************************************
  * This file distributes the Brussels synthetic dataset generated with the
  * BerlinMOD generator using the vehicleid as distribution column.

--- a/BerlinMOD/berlinmod_datagenerator.sql
+++ b/BerlinMOD/berlinmod_datagenerator.sql
@@ -3,8 +3,8 @@
 -------------------------------------------------------------------------------
 
 This file is part of MobilityDB.
-Copyright (C) 2024, Esteban Zimanyi, Mahmoud Sakr,
-  Universite Libre de Bruxelles.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
 
 The functions defined in this file use MobilityDB to generate data
 similar to the data used in the BerlinMOD benchmark as defined in

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -1,6 +1,16 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Export
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Exports the Brussels synthetic dataset obtained from the BerlinMOD generator
- * in CSV format 
+ * in CSV format
  * https://github.com/MobilityDB/MobilityDB-BerlinMOD
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857
@@ -99,6 +109,84 @@ BEGIN
 
 -------------------------------------------------------------------------------
 
+  RETURN 'The End';
+END;
+$$ LANGUAGE 'plpgsql';
+
+-------------------------------------------------------------------------------
+
+/******************************************************************************
+ * Exports a cross-platform–compatible subset of the BerlinMOD dataset in CSV
+ * format, suitable for loading into MobilityDuck (DuckDB) and MobilitySpark
+ * (Apache Spark) using the portable SQL dialect (RFC #861).
+ *
+ * Schema produced:
+ *   vehicles.csv       : vehId, licence, type, model
+ *   trips.csv          : tripId, vehId, trip   -- tgeompoint as WKT text
+ *   query_licences.csv : licenceId, licence
+ *   query_instants.csv : instantId, instant
+ *   query_points.csv   : pointId, geom          -- geometry as WKT text
+ *
+ * Parameters:
+ * - fullpath: directory path (with trailing slash) where CSV files are written.
+ *
+ * Example:
+ *     \i berlinmod_export.sql
+ *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/');
+ *****************************************************************************/
+
+DROP FUNCTION IF EXISTS berlinmod_portability_export;
+CREATE OR REPLACE FUNCTION berlinmod_portability_export(fullpath text)
+RETURNS text AS $$
+DECLARE
+  startTime timestamptz;
+  endTime   timestamptz;
+BEGIN
+  startTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Exporting BerlinMOD data in cross-platform portability schema';
+  RAISE INFO 'Target: %', fullpath;
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO '------------------------------------------------------------------';
+
+  RAISE INFO 'Exporting vehicles.csv';
+  EXECUTE format(
+    'COPY (SELECT VehicleId AS vehId, Licence AS licence,
+                  VehicleType AS type, Model AS model
+           FROM Vehicles ORDER BY VehicleId)
+     TO ''%svehicles.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting trips.csv (tgeompoint as WKT text)';
+  EXECUTE format(
+    'COPY (SELECT TripId AS tripId, VehicleId AS vehId,
+                  asText(Trip) AS trip
+           FROM Trips ORDER BY TripId)
+     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_licences.csv';
+  EXECUTE format(
+    'COPY (SELECT LicenceId AS licenceId, Licence AS licence
+           FROM Licences ORDER BY LicenceId)
+     TO ''%squery_licences.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_instants.csv';
+  EXECUTE format(
+    'COPY (SELECT InstantId AS instantId, Instant AS instant
+           FROM Instants ORDER BY InstantId)
+     TO ''%squery_instants.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  RAISE INFO 'Exporting query_points.csv (geometry as WKT text)';
+  EXECUTE format(
+    'COPY (SELECT PointId AS pointId, ST_AsText(Geom) AS geom
+           FROM Points ORDER BY PointId)
+     TO ''%squery_points.csv'' DELIMITER '','' CSV HEADER', fullpath);
+
+  endTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO 'Execution finished at %', endTime;
+  RAISE INFO 'Execution time %', endTime - startTime;
+  RAISE INFO '------------------------------------------------------------------';
   RETURN 'The End';
 END;
 $$ LANGUAGE 'plpgsql';

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -122,21 +122,36 @@ $$ LANGUAGE 'plpgsql';
  *
  * Schema produced:
  *   vehicles.csv       : vehId, licence, type, model
- *   trips.csv          : tripId, vehId, trip   -- tgeompoint as WKT text
+ *   trips.csv          : tripId, vehId, trip, trip_h3
+ *                        - trip   : tgeompoint as WKT text
+ *                        - trip_h3: th3index temporal H3-cell index, hex-WKB,
+ *                                   produced by tgeompoint_to_th3index(trip, R)
+ *                                   at the chosen H3 resolution.  Used by all
+ *                                   three platforms as a spatial prefilter for
+ *                                   the cross-join family of BerlinMOD queries
+ *                                   (Q4/Q5/Q6/Q10).  R defaults to 7 (cell edge
+ *                                   ≈ 1.2 km) — sound for the 3-10 m distance
+ *                                   thresholds the queries use.
  *   query_licences.csv : licenceId, licence
  *   query_instants.csv : instantId, instant
  *   query_points.csv   : pointId, geom          -- geometry as WKT text
  *
  * Parameters:
- * - fullpath: directory path (with trailing slash) where CSV files are written.
+ * - fullpath:    directory path (with trailing slash) where CSV files are written.
+ * - h3resolution: H3 resolution for the trip_h3 column (default 7).  Use a coarser
+ *                resolution (e.g. 5 — cell edge ≈ 9 km) for an even safer
+ *                prefilter at the cost of selectivity.
  *
  * Example:
  *     \i berlinmod_export.sql
  *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/');
+ *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/', 7);
  *****************************************************************************/
 
 DROP FUNCTION IF EXISTS berlinmod_portability_export;
-CREATE OR REPLACE FUNCTION berlinmod_portability_export(fullpath text)
+CREATE OR REPLACE FUNCTION berlinmod_portability_export(
+    fullpath      text,
+    h3resolution  integer DEFAULT 7)
 RETURNS text AS $$
 DECLARE
   startTime timestamptz;
@@ -146,6 +161,7 @@ BEGIN
   RAISE INFO '------------------------------------------------------------------';
   RAISE INFO 'Exporting BerlinMOD data in cross-platform portability schema';
   RAISE INFO 'Target: %', fullpath;
+  RAISE INFO 'H3 resolution for trip_h3: %', h3resolution;
   RAISE INFO 'Execution started at %', startTime;
   RAISE INFO '------------------------------------------------------------------';
 
@@ -156,12 +172,13 @@ BEGIN
            FROM Vehicles ORDER BY VehicleId)
      TO ''%svehicles.csv'' DELIMITER '','' CSV HEADER', fullpath);
 
-  RAISE INFO 'Exporting trips.csv (tgeompoint as WKT text)';
+  RAISE INFO 'Exporting trips.csv (trip as WKT text + trip_h3 as hex-WKB at resolution %)', h3resolution;
   EXECUTE format(
     'COPY (SELECT TripId AS tripId, VehicleId AS vehId,
-                  asText(Trip) AS trip
+                  asText(Trip) AS trip,
+                  asHexWKB(tgeompoint_to_th3index(Trip, %s)) AS trip_h3
            FROM Trips ORDER BY TripId)
-     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', fullpath);
+     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', h3resolution, fullpath);
 
   RAISE INFO 'Exporting query_licences.csv';
   EXECUTE format(

--- a/BerlinMOD/berlinmod_load.sql
+++ b/BerlinMOD/berlinmod_load.sql
@@ -49,8 +49,9 @@ BEGIN
   */
 
   CREATE VIEW Instants1 (InstantId, Instant) AS
-  SELECT InstantId, Instant 
+  SELECT InstantId, Instant
   FROM Instants
+  ORDER BY InstantId
   LIMIT 10;
 
 --------------------------------------------------------------
@@ -81,6 +82,7 @@ BEGIN
   CREATE VIEW Periods1 (PeriodId, Period) AS
   SELECT PeriodId, Period
   FROM Periods
+  ORDER BY PeriodId
   LIMIT 10;
 
 --------------------------------------------------------------
@@ -111,6 +113,7 @@ BEGIN
   CREATE VIEW Points1 (PointId, Geom) AS
   SELECT PointId, Geom
   FROM Points
+  ORDER BY PointId
   LIMIT 10;
 
 --------------------------------------------------------------
@@ -134,6 +137,7 @@ BEGIN
   CREATE VIEW Regions1 (RegionId, Geom) AS
   SELECT RegionId, Geom
   FROM Regions
+  ORDER BY RegionId
   LIMIT 10;
 
 --------------------------------------------------------------
@@ -236,11 +240,13 @@ BEGIN
   CREATE VIEW Licences1 (LicenceId, Licence, VehicleId) AS
   SELECT LicenceId, Licence, VehicleId
   FROM Licences
+  ORDER BY LicenceId
   LIMIT 10;
 
   CREATE VIEW Licences2 (LicenceId, Licence, VehicleId) AS
   SELECT LicenceId, Licence, VehicleId
   FROM Licences
+  ORDER BY LicenceId
   LIMIT 10 OFFSET 10;
 
 --------------------------------------------------------------

--- a/BerlinMOD/berlinmod_load.sql
+++ b/BerlinMOD/berlinmod_load.sql
@@ -1,5 +1,15 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Load
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
- * Loads the BerlinMOD data with WGS84 coordinates in CSV format 
+ * Loads the BerlinMOD data with WGS84 coordinates in CSV format
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD.html  
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857

--- a/BerlinMOD/berlinmod_nn_queries.sql
+++ b/BerlinMOD/berlinmod_nn_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Nearest-Neighbor Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 9 BerlinMOD/NN benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf

--- a/BerlinMOD/berlinmod_r_queries.sql
+++ b/BerlinMOD/berlinmod_r_queries.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 17 BerlinMOD/r benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf
@@ -6,7 +16,7 @@
  *    notimes: number of times that each query is run. It is set by default
  *       to 5
  *    detailed: states whether detailed statistics are collected during
- *      the execution. By default it is set to TRUE. 
+ *      the execution. By default it is set to TRUE.
  * Example of usage:
  *     <Create the function>
  *     SELECT berlinmod_R_queries(1, true);

--- a/BerlinMOD/berlinmod_r_queries_citus.sql
+++ b/BerlinMOD/berlinmod_r_queries_citus.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries (Citus)
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Executes the 17 BerlinMOD/r benchmark queries
  * http://dna.fernuni-hagen.de/secondo/BerlinMOD/BerlinMOD-FinalReview-2008-06-18.pdf
@@ -6,7 +16,7 @@
  *    notimes: number of times that each query is run. It is set by default
  *       to 5
  *    detailed: states whether detailed statistics are collected during
- *      the execution. By default it is set to TRUE. 
+ *      the execution. By default it is set to TRUE.
  * Example of usage:
  *     <Create the function>
  *     SELECT berlinmod_R_queries(1, true)

--- a/BerlinMOD/berlinmod_r_queries_portable.sql
+++ b/BerlinMOD/berlinmod_r_queries_portable.sql
@@ -1,0 +1,232 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries — Portable Dialect (Q1–Q17)
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+Portable variant of `berlinmod_r_queries.sql` for the cross-platform
+edge-to-cloud benchmark.  The PG-specific PL/pgSQL harness, the
+`EXPLAIN (ANALYZE, FORMAT JSON)` capture, and the
+`execution_tests_explain` results table belong to the canonical file
+and are not reproduced here.  This file is the 17 query bodies as
+runnable, platform-agnostic SQL.
+
+Operator-to-function mapping (PG → portable):
+  &&   (bbox overlap)         → drop as a prefilter; rely on semantic
+                                predicate.  The portable form retains
+                                correctness; per-platform performance
+                                comes from each platform's own
+                                indexing / pushdown.
+  @>   (bbox contains)        → drop; rely on `valueAtTimestamp IS NOT NULL`
+                                or `eIntersects` for the actual containment.
+  _ST_Intersects              → `ST_Intersects` (bbox-bypass form is
+                                a PG-only optimization).
+
+Schema:
+  Trips(TripId, VehicleId, Trip tgeompoint, Trajectory geometry, …)
+  Vehicles(VehicleId, Licence, VehicleType, Model)
+  Licences(LicenceId, Licence, VehicleId)
+  Licences1, Licences2 (subsets)
+  Points(PointId, PosX, PosY, Geom)
+  Points1 (subset)
+  Regions(RegionId, RegionName, Geom)
+  Regions1 (subset)
+  Instants(InstantId, Instant)
+  Instants1 (subset)
+  Periods(PeriodId, Period)
+  Periods1 (subset)
+
+Expected row counts (BerlinMOD scalefactor 0.005, Brussels) — identical
+on PostgreSQL, DuckDB, and Spark when the LIMIT-10 parameter views use
+deterministic `ORDER BY <PrimaryKey>` (per the matching fix in
+`berlinmod_load.sql`):
+  Q1:72  Q2:1  Q3:6  Q4:80  Q5:100 Q6:0 Q7:26 Q8:75 Q9:94
+  Q10:21 Q11:0 Q12:0 Q13:278 Q14:1 Q15:118 Q16:2 Q17:1
+
+-----------------------------------------------------------------------------*/
+
+-- Q1: Models of vehicles with licences from Licences
+SELECT DISTINCT l.Licence, v.Model AS Model
+FROM Vehicles v, Licences l
+WHERE v.Licence = l.Licence
+ORDER BY l.Licence;
+
+-- Q2: How many vehicles are passenger cars?
+SELECT COUNT(Licence)
+FROM Vehicles v
+WHERE VehicleType = 'passenger';
+
+-- Q3: Position of each Licences1 vehicle at each Instants1 instant
+SELECT DISTINCT l.Licence, i.InstantId, i.Instant AS Instant,
+  valueAtTimestamp(t.Trip, i.Instant) AS Location
+FROM Trips t, Licences1 l, Instants1 i
+WHERE t.VehicleId = l.VehicleId
+  AND valueAtTimestamp(t.Trip, i.Instant) IS NOT NULL
+ORDER BY l.Licence, i.InstantId;
+
+-- Q4: Which vehicles passed any Points?
+SELECT DISTINCT p.PointId, p.Geom, v.Licence
+FROM Trips t, Vehicles v, Points p
+WHERE t.VehicleId = v.VehicleId
+  AND ST_Intersects(trajectory(t.Trip), p.Geom)
+ORDER BY p.PointId, v.Licence;
+
+-- Q5: Minimum distance between trip locations of two licence sets
+-- PG's `ST_Collect` is an aggregate function over geometry; DuckDB's
+-- spatial extension `ST_Collect` takes a GEOMETRY[] array.  Aggregating
+-- into an array first works on both: PG `array_agg` + DuckDB `array_agg`
+-- both produce the same shape, and DuckDB's `ST_Collect(geom_array)`
+-- is the canonical reduction; PG accepts `ST_Collect(array)` too (it
+-- has both aggregate and array-input overloads).
+WITH Temp1(Licence1, Trajs) AS (
+  SELECT l1.Licence, ST_Collect(array_agg(trajectory(t1.Trip)))
+  FROM Trips t1, Licences1 l1
+  WHERE t1.VehicleId = l1.VehicleId
+  GROUP BY l1.Licence),
+Temp2(Licence2, Trajs) AS (
+  SELECT l2.Licence, ST_Collect(array_agg(trajectory(t2.Trip)))
+  FROM Trips t2, Licences2 l2
+  WHERE t2.VehicleId = l2.VehicleId
+  GROUP BY l2.Licence)
+SELECT Licence1, Licence2, ST_Distance(t1.Trajs, t2.Trajs) AS MinDist
+FROM Temp1 t1, Temp2 t2
+ORDER BY Licence1, Licence2;
+
+-- Q6: Truck pairs that ever met within 10 m
+WITH Temp(Licence, VehicleId, Trip) AS (
+  SELECT v.Licence, t.VehicleId, t.Trip
+  FROM Trips t, Vehicles v
+  WHERE t.VehicleId = v.VehicleId
+    AND v.VehicleType = 'truck')
+SELECT DISTINCT t1.Licence, t2.Licence
+FROM Temp t1, Temp t2
+WHERE t1.VehicleId < t2.VehicleId
+  AND eDwithin(t1.Trip, t2.Trip, 10.0)
+ORDER BY t1.Licence, t2.Licence;
+
+-- Q7: For each Points geometry, earliest passenger-car visit
+WITH Temp AS (
+  SELECT DISTINCT v.Licence, p.PointId, p.Geom,
+    MIN(startTimestamp(atValues(t.Trip, p.Geom))) AS Instant
+  FROM Trips t, Vehicles v, Points p
+  WHERE t.VehicleId = v.VehicleId
+    AND v.VehicleType = 'passenger'
+    AND ST_Intersects(trajectory(t.Trip), p.Geom)
+  GROUP BY v.Licence, p.PointId, p.Geom)
+SELECT t1.Licence, t1.PointId, t1.Geom, t1.Instant
+FROM Temp t1
+WHERE t1.Instant <= ALL (
+  SELECT t2.Instant
+  FROM Temp t2
+  WHERE t1.PointId = t2.PointId)
+ORDER BY t1.PointId, t1.Licence;
+
+-- Q8: Total distance per licence × Periods1 period
+SELECT l.Licence, p.PeriodId, p.Period,
+  SUM(length(atTime(t.Trip, p.Period))) AS Dist
+FROM Trips t, Licences1 l, Periods1 p
+WHERE t.VehicleId = l.VehicleId
+  AND atTime(t.Trip, p.Period) IS NOT NULL
+GROUP BY l.Licence, p.PeriodId, p.Period
+ORDER BY l.Licence, p.PeriodId;
+
+-- Q9: Longest single-period vehicle distance per Periods period
+WITH Distances AS (
+  SELECT p.PeriodId, p.Period, t.VehicleId,
+    SUM(length(atTime(t.Trip, p.Period))) AS Dist
+  FROM Trips t, Periods p
+  WHERE atTime(t.Trip, p.Period) IS NOT NULL
+  GROUP BY p.PeriodId, p.Period, t.VehicleId)
+SELECT PeriodId, Period, MAX(Dist) AS MaxDist
+FROM Distances
+GROUP BY PeriodId, Period
+ORDER BY PeriodId;
+
+-- Q10: When and where each Licences1 vehicle was within 3 m of another
+WITH Temp AS (
+  SELECT l1.Licence AS Licence1, t2.VehicleId AS Car2Id,
+    whenTrue(tDwithin(t1.Trip, t2.Trip, 3.0)) AS Periods
+  FROM Trips t1, Licences1 l1, Trips t2, Vehicles v
+  WHERE t1.VehicleId = l1.VehicleId
+    AND t2.VehicleId = v.VehicleId
+    AND t1.VehicleId <> t2.VehicleId)
+SELECT Licence1, Car2Id, Periods
+FROM Temp
+WHERE Periods IS NOT NULL;
+
+-- Q11: Vehicles passing a Points1 at an Instants1 instant
+WITH Temp AS (
+  SELECT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Points1 p, Instants1 i
+  WHERE valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
+SELECT t.PointId, t.Geom, t.InstantId, t.Instant, v.Licence
+FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
+ORDER BY t.PointId, t.InstantId, v.Licence;
+
+-- Q12: Pairs of vehicles meeting at a Points1 at an Instants1 instant
+WITH Temp AS (
+  SELECT DISTINCT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Points1 p, Instants1 i
+  WHERE valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
+SELECT DISTINCT t1.PointId, t1.Geom, t1.InstantId, t1.Instant,
+  v1.Licence AS Licence1, v2.Licence AS Licence2
+FROM Temp t1
+JOIN Vehicles v1 ON t1.VehicleId = v1.VehicleId
+JOIN Temp t2 ON t1.VehicleId < t2.VehicleId
+  AND t1.PointId = t2.PointId
+  AND t1.InstantId = t2.InstantId
+JOIN Vehicles v2 ON t2.VehicleId = v2.VehicleId
+ORDER BY t1.PointId, t1.InstantId, v1.Licence, v2.Licence;
+
+-- Q13: Vehicles ever in a Regions1 during a Periods1 period
+WITH Temp AS (
+  SELECT DISTINCT r.RegionId, p.PeriodId, p.Period, t.VehicleId
+  FROM Trips t, Regions1 r, Periods1 p
+  WHERE ST_Intersects(trajectory(atTime(t.Trip, p.Period)), r.Geom))
+SELECT DISTINCT t.RegionId, t.PeriodId, t.Period, v.Licence
+FROM Temp t, Vehicles v
+WHERE t.VehicleId = v.VehicleId
+ORDER BY t.RegionId, t.PeriodId, v.Licence;
+
+-- Q14: Vehicles inside a Regions1 at an Instants1 instant
+WITH Temp AS (
+  SELECT DISTINCT r.RegionId, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Regions1 r, Instants1 i
+  WHERE ST_Contains(r.Geom, valueAtTimestamp(t.Trip, i.Instant)))
+SELECT DISTINCT t.RegionId, t.InstantId, t.Instant, v.Licence
+FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
+ORDER BY t.RegionId, t.InstantId, v.Licence;
+
+-- Q15: Vehicles passing a Points1 during a Periods1 period
+WITH Temp AS (
+  SELECT DISTINCT pt.PointId, pt.Geom, pr.PeriodId, pr.Period, t.VehicleId
+  FROM Trips t, Points1 pt, Periods1 pr
+  WHERE ST_Intersects(trajectory(atTime(t.Trip, pr.Period)), pt.Geom))
+SELECT DISTINCT t.PointId, t.Geom, t.PeriodId, t.Period, v.Licence
+FROM Temp t, Vehicles v
+WHERE t.VehicleId = v.VehicleId
+ORDER BY t.PointId, t.PeriodId, v.Licence;
+
+-- Q16: Pairs of vehicles that ever met in a Regions1 during a Periods1
+SELECT p.PeriodId, p.Period, r.RegionId,
+  l1.Licence AS Licence1, l2.Licence AS Licence2
+FROM Trips t1, Licences1 l1, Trips t2, Licences2 l2, Periods1 p, Regions1 r
+WHERE t1.VehicleId = l1.VehicleId
+  AND t2.VehicleId = l2.VehicleId
+  AND l1.Licence < l2.Licence
+  AND ST_Intersects(trajectory(atTime(t1.Trip, p.Period)), r.Geom)
+  AND ST_Intersects(trajectory(atTime(t2.Trip, p.Period)), r.Geom)
+  AND aDisjoint(atTime(t1.Trip, p.Period), atTime(t2.Trip, p.Period))
+ORDER BY PeriodId, RegionId, Licence1, Licence2;
+
+-- Q17: Points visited by the maximum number of vehicles
+WITH PointCount AS (
+  SELECT p.PointId, COUNT(DISTINCT t.VehicleId) AS Hits
+  FROM Trips t, Points p
+  WHERE ST_Intersects(trajectory(t.Trip), p.Geom)
+  GROUP BY p.PointId)
+SELECT PointId, Hits
+FROM PointCount AS p
+WHERE p.Hits = (SELECT MAX(Hits) FROM PointCount);

--- a/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
+++ b/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
@@ -1,0 +1,235 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD Range Queries — Portable Dialect with th3index Prefilter
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+th3index-accelerated sibling of `berlinmod_r_queries_portable.sql`.
+Same Q1–Q17 as the portable variant, with one extra clause per
+spatial-against-static query:
+
+    everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7), T.trip_h3)
+      AND <semantic predicate>
+
+`geoToH3IndexSet` covers POINT / LINESTRING / POLYGON / MULTI* /
+GeometryCollection in one walker, so the same prefilter shape applies
+to all spatial-static predicates.  Q1 and Q2 are relational (no spatial
+predicate) so they are unchanged.  Q3 and Q11 / Q12 use
+`valueAtTimestamp` (a point lookup at a single instant) — the
+prefilter applies via the point form.
+
+Prerequisites:
+  - The `Trips` table carries a `trip_h3 th3index` column populated at
+    H3 resolution 7 via `h3_latlng_to_cell(transform(Trip, 4326), 7)`.
+    The shared CSV produced by `berlinmod_portability_export()`
+    contains it; loaders on each platform unpack it.
+  - The static-geometry → H3 cell-set public API is registered:
+    `geoToH3Cell`, `geoToH3IndexSet`,
+    `everIntersectsH3IndexSet_Th3Index`.
+  - For MobilityDB specifically, the GiST index on `trip_h3` makes
+    the prefilter pushable to the planner.  Other platforms use the
+    columnar `trip_h3` value directly.
+
+Expected row counts must match the non-h3 portable variant (the
+prefilter is sound — see the chapter-1 bench report).
+
+The h3 prefilter uses the 4326-reprojected geometry of the static
+input.  In schemas where the canonical geometry is metric (e.g.
+EPSG:3857), the prefilter argument should be transformed:
+`geoToH3IndexSet(ST_Transform(G, 4326), 7)`.
+
+-----------------------------------------------------------------------------*/
+
+-- Q1: Models of vehicles with licences (relational, no prefilter)
+SELECT DISTINCT l.Licence, v.Model AS Model
+FROM Vehicles v, Licences l
+WHERE v.Licence = l.Licence
+ORDER BY l.Licence;
+
+-- Q2: How many vehicles are passenger cars? (relational, no prefilter)
+SELECT COUNT(Licence)
+FROM Vehicles v
+WHERE VehicleType = 'passenger';
+
+-- Q3: Position at instants (no geometry input, prefilter not applicable)
+SELECT DISTINCT l.Licence, i.InstantId, i.Instant AS Instant,
+  valueAtTimestamp(t.Trip, i.Instant) AS Location
+FROM Trips t, Licences1 l, Instants1 i
+WHERE t.VehicleId = l.VehicleId
+  AND valueAtTimestamp(t.Trip, i.Instant) IS NOT NULL
+ORDER BY l.Licence, i.InstantId;
+
+-- Q4: Trips passing each Points geometry
+SELECT DISTINCT p.PointId, p.Geom, v.Licence
+FROM Trips t, Vehicles v, Points p
+WHERE t.VehicleId = v.VehicleId
+  AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+  AND ST_Intersects(trajectory(t.Trip), p.Geom)
+ORDER BY p.PointId, v.Licence;
+
+-- Q5: Trip-trip min distance (cross-join, no static geometry — prefilter
+--     not applicable to static-vs-temporal; trip-vs-trip prefilter would
+--     need everEqTh3IndexTh3Index but the static-set form does not apply)
+WITH Temp1(Licence1, Trajs) AS (
+  SELECT l1.Licence, ST_Collect(trajectory(t1.Trip))
+  FROM Trips t1, Licences1 l1
+  WHERE t1.VehicleId = l1.VehicleId
+  GROUP BY l1.Licence),
+Temp2(Licence2, Trajs) AS (
+  SELECT l2.Licence, ST_Collect(trajectory(t2.Trip))
+  FROM Trips t2, Licences2 l2
+  WHERE t2.VehicleId = l2.VehicleId
+  GROUP BY l2.Licence)
+SELECT Licence1, Licence2, ST_Distance(t1.Trajs, t2.Trajs) AS MinDist
+FROM Temp1 t1, Temp2 t2
+ORDER BY Licence1, Licence2;
+
+-- Q6: Truck pairs that ever met within 10 m (trip-trip cross-join)
+WITH Temp(Licence, VehicleId, Trip, trip_h3) AS (
+  SELECT v.Licence, t.VehicleId, t.Trip, t.trip_h3
+  FROM Trips t, Vehicles v
+  WHERE t.VehicleId = v.VehicleId
+    AND v.VehicleType = 'truck')
+SELECT DISTINCT t1.Licence, t2.Licence
+FROM Temp t1, Temp t2
+WHERE t1.VehicleId < t2.VehicleId
+  AND ever_eq(t1.trip_h3, t2.trip_h3)
+  AND eDwithin(t1.Trip, t2.Trip, 10.0)
+ORDER BY t1.Licence, t2.Licence;
+
+-- Q7: Earliest passenger-car visit per Points geometry
+WITH Temp AS (
+  SELECT DISTINCT v.Licence, p.PointId, p.Geom,
+    MIN(startTimestamp(atValues(t.Trip, p.Geom))) AS Instant
+  FROM Trips t, Vehicles v, Points p
+  WHERE t.VehicleId = v.VehicleId
+    AND v.VehicleType = 'passenger'
+    AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+    AND ST_Intersects(trajectory(t.Trip), p.Geom)
+  GROUP BY v.Licence, p.PointId, p.Geom)
+SELECT t1.Licence, t1.PointId, t1.Geom, t1.Instant
+FROM Temp t1
+WHERE t1.Instant <= ALL (
+  SELECT t2.Instant
+  FROM Temp t2
+  WHERE t1.PointId = t2.PointId)
+ORDER BY t1.PointId, t1.Licence;
+
+-- Q8: Total distance per licence × Periods1 (no spatial geometry input)
+SELECT l.Licence, p.PeriodId, p.Period,
+  SUM(length(atTime(t.Trip, p.Period))) AS Dist
+FROM Trips t, Licences1 l, Periods1 p
+WHERE t.VehicleId = l.VehicleId
+  AND atTime(t.Trip, p.Period) IS NOT NULL
+GROUP BY l.Licence, p.PeriodId, p.Period
+ORDER BY l.Licence, p.PeriodId;
+
+-- Q9: Max single-period vehicle distance (no spatial geometry input)
+WITH Distances AS (
+  SELECT p.PeriodId, p.Period, t.VehicleId,
+    SUM(length(atTime(t.Trip, p.Period))) AS Dist
+  FROM Trips t, Periods p
+  WHERE atTime(t.Trip, p.Period) IS NOT NULL
+  GROUP BY p.PeriodId, p.Period, t.VehicleId)
+SELECT PeriodId, Period, MAX(Dist) AS MaxDist
+FROM Distances
+GROUP BY PeriodId, Period
+ORDER BY PeriodId;
+
+-- Q10: Licences1 vehicles within 3 m of other vehicles (trip-trip)
+WITH Temp AS (
+  SELECT l1.Licence AS Licence1, t2.VehicleId AS Car2Id,
+    whenTrue(tDwithin(t1.Trip, t2.Trip, 3.0)) AS Periods
+  FROM Trips t1, Licences1 l1, Trips t2, Vehicles v
+  WHERE t1.VehicleId = l1.VehicleId
+    AND t2.VehicleId = v.VehicleId
+    AND t1.VehicleId <> t2.VehicleId
+    AND ever_eq(t1.trip_h3, t2.trip_h3))
+SELECT Licence1, Car2Id, Periods
+FROM Temp
+WHERE Periods IS NOT NULL;
+
+-- Q11: Vehicles passing a Points1 at an Instants1 instant
+WITH Temp AS (
+  SELECT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Points1 p, Instants1 i
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+    AND valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
+SELECT t.PointId, t.Geom, t.InstantId, t.Instant, v.Licence
+FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
+ORDER BY t.PointId, t.InstantId, v.Licence;
+
+-- Q12: Pairs of vehicles meeting at a Points1 at an Instants1 instant
+WITH Temp AS (
+  SELECT DISTINCT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Points1 p, Instants1 i
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+    AND valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
+SELECT DISTINCT t1.PointId, t1.Geom, t1.InstantId, t1.Instant,
+  v1.Licence AS Licence1, v2.Licence AS Licence2
+FROM Temp t1
+JOIN Vehicles v1 ON t1.VehicleId = v1.VehicleId
+JOIN Temp t2 ON t1.VehicleId < t2.VehicleId
+  AND t1.PointId = t2.PointId
+  AND t1.InstantId = t2.InstantId
+JOIN Vehicles v2 ON t2.VehicleId = v2.VehicleId
+ORDER BY t1.PointId, t1.InstantId, v1.Licence, v2.Licence;
+
+-- Q13: Vehicles ever in a Regions1 during a Periods1 period
+WITH Temp AS (
+  SELECT DISTINCT r.RegionId, p.PeriodId, p.Period, t.VehicleId
+  FROM Trips t, Regions1 r, Periods1 p
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
+    AND ST_Intersects(trajectory(atTime(t.Trip, p.Period)), r.Geom))
+SELECT DISTINCT t.RegionId, t.PeriodId, t.Period, v.Licence
+FROM Temp t, Vehicles v
+WHERE t.VehicleId = v.VehicleId
+ORDER BY t.RegionId, t.PeriodId, v.Licence;
+
+-- Q14: Vehicles inside a Regions1 at an Instants1 instant
+WITH Temp AS (
+  SELECT DISTINCT r.RegionId, i.InstantId, i.Instant, t.VehicleId
+  FROM Trips t, Regions1 r, Instants1 i
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
+    AND ST_Contains(r.Geom, valueAtTimestamp(t.Trip, i.Instant)))
+SELECT DISTINCT t.RegionId, t.InstantId, t.Instant, v.Licence
+FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
+ORDER BY t.RegionId, t.InstantId, v.Licence;
+
+-- Q15: Vehicles passing a Points1 during a Periods1 period
+WITH Temp AS (
+  SELECT DISTINCT pt.PointId, pt.Geom, pr.PeriodId, pr.Period, t.VehicleId
+  FROM Trips t, Points1 pt, Periods1 pr
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(pt.Geom, 4326), 7), t.trip_h3)
+    AND ST_Intersects(trajectory(atTime(t.Trip, pr.Period)), pt.Geom))
+SELECT DISTINCT t.PointId, t.Geom, t.PeriodId, t.Period, v.Licence
+FROM Temp t, Vehicles v
+WHERE t.VehicleId = v.VehicleId
+ORDER BY t.PointId, t.PeriodId, v.Licence;
+
+-- Q16: Vehicle pairs ever met in a Regions1 during a Periods1 (cross-join)
+SELECT p.PeriodId, p.Period, r.RegionId,
+  l1.Licence AS Licence1, l2.Licence AS Licence2
+FROM Trips t1, Licences1 l1, Trips t2, Licences2 l2, Periods1 p, Regions1 r
+WHERE t1.VehicleId = l1.VehicleId
+  AND t2.VehicleId = l2.VehicleId
+  AND l1.Licence < l2.Licence
+  AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t1.trip_h3)
+  AND everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t2.trip_h3)
+  AND ST_Intersects(trajectory(atTime(t1.Trip, p.Period)), r.Geom)
+  AND ST_Intersects(trajectory(atTime(t2.Trip, p.Period)), r.Geom)
+  AND aDisjoint(atTime(t1.Trip, p.Period), atTime(t2.Trip, p.Period))
+ORDER BY PeriodId, RegionId, Licence1, Licence2;
+
+-- Q17: Points visited by the maximum number of vehicles
+WITH PointCount AS (
+  SELECT p.PointId, COUNT(DISTINCT t.VehicleId) AS Hits
+  FROM Trips t, Points p
+  WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+    AND ST_Intersects(trajectory(t.Trip), p.Geom)
+  GROUP BY p.PointId)
+SELECT PointId, Hits
+FROM PointCount AS p
+WHERE p.Hits = (SELECT MAX(Hits) FROM PointCount);

--- a/BerlinMOD/berlinmod_runall.sh
+++ b/BerlinMOD/berlinmod_runall.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#-----------------------------------------------------------------------------
+# BerlinMOD Run All
+#-----------------------------------------------------------------------------
+#
+# This file is part of MobilityDB.
+# Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+#-----------------------------------------------------------------------------
+
 # A script to run the BerlinMOD generator
 # Run this script inside the BerlinMOD/ folder.
 # This script expects the file brussels.osm

--- a/BerlinMOD/berlinmod_th3index_setup.sql
+++ b/BerlinMOD/berlinmod_th3index_setup.sql
@@ -1,0 +1,43 @@
+/*-----------------------------------------------------------------------------
+-- BerlinMOD th3index Setup -- one-time, idempotent
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+Run once after the standard BerlinMOD load, before sourcing
+`berlinmod_chapter1_queries_th3index_portable.sql`.  The script is
+idempotent — safe to re-run.
+
+What it does:
+  1. Adds `trip_h3 th3index` to the `Trips` table (NULL if absent).
+  2. Populates it by converting the `Trip tgeompoint` column to a
+     `th3index` at H3 resolution 7 via `h3_latlng_to_cell`.  Resolution
+     7 (cell edge ~ 1.2 km) is the default for BerlinMOD; lower
+     resolutions trade selectivity for coverage and may be preferable
+     at larger scale factors.
+  3. Builds a GiST index on `trip_h3` so the th3index prefilter
+     predicates can be pushed down by the planner.
+  4. Re-analyses the table.
+
+This script is MobilityDB/PostgreSQL specific.  The cross-platform
+loaders for MobilityDuck and MobilitySpark read `trip_h3` directly
+from the shared CSV produced by `berlinmod_portability_export()`.
+
+-----------------------------------------------------------------------------*/
+
+\timing OFF
+
+ALTER TABLE Trips
+  ADD COLUMN IF NOT EXISTS trip_h3 th3index;
+
+UPDATE Trips
+   SET trip_h3 = h3_latlng_to_cell(Trip, 7)
+ WHERE trip_h3 IS NULL;
+
+DROP INDEX IF EXISTS Trips_trip_h3_gist_idx;
+CREATE INDEX Trips_trip_h3_gist_idx
+  ON Trips USING GIST(trip_h3);
+
+ANALYZE Trips;

--- a/BerlinMOD/deliveries_datagenerator.sql
+++ b/BerlinMOD/deliveries_datagenerator.sql
@@ -2,8 +2,8 @@
 -- Deliveries Data Generator
 -------------------------------------------------------------------------------
 This file is part of MobilityDB.
-Copyright (c) 2024, Esteban Zimanyi, Mahmoud Sakr,
-  Universite Libre de Bruxelles.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
 
 The functions defined in this file use MobilityDB to generate data
 corresponding to a delivery service as specified in

--- a/BerlinMOD/deliveries_export.sql
+++ b/BerlinMOD/deliveries_export.sql
@@ -1,6 +1,16 @@
+/*-----------------------------------------------------------------------------
+-- Deliveries Export
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Exports the Brussels synthetic dataset obtained from the BerlinMOD generator
- * in CSV format 
+ * in CSV format
  * https://github.com/MobilityDB/MobilityDB-BerlinMOD
  * into MobilityDB using projected (2D) coordinates with SRID 3857
  * https://epsg.io/3857

--- a/BerlinMOD/deliveries_load.sql
+++ b/BerlinMOD/deliveries_load.sql
@@ -1,3 +1,13 @@
+/*-----------------------------------------------------------------------------
+-- Deliveries Load
+-------------------------------------------------------------------------------
+
+This file is part of MobilityDB.
+Copyright(c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+-----------------------------------------------------------------------------*/
+
 /******************************************************************************
  * Loads the Deliveries data in CSV format into MobilityDB using projected (2D)
  * coordinates with SRID 3857

--- a/BerlinMOD/mobilityduck_schema_adapter.sql
+++ b/BerlinMOD/mobilityduck_schema_adapter.sql
@@ -1,0 +1,114 @@
+/*-----------------------------------------------------------------------------
+-- MobilityDuck — Schema adapter for the portable R-queries
+-------------------------------------------------------------------------------
+
+Bridges the cross-platform CSV-loaded BerlinMOD schema to the canonical
+column names the portable R-queries expect.  Run once before sourcing
+`berlinmod_r_queries_portable.sql`.
+
+Native cross-platform schema:
+  Trips(tripid, vehid, trip)
+  Vehicles(vehid, licence, type, model)
+  QueryLicences(licenceid, licence)
+  QueryInstants(instantid, instant)
+  QueryPeriods(periodid, period)
+  QueryPoints(pointid, geom, geomwkt)
+  QueryRegions(regionid, geom, geomwkt)
+
+What the portable R-queries expect:
+  Trips(TripId, VehicleId, Trip)
+  Vehicles(VehicleId, Licence, VehicleType, Model)
+  Licences(LicenceId, Licence, VehicleId)
+  Licences1, Licences2 (subsets)
+  Instants1(InstantId, Instant)
+  Periods1(PeriodId, Period)
+  Points, Points1(PointId, Geom)
+  Regions, Regions1(RegionId, Geom)
+
+The adapter creates views with the canonical names.  Columns map
+case-insensitively in DuckDB / MobilityDB / MobilitySpark, so the
+portable SQL's `T.VehicleId` reads as `t.vehid` on each platform.
+
+-----------------------------------------------------------------------------*/
+
+-- Preparation: rename the loaded tables to expose canonical column
+-- names through views.  Run once on a fresh load:
+--   ALTER TABLE Vehicles RENAME TO VehiclesRaw;
+--   ALTER TABLE Trips    RENAME TO TripsRaw;
+
+-- Vehicles: view exposing canonical names.
+DROP VIEW IF EXISTS Vehicles;
+CREATE VIEW Vehicles AS
+  SELECT vehid AS VehicleId, licence AS Licence,
+         type AS VehicleType, model AS Model
+  FROM VehiclesRaw;
+
+-- Trips: view exposing canonical names.  No StartDate / SeqNo / Trajectory
+-- in the cross-platform schema; the R-queries that reference them get a
+-- NULL but the predicates that matter (vehicle / trip) still resolve.
+DROP VIEW IF EXISTS Trips;
+CREATE VIEW Trips AS
+  SELECT tripid AS TripId, vehid AS VehicleId, trip AS Trip
+  FROM TripsRaw;
+
+-- Licences: the full canonical PG table is the parameter set
+-- `QueryLicences` here (the cross-platform export does not retain
+-- the wider Licences table; it carries only the query parameters).
+DROP VIEW IF EXISTS Licences;
+CREATE VIEW Licences AS
+  SELECT q.licenceid AS LicenceId, q.licence AS Licence, v.vehid AS VehicleId
+  FROM QueryLicences q JOIN VehiclesRaw v ON q.licence = v.licence;
+
+-- Licences1, Licences2: subsets via QueryLicences (parameter sample).
+DROP VIEW IF EXISTS Licences1;
+CREATE VIEW Licences1 AS
+  SELECT q.licenceid AS LicenceId, q.licence AS Licence, v.vehid AS VehicleId
+  FROM QueryLicences q JOIN VehiclesRaw v ON q.licence = v.licence
+  ORDER BY q.licenceid LIMIT 10;
+
+DROP VIEW IF EXISTS Licences2;
+CREATE VIEW Licences2 AS
+  SELECT q.licenceid AS LicenceId, q.licence AS Licence, v.vehid AS VehicleId
+  FROM QueryLicences q JOIN VehiclesRaw v ON q.licence = v.licence
+  ORDER BY q.licenceid OFFSET 10 LIMIT 10;
+
+-- Instants, Instants1
+DROP VIEW IF EXISTS Instants;
+CREATE VIEW Instants AS
+  SELECT instantid AS InstantId, instant AS Instant FROM QueryInstants;
+DROP VIEW IF EXISTS Instants1;
+CREATE VIEW Instants1 AS
+  SELECT instantid AS InstantId, instant AS Instant
+  FROM QueryInstants ORDER BY instantid LIMIT 10;
+
+-- Periods, Periods1
+DROP VIEW IF EXISTS Periods;
+CREATE VIEW Periods AS
+  SELECT periodid AS PeriodId, period AS Period FROM QueryPeriods;
+DROP VIEW IF EXISTS Periods1;
+CREATE VIEW Periods1 AS
+  SELECT periodid AS PeriodId, period AS Period
+  FROM QueryPeriods ORDER BY periodid LIMIT 10;
+
+-- Points, Points1
+DROP VIEW IF EXISTS Points;
+CREATE VIEW Points AS
+  SELECT pointid AS PointId, geom AS Geom FROM QueryPoints;
+DROP VIEW IF EXISTS Points1;
+CREATE VIEW Points1 AS
+  SELECT pointid AS PointId, geom AS Geom
+  FROM QueryPoints ORDER BY pointid LIMIT 10;
+
+-- Regions, Regions1: the cross-platform export keeps polygons in
+-- EPSG:4326 while Trips and Points are reprojected to EPSG:3857 at
+-- load time.  Match the SRID of Trips for spatial predicates.
+DROP VIEW IF EXISTS Regions;
+CREATE VIEW Regions AS
+  SELECT regionid AS RegionId,
+         ST_Transform(geom, 'EPSG:4326', 'EPSG:3857', always_xy := true) AS Geom
+  FROM QueryRegions;
+DROP VIEW IF EXISTS Regions1;
+CREATE VIEW Regions1 AS
+  SELECT regionid AS RegionId,
+         ST_Transform(geom, 'EPSG:4326', 'EPSG:3857', always_xy := true) AS Geom
+  FROM QueryRegions ORDER BY regionid LIMIT 10;

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+-------------------------------------------------------------------------------
+This MobilityDB code is provided under The PostgreSQL License.
+
+Copyright (c) 2020-2026, Université libre de Bruxelles and MobilityDB
+contributors
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement is
+hereby granted, provided that the above copyright notice and this paragraph and
+the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND
+UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This repository contains code and documentation for running the
 [BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html)
 benchmark on MobilityDB.
 
+### For contributors and reviewers
+
+- Reviewing a pull request? See the
+  [PR Reviewer Guide](doc/contributing/reviewer-guide.md) — tier ranking,
+  dependency chain (this repo + MobilityDB + MobilityDuck + MobilitySpark
+  + JMEOS) and the standards checklist. Reviewers landing in any of the
+  five ecosystem repos find the same canonical structure at the same path.
+
 ## 1. Requirements
 
 - [PostgreSQL](https://www.postgresql.org/) 14 or later

--- a/README.md
+++ b/README.md
@@ -3,81 +3,242 @@ BerlinMOD Benchmark for MobilityDB
 
 <img src="docs/images/mobilitydb-logo.svg" width="200" alt="MobilityDB Logo" />
 
-[MobilityDB](https://github.com/ULB-CoDE-WIT/MobilityDB) is an open source software program that adds support for temporal and spatio-temporal objects to the [PostgreSQL](https://www.postgresql.org/) database and its spatial extension [PostGIS](http://postgis.net/).
+[MobilityDB](https://github.com/MobilityDB/MobilityDB) is an open source
+software program that adds support for temporal and spatio-temporal objects to
+the [PostgreSQL](https://www.postgresql.org/) database and its spatial
+extension [PostGIS](http://postgis.net/).
 
-This repository contains code and the documentation for running the [BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html) benchmark on MobilityDB.
+This repository contains code and documentation for running the
+[BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html)
+benchmark on MobilityDB.
 
-Documentation
--------------
+## 1. Requirements
 
-You can generate the benchmark documentation from the sources.
-*  In HTML format
+- [PostgreSQL](https://www.postgresql.org/) 14 or later
+- [PostGIS](http://postgis.net/) 3.0 or later
+- [MobilityDB](https://github.com/MobilityDB/MobilityDB) 1.1 or later
+- [pgRouting](https://pgrouting.org/) (for data generation)
+- [osm2pgrouting](https://github.com/pgRouting/osm2pgrouting) and
+  [osm2pgsql](https://osm2pgsql.org/) (for importing OSM road network data)
 
-        xsltproc --stringparam html.stylesheet "docbook.css" --xinclude -o index.html /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl mobilitydb-berlinmod.xml
-*  In PDF format
+## 2. Building / Installation
 
-        dblatex -s texstyle.sty -T native -t pdf -o mobilitydb-berlinmod.pdf mobilitydb-berlinmod.xml
-* In EPUB format
+**Create the database and load the road network:**
 
-        dbtoepub -o mobilitydb-berlinmod.epub mobilitydb-berlinmod.xml
+```bash
+createdb berlinmod
+psql -d berlinmod -c 'CREATE EXTENSION MobilityDB CASCADE'
+psql -d berlinmod -c 'CREATE EXTENSION pgRouting'
+```
 
-In addition, pregenerated versions of them are available.
+Import OSM data for Brussels (or another city) using `osm2pgrouting` and
+`osm2pgsql`:
 
-*  In HTML format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/html/index.html
-*  In PDF format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.pdf
-* In EPUB format: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.epub
+```bash
+osm2pgrouting -f brussels.osm --dbname berlinmod -c BerlinMOD/mapconfig.xml
+osm2pgsql -c -d berlinmod brussels.osm
+```
 
-Docker container
------------------
+Prepare the road network graph:
 
-The dependencies and scripts of the MobilityDB-BerlinMOD Project are available in a Docker container running PostgreSQL-15, PostGIS-2.5 and MobilityDB-develop.
+```bash
+psql -d berlinmod -f BerlinMOD/brussels_preparedata.sql
+```
 
-*  Pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/mobilitydb/mobilitydb).
+Alternatively, use the optimized graph builder:
 
-        docker pull mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+```bash
+psql -d berlinmod -f BerlinMOD/brussels_creategraph.sql
+```
 
-*  Create a Docker volume to preserve the PostgreSQL database files outside of the container.
+## 3. Using
 
-        docker volume create mobilitydb_data
-        
- *  Run the Docker container.
+**Generate BerlinMOD synthetic data:**
 
-        docker run --name mobilitydb -e POSTGRES_PASSWORD=mysecretpassword \
-        -p 25432:5432 -v mobilitydb_data:/var/lib/postgresql -d mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD 
-        
- *  Connect to the database  (db=postgres,username=postgres,pw=_mysecretpassword_).
+Load the data generator and call it with a scale factor:
 
-        psql -h localhost -p 25432 -U postgres 
+```sql
+\i BerlinMOD/berlinmod_datagenerator.sql
+SELECT berlinmod_datagenerator(scaleFactor := 0.005);
+```
 
- *  BerlinMOD scripts are available in the BerlinMOD directory inside the container.
-      
-Generated datasets
----------------------
+**Generate Deliveries synthetic data:**
 
-The generator has two scenarios, the original one from BerlinMOD, and another one concerning deliveries pertaining to mobility data warehouses. We have generated the benchmark data for different scale factors (SF) for the two scenarios The different datasets and their characteristics are given in the tables below, that also provides links to download the data in compressed CSV files.
+```sql
+\i BerlinMOD/deliveries_datagenerator.sql
+SELECT deliveries_datagenerator(scaleFactor := 0.005);
+```
 
-BerlinMOD synthetic data using OSM data from Brussels.
+**Run all steps with the shell script:**
+
+```bash
+cd BerlinMOD
+bash berlinmod_runall.sh
+```
+
+**Run benchmark queries:**
+
+After loading data (see [Generated datasets](#5-examples) below for
+pre-generated CSV files), execute the benchmark queries:
+
+```sql
+-- Chapter 1 ad-hoc queries (range, temporal aggregate, distance)
+\i BerlinMOD/berlinmod_chapter1_queries.sql
+
+-- Range queries (17 BerlinMOD/R queries)
+\i BerlinMOD/berlinmod_load.sql
+SELECT berlinmod_R_queries(1, true);
+
+-- Nearest-neighbor queries (9 BerlinMOD/NN queries)
+SELECT berlinmod_NN_queries(1, true);
+```
+
+**Load pre-generated CSV data:**
+
+```sql
+\i BerlinMOD/berlinmod_load.sql
+SELECT berlinmod_load('/path/to/csv/files/', true);
+```
+
+## 4. Cross-Platform Portability
+
+BerlinMOD queries can run unchanged on all three platforms of the MobilityDB
+ecosystem using the **portable SQL dialect** (named functions only, no
+platform-specific operator symbols):
+
+| Platform | Engine | Extension |
+|---|---|---|
+| [MobilityDB](https://github.com/MobilityDB/MobilityDB) | PostgreSQL | `CREATE EXTENSION mobilitydb` |
+| [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) | DuckDB | `LOAD mobilitydb` |
+| [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) | Apache Spark | `MobilitySparkSession.create(spark)` |
+
+**Run portable Chapter 1 queries (Q1–Q6) on MobilityDB:**
+
+```sql
+\i BerlinMOD/berlinmod_chapter1_queries_portable.sql
+```
+
+**Export data for MobilityDuck / MobilitySpark:**
+
+The `berlinmod_portability_export()` function writes five CSV files in the
+shared cross-platform schema:
+
+```sql
+\i BerlinMOD/berlinmod_export.sql
+SELECT berlinmod_portability_export('/path/to/output/');
+```
+
+This produces:
+
+| File | Contents |
+|------|----------|
+| `vehicles.csv` | `vehId, licence, type, model` |
+| `trips.csv` | `tripId, vehId, trip` — tgeompoint as WKT text |
+| `query_licences.csv` | `licenceId, licence` |
+| `query_instants.csv` | `instantId, instant` |
+| `query_points.csv` | `pointId, geom` — geometry as WKT text |
+
+These files can be loaded directly by the MobilitySpark cross-platform test
+runner (`berlinmod/run_mbdb.sh`, `run_mduck.sh`) as described in the
+[MobilitySpark repository](https://github.com/MobilityDB/MobilitySpark).
+
+## 5. Running the Tests
+
+After running the benchmark queries, compare results against expected output
+to validate correctness. The documentation (see below) specifies expected
+result counts for each query at each scale factor.
+
+Generate the documentation from source to obtain the full reference:
+
+```bash
+cd docs
+dblatex -s texstyle.sty -T native -t pdf -o mobilitydb-berlinmod.pdf mobilitydb-berlinmod.xml
+```
+
+Pre-generated documentation is available online:
+
+- HTML: https://mobilitydb.github.io/MobilityDB-BerlinMOD/html/index.html
+- PDF: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.pdf
+- EPUB: https://mobilitydb.github.io/MobilityDB-BerlinMOD/mobilitydb-berlinmod.epub
+
+## 6. Examples
+
+The generator produces two benchmark scenarios:
+
+**BerlinMOD** — vehicles moving through the Brussels road network.
 
 | Scale Factor | Vehicles | Days | Trips | File | Size |
-|--------------|---------:|-----:|------:|-----|-----:|
-| SF 0.1 |   632 | 11 |  18,910 | [brussels_sf0.1.zip](https://docs.mobilitydb.com/pub/brussels_sf0.1.zip) | 5.5 MB |
-| SF 0.2 |   894 | 15 |  35,319 | [brussels_sf0.2.zip](https://docs.mobilitydb.com/pub/brussels_sf0.2.zip) | 9.6 MB |
-| SF 0.5 | 1,414 | 22 |  81,584 | [brussels_sf0.5.zip](https://docs.mobilitydb.com/pub/brussels_sf0.5.zip) | 2.2 GB |
-| SF 1   | 2,000 | 30 | 157,565 | [brussels_sf1.zip](https://docs.mobilitydb.com/pub/brussels_sf1.zip) | 4.2 GB |
+|:-------------|--------:|-----:|------:|:-----|-----:|
+| SF 0.1 | 632 | 11 | 18,910 | [brussels_sf0.1.zip](https://docs.mobilitydb.com/pub/brussels_sf0.1.zip) | 5.5 MB |
+| SF 0.2 | 894 | 15 | 35,319 | [brussels_sf0.2.zip](https://docs.mobilitydb.com/pub/brussels_sf0.2.zip) | 9.6 MB |
+| SF 0.5 | 1,414 | 22 | 81,584 | [brussels_sf0.5.zip](https://docs.mobilitydb.com/pub/brussels_sf0.5.zip) | 2.2 GB |
+| SF 1 | 2,000 | 30 | 157,565 | [brussels_sf1.zip](https://docs.mobilitydb.com/pub/brussels_sf1.zip) | 4.2 GB |
 
-
-Deliveries synthetic data using OSM data from Brussels.
-
+**Deliveries** — vehicles making deliveries from warehouses to customers.
 
 | Scale Factor | Warehouses | Vehicles | Customers | Days | Deliveries | File | Size |
-|--------------|-----------:|---------:|----------:|------|-----------:|-----|-----:|
-| SF 0.1       |  32 |   632 |  3,162 | 11 |  6,320 | [deliveries_sf0.1.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.1.zip) | 1.4 GB |
-| SF 0.2       |  45 |   894 |  4,472 | 15 | 11,622 | [deliveries_sf0.2.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.2.zip) | 2.6 GB |
-| SF 0.5       |  71 | 1,414 |  7,071 | 22 | 26,866 | [deliveries_sf0.5.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.5.zip) | 6.1 GB |
-| SF 1         | 100 | 2,000 | 10,000 | 30 | 26,866 | [deliveries_sf1.zip](https://docs.mobilitydb.com/pub/deliveries_sf1.zip) | 11.8 GB |
-  
+|:-------------|----------:|---------:|----------:|-----:|-----------:|:-----|-----:|
+| SF 0.1 | 32 | 632 | 3,162 | 11 | 6,320 | [deliveries_sf0.1.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.1.zip) | 1.4 GB |
+| SF 0.2 | 45 | 894 | 4,472 | 15 | 11,622 | [deliveries_sf0.2.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.2.zip) | 2.6 GB |
+| SF 0.5 | 71 | 1,414 | 7,071 | 22 | 26,866 | [deliveries_sf0.5.zip](https://docs.mobilitydb.com/pub/deliveries_sf0.5.zip) | 6.1 GB |
+| SF 1 | 100 | 2,000 | 10,000 | 30 | 26,866 | [deliveries_sf1.zip](https://docs.mobilitydb.com/pub/deliveries_sf1.zip) | 11.8 GB |
 
-License
--------
+**Docker container:**
 
-The documentation of this benchmark is licensed under a [Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/)
+A Docker image with all dependencies pre-installed is available:
+
+```bash
+docker pull mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+docker volume create mobilitydb_data
+docker run --name mobilitydb -e POSTGRES_PASSWORD=mysecretpassword \
+  -p 25432:5432 -v mobilitydb_data:/var/lib/postgresql \
+  -d mobilitydb/mobilitydb:15-3.4-1.1-BerlinMOD
+psql -h localhost -p 25432 -U postgres
+```
+
+BerlinMOD scripts are available in the `BerlinMOD/` directory inside the
+container. See the [Docker documentation](docker/) for further details.
+
+## 7. Project Structure
+
+```
+MobilityDB-BerlinMOD/
+├── BerlinMOD/
+│   ├── berlinmod_datagenerator.sql      # BerlinMOD data generator
+│   ├── deliveries_datagenerator.sql     # Deliveries data generator
+│   ├── berlinmod_load.sql               # Load pre-generated CSV data
+│   ├── deliveries_load.sql              # Load pre-generated deliveries CSV
+│   ├── berlinmod_export.sql             # Export data to CSV (incl. berlinmod_portability_export)
+│   ├── deliveries_export.sql            # Export deliveries data to CSV
+│   ├── berlinmod_chapter1_queries.sql   # Ad-hoc benchmark queries
+│   ├── berlinmod_chapter1_queries_portable.sql  # Portable dialect queries
+│   ├── berlinmod_r_queries.sql          # BerlinMOD/R range queries
+│   ├── berlinmod_r_queries_citus.sql    # Range queries for Citus
+│   ├── berlinmod_nn_queries.sql         # BerlinMOD/NN nearest-neighbor queries
+│   ├── berlinmod_d_vehicleid.sql        # Citus distribution by vehicle ID
+│   ├── berlinmod_runall.sh              # Shell script to run all steps
+│   ├── brussels_preparedata.sql         # Prepare Brussels road network
+│   └── brussels_creategraph.sql         # Optimized graph builder
+├── docs/                                # DocBook documentation source
+├── docker/                              # Docker setup files
+└── README.md
+```
+
+## Contributing
+
+This repository uses a single perennial **`master`** branch — the same model
+as [MobilityDB](https://github.com/MobilityDB/MobilityDB) itself:
+
+1. Fork this repository.
+2. Create a feature or fix branch on your fork.
+3. Open a pull request against `MobilityDB/MobilityDB-BerlinMOD:master`.
+
+There are no long-lived release branches; tags mark stable snapshots.
+
+## License
+
+The SQL scripts in this repository are provided under the
+[PostgreSQL License](LICENSE).
+
+The documentation of this benchmark is licensed under a
+[Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/).

--- a/doc/contributing/reviewer-guide.md
+++ b/doc/contributing/reviewer-guide.md
@@ -1,0 +1,96 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is licensed under a
+Creative Commons Attribution-Share Alike 3.0 License
+https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# MobilityDB-BerlinMOD PR Reviewer Guide
+
+Quick reference for anyone reviewing open pull requests in **MobilityDB-BerlinMOD** —
+the canonical BerlinMOD data generator + portable SQL benchmark surface for the
+MobilityDB ecosystem.
+Updated in the same commit as any PR that changes PR state or adds new branches.
+**Last updated: 2026-05-11 — 2 open PRs (#23 ecosystem-standards, #24 trip_h3 export). Both source-complete, awaiting external committer review.**
+
+---
+
+## How to find this guide
+
+- **In the repo:** `doc/contributing/reviewer-guide.md`
+- **Rule:** every commit that opens, closes, or restructures a PR must update this file in the same commit. A one-liner status change is enough; a fuller rewrite is needed when the dependency graph changes.
+
+Reviewers landing in any of the five ecosystem repos (MobilityDB / MobilityDuck /
+MobilitySpark / JMEOS / MobilityDB-BerlinMOD) find the same canonical structure
+at the same path.
+
+---
+
+## CI legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | All checks green |
+| ❌ | Real failure — needs investigation before review |
+| ⏳ | CI running |
+| ❓ | No CI result yet (doc-only, draft, or external PR) |
+| ⚠️ | Non-blocking failure (e.g. macOS/Windows `continue-on-error`, Codacy ACTION_REQUIRED — maintainer overrides in UI) |
+
+---
+
+## Dependency chain — land in this order
+
+```
+PR #23  feat/ecosystem-standards  (LICENSE + ecosystem README + portability_export
+                                    function + Q1-Q6 portable SQL — foundation)
+  └─► PR #24  feat/portability-export-th3index  (extends portability_export to
+                                                  also write trip_h3 column —
+                                                  pairs with MobilityDB PR #938
+                                                  geo_to_h3index_set kernel)
+```
+
+**PR #23 should land first** — it introduces the portability framework that PR #24 extends.
+
+PR #24 also has a cross-repo dependency: it calls `tgeompoint_to_th3index(Trip, 7)`
+which comes from MobilityDB PRs #807 / #866 / #893 (the th3index type itself).
+Per `feedback_issued_pr_treat_as_landed.md`, downstream work proceeds without
+waiting on upstream merge — PR #24 is source-complete; the actual `trip_h3`
+column generation works once the MobilityDB th3index branch lands.
+
+---
+
+## Tier 1 — Merge after MobilityDB ecosystem standards land
+
+| PR | Branch | Description | CI |
+|----|--------|-------------|----|
+| #23 | `estebanzimanyi:feat/ecosystem-standards` | LICENSE + copyright header sweep + cross-platform portability scaffold: `berlinmod_portability_export(fullpath text)` writes 5 CSVs in the shared schema (vehicles, trips as WKT tgeompoint, query_licences/instants/points); `berlinmod_chapter1_queries_portable.sql` for Q1-Q6 portable dialect; README extension; CI workflow improvements. Stale fork branches deleted (`load_export`, `sync`, `version1.3`) | ✅ |
+
+---
+
+## Tier 0 — Performance (depends on upstream th3index)
+
+| PR | Branch | Description | CI | Notes |
+|----|--------|-------------|----|-------|
+| #24 | `estebanzimanyi:feat/portability-export-th3index` | Extends `berlinmod_portability_export()` to write a 4-column `trips.csv` including `trip_h3` (th3index hex-WKB at H3 resolution 7). Cross-platform spatial prefilter source for BerlinMOD Q2/Q4/Q5/Q6/Q10. | ❓ | Stacks on **MobilityDB #807** (th3index type) + #866 (spatial wiring) + #938 (geo_to_h3index_set). Source-complete; needs MobilityDB th3index merge to actually generate trip_h3 from a live PG instance. Paired with MobilitySpark PR #9 (the consumer side). |
+
+---
+
+## Review checklist
+
+For every MobilityDB-BerlinMOD PR, verify:
+
+- [ ] PostgreSQL License header on every new `.sql` / `.c` file
+- [ ] New SQL function follows ecosystem RFC #861 portable-name convention (camelCase, no operators, no `::numeric` casts)
+- [ ] Generated CSV output is platform-portable (WKT or hex-WKB; no platform-specific binary encodings)
+- [ ] Any new generator step has a `RAISE INFO` execution trace + start/end timestamps
+- [ ] If the PR modifies `berlinmod_export.sql` or `berlinmod_portability_export()`, the cross-platform loaders in MobilitySpark `berlinmod/load_*.sql` need a matching update — flag in the PR description
+
+---
+
+## Cross-repo links
+
+- **MobilityDB:** [doc/contributing/reviewer-guide.md](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md)
+- **MobilityDuck:** [doc/contributing/reviewer-guide.md](https://github.com/MobilityDB/MobilityDuck/blob/master/doc/contributing/reviewer-guide.md)
+- **MobilitySpark:** [doc/contributing/reviewer-guide.md](https://github.com/MobilityDB/MobilitySpark/blob/main/doc/contributing/reviewer-guide.md)
+- **JMEOS:** [doc/contributing/reviewer-guide.md](https://github.com/MobilityDB/JMEOS/blob/main/doc/contributing/reviewer-guide.md)


### PR DESCRIPTION
Adds \`doc/contributing/reviewer-guide.md\` mirroring the canonical reviewer-guide structure used in MobilityDB / MobilityDuck / MobilitySpark / JMEOS, scoped to MobilityDB-BerlinMOD.

Same canonical path (\`doc/contributing/reviewer-guide.md\`) as the other four ecosystem repos — reviewers landing in any of the five find the same structure at the same place.

## Summary

- Dependency chain: PR #23 (ecosystem-standards foundation) → PR #24 (extends \`berlinmod_portability_export()\` with \`trip_h3\` — pairs with MobilityDB PR #938 \`geo_to_h3index_set\`). Cross-repo dependency on MobilityDB th3index branch (#807 / #866 / #893) documented per \`feedback_issued_pr_treat_as_landed.md\`.
- Tier ranking + per-tier review notes
- Standards checklist: license header, portable-name convention, CSV portability, loader cross-platform impact
- Cross-repo links to the other four ecosystem reviewer guides

Wires visibility:

- \`.github/PULL_REQUEST_TEMPLATE.md\` links to the guide so contributors are prompted to update it in any commit that opens / closes / restructures a PR
- \`README.md\` gains a "For contributors and reviewers" section pointing to the guide

## Test plan

- [x] Doc-only PR — no CI impact
- [x] Single commit on a clean branch off \`master\`
- [x] Mirrors structure of MobilityDB#931 / MobilityDuck#117 / MobilitySpark#8 / JMEOS#13