### PR TITLE
Add the dated three-platform BerlinMOD benchmark reports

### DIFF
--- a/BerlinMOD/benchmarks/BETA_TESTING.md
+++ b/BerlinMOD/benchmarks/BETA_TESTING.md
@@ -66,20 +66,20 @@ All three platforms must return identical row counts.  Reference numbers
 |---:|---:|
 | Q1 | 72 |
 | Q2 | 1 |
-| Q3 | 0 |
+| Q3 | 6 |
 | Q4 | 80 |
-| Q5 | 30 |
+| Q5 | 100 |
 | Q6 | 0 |
 | Q7 | 26 |
-| Q8 | 39 |
+| Q8 | 75 |
 | Q9 | 94 |
-| Q10 | 4 |
+| Q10 | 21 |
 | Q11 | 0 |
 | Q12 | 0 |
-| Q13 | 425 |
-| Q14 | 2 |
+| Q13 | 278 |
+| Q14 | 1 |
 | Q15 | 118 |
-| Q16 | 9 |
+| Q16 | 2 |
 | Q17 | 1 |
 
 Both the standard portable variant and the th3index variant must

--- a/BerlinMOD/benchmarks/BETA_TESTING.md
+++ b/BerlinMOD/benchmarks/BETA_TESTING.md
@@ -1,0 +1,162 @@
+# BerlinMOD ecosystem benchmark — Beta testing guide
+
+Audience: privileged testers running the BerlinMOD benchmark on
+MobilityDB, MobilityDuck, and MobilitySpark to validate cross-platform
+parity and performance.
+
+This guide is for **testers**.  Engineering details and PR links live
+in the bench reports under `BerlinMOD/benchmarks/`.
+
+---
+
+## What to run
+
+For each platform, the benchmark covers the 17 BerlinMOD R-queries
+plus the 6 chapter-1 queries.  Two query files exist:
+
+| File | Purpose |
+|---|---|
+| `berlinmod_r_queries_portable.sql` | Cross-platform reference; same SQL on all three platforms. |
+| `berlinmod_r_queries_th3index_portable.sql` | Same queries, with the h3 cell-set prefilter on spatial predicates.  Drop-in replacement for performance comparison. |
+| `berlinmod_chapter1_queries_portable.sql` | Existing 6-query subset (textbook reference). |
+| `berlinmod_chapter1_queries_th3index_portable.sql` | Chapter-1 + h3 prefilter. |
+
+Per platform:
+
+### MobilityDB / PostgreSQL
+
+```
+psql -d <bench-db> -f BerlinMOD/berlinmod_th3index_setup.sql
+psql -d <bench-db> -f BerlinMOD/berlinmod_r_queries_portable.sql
+psql -d <bench-db> -f BerlinMOD/berlinmod_r_queries_th3index_portable.sql
+```
+
+For MobilityDB, the canonical PL/pgSQL driver
+`berlinmod_r_queries.sql` (call `SELECT berlinmod_R_queries(1, false);`)
+is also available and captures detailed `EXPLAIN ANALYZE` timings into
+`execution_tests_explain`.
+
+### MobilityDuck / DuckDB
+
+```
+duckdb <bench.db> -c ".read BerlinMOD/berlinmod_r_queries_portable.sql"
+duckdb <bench.db> -c ".read BerlinMOD/berlinmod_r_queries_th3index_portable.sql"
+```
+
+Capture wall-clock time per statement via DuckDB's `.timer on` directive.
+
+### MobilitySpark / Spark SQL
+
+```
+spark-submit --master local[2] BerlinMODBench --queries r_queries_portable
+spark-submit --master local[2] BerlinMODBench --queries r_queries_th3index_portable
+```
+
+**`local[2]` is a correctness constraint, not a tuning knob — see
+`feedback_mobilityspark_local2_constraint.md`.  Do not raise it.**
+
+---
+
+## Expected row counts
+
+All three platforms must return identical row counts.  Reference numbers
+(BerlinMOD scalefactor 0.005 — 1620 trips):
+
+| Query | Rows |
+|---:|---:|
+| Q1 | 72 |
+| Q2 | 1 |
+| Q3 | 0 |
+| Q4 | 80 |
+| Q5 | 30 |
+| Q6 | 0 |
+| Q7 | 26 |
+| Q8 | 39 |
+| Q9 | 94 |
+| Q10 | 4 |
+| Q11 | 0 |
+| Q12 | 0 |
+| Q13 | 425 |
+| Q14 | 2 |
+| Q15 | 118 |
+| Q16 | 9 |
+| Q17 | 1 |
+
+Both the standard portable variant and the th3index variant must
+produce the **same** row counts — the h3 prefilter is sound.
+
+Any row-count divergence is a test failure and should be reported (see
+"How to report" below).
+
+---
+
+## What to measure
+
+For each platform and each query, record:
+
+1. Wall-clock execution time
+2. Returned row count
+3. (PG only, optional) `EXPLAIN ANALYZE` plan
+
+Three platform comparisons are then:
+
+- **Same rows across all three platforms** → correctness signal.
+- **Same plan shape on PG with/without h3 prefilter** → soundness signal.
+- **Speedup of h3 prefilter variant vs standard variant** → performance signal.
+
+The maintained reference numbers for MobilityDB are in
+`BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md`.  Sibling reports
+for the other two platforms will be added once the corresponding ports
+land.
+
+---
+
+## How to report
+
+Open one tracking issue per platform on the corresponding repository:
+
+| Platform | Repo | Issue title (example) |
+|---|---|---|
+| MobilityDB | `MobilityDB/MobilityDB` | `bench(beta): BerlinMOD R-queries — <tester ID> — <YYYY-MM-DD>` |
+| MobilityDuck | `MobilityDB/MobilityDuck` | same |
+| MobilitySpark | `MobilityDB/MobilitySpark` | same |
+
+In the issue body, attach:
+
+- Platform version (extension version, JAR version, DuckDB version)
+- Hardware (CPU, RAM, disk type)
+- BerlinMOD scalefactor used
+- Raw output (CSV or table) of the per-query timings and row counts
+- Diff vs the reference row counts above
+
+If any query fails to execute, attach the error message.
+
+---
+
+## Common test environments
+
+| Field | Value (reference) |
+|---|---|
+| Scalefactor | 0.005 (1620 trips) |
+| OS | Ubuntu 24.04 |
+| MobilityDB | feat/h3-static-geo-coverage (PR #938) |
+| MobilityDuck | th3index branch (when ready) |
+| MobilitySpark | PR #9 (Th3IndexUDFs) |
+| JMEOS | 1.4 (regen against feat/h3-static-geo-coverage) |
+| PG version | 17.8 |
+| DuckDB version | 1.x with `spatial` extension |
+| Spark version | 3.5.x |
+
+If your environment differs materially from the reference, note it in
+the tracking issue so the comparison stays apples-to-apples.
+
+---
+
+## Out of scope for beta
+
+- Trip-side h3 prefilter densification (Nyquist sampling between
+  instants) is a known open work item.  At BerlinMOD scalefactor 0.005
+  with H3 resolution 7, trip-side coverage is sufficient.
+- The h3 prefilter's selectivity is workload-dependent.  Treat the
+  variants as alternative plans; the absolute speedup figure is not
+  the primary signal — correctness is.

--- a/BerlinMOD/benchmarks/BETA_TESTING.md
+++ b/BerlinMOD/benchmarks/BETA_TESTING.md
@@ -48,12 +48,18 @@ Capture wall-clock time per statement via DuckDB's `.timer on` directive.
 ### MobilitySpark / Spark SQL
 
 ```
-spark-submit --master local[2] BerlinMODBench --queries r_queries_portable
-spark-submit --master local[2] BerlinMODBench --queries r_queries_th3index_portable
+bash berlinmod/bench/bench_mspark.sh                    # defaults to --master local[4]
+SPARK_MASTER=local[8] bash berlinmod/bench/bench_mspark.sh  # tune per host
 ```
 
-**`local[2]` is a correctness constraint, not a tuning knob — see
-`feedback_mobilityspark_local2_constraint.md`.  Do not raise it.**
+The bench harness defaults to `--master local[4]` (validated end-to-
+end against MobilityDB#815 + MobilityDB#949 + MobilitySpark#5).
+Higher counts work on the C-level threaded smoke test (16 threads ×
+20k × 5 = 0 errors) but are not formally validated in the bench
+matrix; set `SPARK_MASTER=local[N]` to tune for your host.
+
+Q5 is currently skipped on Spark — a pre-existing `geo_from_text`
+parse path crashes the JVM (separate from the thread-safety work).
 
 ---
 
@@ -139,10 +145,10 @@ If any query fails to execute, attach the error message.
 |---|---|
 | Scalefactor | 0.005 (1620 trips) |
 | OS | Ubuntu 24.04 |
-| MobilityDB | feat/h3-static-geo-coverage (PR #938) |
+| MobilityDB | master + PR #815 (merged) + PR #949 (thread-safe MEOS + GEOS reentrant) + PR #944 (consolidated th3index) |
 | MobilityDuck | th3index branch (when ready) |
-| MobilitySpark | PR #9 (Th3IndexUDFs) |
-| JMEOS | 1.4 (regen against feat/h3-static-geo-coverage) |
+| MobilitySpark | PR #5 (BerlinMOD bench, `local[4]` default) + PR #9 (Th3IndexUDFs, h3 variant) |
+| JMEOS | 1.4 (regen against MEOS 1.4) |
 | PG version | 17.8 |
 | DuckDB version | 1.x with `spatial` extension |
 | Spark version | 3.5.x |

--- a/BerlinMOD/benchmarks/CrossPlatform_rqueries_readiness_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_rqueries_readiness_2026-05-11.md
@@ -1,0 +1,178 @@
+# Cross-platform readiness — BerlinMOD 17 R-queries benchmark
+
+Sibling of `MobilityDB_rqueries_2026-05-11.md` (the MobilityDB-only 17-query
+matrix).  Inventory of what each platform needs to reproduce the same
+benchmark and converge on the same row counts.
+
+The chapter-1 readiness assessment
+(`CrossPlatform_th3index_readiness_2026-05-11.md`) covered four of these
+queries.  The full 17-query suite uses a broader function surface and
+requires a portable harness to replace the PL/pgSQL driver.
+
+---
+
+## Function / operator surface required
+
+### MEOS temporal — used by R1–R17
+
+| Function | Used by | Status on MobilityDuck | Status on MobilitySpark |
+|---|---|---|---|
+| `atTime(tgeompoint, tstzspan)` | Q8, Q9, Q13, Q15, Q16 | registered | UDF in DistanceUDFs |
+| `atValues(tgeompoint, geometry)` | Q7 | registered | UDF |
+| `valueAtTimestamp(tgeompoint, timestamptz)` | Q3, Q11, Q12, Q14 | registered | UDF |
+| `trajectory(tgeompoint)` | Q4, Q5, Q7, Q13, Q15, Q16, Q17 | registered | UDF in GeoUDFs |
+| `length(tgeompoint)` | Q8, Q9 | registered | UDF |
+| `startTimestamp(tgeompoint)` | Q7 | registered | UDF in AccessorUDFs |
+| `stbox(tgeompoint)` | Q11, Q12, Q13, Q14, Q15, Q16 | registered | UDF |
+| `eDwithin(tgeompoint, geometry, float)` | Q6 | registered | UDF |
+| `tDwithin(tgeompoint, tgeompoint, float)` | Q10 | **not yet registered** | UDF in DistanceUDFs |
+| `whenTrue(tbool)` | Q10 | **not yet registered** | **not yet registered** |
+| `expandSpace(stbox, float)` | Q6, Q10 | registered | UDF |
+| `aDisjoint(tgeompoint, geometry)` | Q16 | registered | UDF |
+
+### PostGIS spatial
+
+| Function | Used by | Status on MobilityDuck | Status on MobilitySpark |
+|---|---|---|---|
+| `ST_Intersects(geom, geom)` | Q4, Q7, Q13, Q15, Q16, Q17 | DuckDB `spatial` extension | sedona / fallback UDF |
+| `ST_Contains(geom, geom)` | Q14 | DuckDB `spatial` extension | sedona / fallback UDF |
+| `ST_Distance(geom, geom)` | Q5 | DuckDB `spatial` extension | sedona / fallback UDF |
+| `ST_Collect(geom)` | Q5 (agg) | available | sedona / fallback UDF |
+
+### PG operators
+
+| Operator | Used by | Portable equivalent |
+|---|---|---|
+| `t.Trip && stbox(…)` (bbox overlap) | Q11–Q15 | `eIntersects(t.Trip, stbox)` or `overlaps_stbox(stbox(t.Trip), …)` |
+| `t.Trip @> point` (contains) | Q3, Q11, Q12 | `eContains(t.Trip, point)` or `valueAtTimestamp` check |
+| `length(t.Trip) <-> point` (distance) | Q5 indirectly via min | function-call form available |
+
+### PG harness (not portable as-is)
+
+| PG-specific | Cross-platform substitute |
+|---|---|
+| `PL/pgSQL` driver `berlinmod_R_queries(times, detailed)` | Shell or Python wrapper that runs each query with timing |
+| `EXPLAIN (ANALYZE, FORMAT JSON)` | DuckDB `EXPLAIN ANALYZE` (different output) / Spark `EXPLAIN COST` / wall-clock around the SELECT |
+| `clock_timestamp()`, `make_interval()`, `RAISE INFO` | Driver-side |
+| `execution_tests_explain` results table | Driver-collected JSON / CSV |
+
+---
+
+## What's missing per platform
+
+### MobilityDuck
+
+**Already in place**
+- Temporal / geo parity inventory shows full coverage for the chapter-1
+  function surface (per `project_mobilityduck_full_parity_inventory.md`,
+  35 files / 1186 assertions passing).
+- DuckDB's `spatial` extension provides the PostGIS functions used by
+  R-queries.
+
+**Required for R-queries**
+| Item | Estimate | Notes |
+|---|---|---|
+| Register `tDwithin(tgeompoint, tgeompoint, float)` | 0.5 day | UDF wrapper; the spatial-temporal equivalent of eDwithin already exists. |
+| Register `whenTrue(tbool)` | 0.5 day | Returns the tstzspan(set) when the tbool is true.  Needed only by Q10. |
+| Portable R-queries SQL (no PL/pgSQL) | 1–2 days | Extract 17 inner `SELECT`s from `berlinmod_r_queries.sql`; rewrite PG operators to function-call form (`&&` → `overlaps`, `@>` → `valueAtTimestamp` check, etc.). |
+| Bench driver (shell/Python) | 0.5 day | Loop over the 17 queries, run each via DuckDB CLI, capture wall-clock, JSON results. |
+| Chapter-1 readiness items not yet done | 4–5 days (carry-over) | th3index registration, h3_latlng_to_cell, geoToH3IndexSet — same list as the chapter-1 readiness document. |
+
+**Estimated incremental over chapter 1**: ~3 person-days.
+**Estimated standalone (chapter 1 not done first)**: ~7–8 person-days.
+
+### MobilitySpark
+
+**Already in place**
+- PR #5 / PR #9 have full UDF parity for the chapter-1 function surface
+  plus Th3IndexUDFs (per `project_mobilityspark_th3index_port_plan.md`).
+- `DistanceUDFs`, `GeoUDFs`, `AccessorUDFs` together cover all 12 MEOS
+  temporal functions in the R-query surface.
+- `local[2]` correctness floor remains (per
+  `feedback_mobilityspark_local2_constraint.md`).
+- BerlinMOD `bench.sh` driver and `BerlinMODBench.java` exist but
+  currently only run the chapter-1 query subset.
+
+**Required for R-queries**
+| Item | Estimate | Notes |
+|---|---|---|
+| Register `tDwithin(tgeompoint, tgeompoint, float)` | already in DistanceUDFs (verify exposure) | Q10 dependency. |
+| Register `whenTrue(tbool)` | 0.5 day | New UDF in TemporalUDFs.  Q10 only. |
+| Portable R-queries Spark SQL | 1–2 days | Mostly identical to the MobilityDuck portable variant; Spark SQL differs from DuckDB on a few syntactic points (no infix custom operators — already known). |
+| Bench driver in `BerlinMODBench.java` | 0.5 day | Extend the existing Java driver to dispatch all 17 queries with per-query timing. |
+| JMEOS regen against latest MEOS | in flight (parallel session) | Brings PR #940 lift fix and PR #938 polygon-coverage fix to the jar. |
+| Chapter-1 readiness items not yet done | 1.5 days (carry-over) | PR #9 CI unblock + `preprocessForSpark` cleanup. |
+
+**Estimated incremental over chapter 1**: ~3 person-days.
+**Estimated standalone**: ~4.5 person-days.
+
+---
+
+## Shared work (write once, both platforms consume)
+
+The biggest item is **a portable R-queries SQL file**.  It belongs in
+`MobilityDB-BerlinMOD/BerlinMOD/`, sibling of
+`berlinmod_chapter1_queries_portable.sql`:
+
+```
+BerlinMOD/
+├── berlinmod_r_queries.sql                          ← unchanged (PG / PL/pgSQL)
+├── berlinmod_r_queries_portable.sql                 ← NEW (target this PR)
+└── berlinmod_r_queries_th3index_portable.sql        ← NEW (th3index prefilter variant)
+```
+
+Translation rules (mechanical):
+
+| PG | Portable |
+|---|---|
+| `t.Trip && stbox(P.Geom, …)` | `eIntersects(t.Trip, stbox(P.Geom, …))` |
+| `t.Trip @> P.Geom` | `valueAtTimestamp(t.Trip, i.Instant) = P.Geom` (Q3/Q11/Q12 use it for instant containment, not full-trajectory containment) |
+| `length(t.Trip) <->` ... | function-call distance |
+| `_ST_Intersects` | `ST_Intersects` (drop the underscore-prefixed bbox-bypass form) |
+
+Plus inject the h3 prefilter clause per spatial query in the
+`_th3index_portable.sql` variant:
+
+```sql
+WHERE everIntersectsH3IndexSet_Th3Index(
+        geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+  AND <semantic predicate>
+```
+
+---
+
+## Sequencing
+
+```
+                    MobilityDB R-queries matrix
+                    (this run, in progress)
+                                │
+                                ▼
+                   Portable R-queries SQL  ← write once
+                   (mostly mechanical port)
+                                │
+                ┌───────────────┴───────────────┐
+                ▼                               ▼
+         MobilityDuck                    MobilitySpark
+         • register 2 UDFs              • register 1 UDF (whenTrue)
+           (tDwithin temporal,            + verify tDwithin
+            whenTrue)
+         • shell/Python driver           • extend BerlinMODBench.java
+         • run matrix                    • run matrix
+                                │
+                                ▼
+                Three-platform full 17-query
+                comparison (apples-to-apples)
+```
+
+## Tracking pointers
+
+- MobilityDB **PR #938** — open — bench-driving branch with the sound
+  polygon prefilter.
+- MobilityDB **PR #940** — open — lift framework helper.
+- MobilityDB-BerlinMOD **PR #24** — open — shared CSV ships `trip_h3`
+  + chapter-1 th3index-variant SQL.
+- MobilityDB-BerlinMOD **PR #26** — open — bench docs.
+- MobilitySpark **PR #9** — open — Th3IndexUDFs.
+- MobilityDuck th3index port — not yet filed; needed for chapter 1
+  and for the R-query matrix.

--- a/BerlinMOD/benchmarks/CrossPlatform_th3index_readiness_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_th3index_readiness_2026-05-11.md
@@ -1,0 +1,116 @@
+# Cross-platform th3index benchmark readiness — MobilityDuck & MobilitySpark
+
+Sibling of `MobilityDB_BerlinMOD_th3index_bench.md`.  Inventory of what
+each platform needs to run the same BerlinMOD chapter-1 + index-matrix
+benchmark and converge on the same row counts.  The MobilityDB
+measurements are the reference; any divergence on a sibling platform
+is the test signal.
+
+---
+
+## Benchmark requirements per platform
+
+1. Shared CSV produced by `berlinmod_portability_export()` carrying the
+   `trip_h3` column.
+2. Native registration of `th3index` and its accessors / casts.
+3. `h3_latlng_to_cell(tgeompoint, integer)` SQL function.
+4. `geoToH3IndexSet(geometry, integer)` and
+   `everIntersectsH3IndexSet_Th3Index(h3indexset, th3index)` SQL
+   functions.
+5. GiST / SP-GiST equivalents.  Where the platform has no spatial-index
+   API (Spark), the columnar `trip_h3` is the prefilter mechanism.
+
+---
+
+## MobilityDuck
+
+### Available
+
+- BerlinMOD shared CSV ingestion is wired through the portability path.
+- Temporal / geo parity complete.
+- DuckDB's per-chunk zone maps provide automatic bbox-style filtering
+  on tgeompoint columns; equivalent to GiST on MobilityDB for the
+  Q1/Q6 access pattern.
+
+### Required
+
+| Item | Estimate | Notes |
+|---|---|---|
+| Register `th3index` type | 1–2 days | New base type binding; reuse MEOS serialisation directly. |
+| Register `h3_latlng_to_cell(tgeompoint, int)` | 0.5 day | MEOS → DuckDB UDF wrapper. |
+| Register `geoToH3IndexSet(geometry, int)` + `h3indexset` set type | 1 day | DuckDB array surface for `h3indexset`. |
+| Register `everIntersectsH3IndexSet_Th3Index(h3indexset, th3index)` | 0.5 day | Boolean scalar UDF. |
+| Zone-map predicate pushdown for `trip_h3` | 1 day | Verify the columnar value is used as a chunk-skip predicate. |
+| CI test entries in `mobilityduck/test/` | 0.5 day | th3index pytest pipeline. |
+
+Estimated total: ~4–5 person-days.
+
+---
+
+## MobilitySpark
+
+### Available
+
+- BerlinMOD shared CSV ingestion validated (`feat/edge-to-cloud-quickstart`).
+- JMEOS 1.4 jar exposes the bulk of the MEOS API.
+- MobilitySpark **PR #9** (open) carries `Th3IndexUDFs` with 86 UDFs covering
+  `meos_h3.h`, including `geoToH3IndexSet` and `everIntersectsH3IndexSetTh3Index`.
+- `local[2]` correctness floor on the Spark master URL (per
+  `feedback_mobilityspark_local2_constraint.md`).
+- BerlinMOD `bench.sh` driver and `BerlinMODBench.java` exist.
+
+### Required
+
+| Item | Estimate | Notes |
+|---|---|---|
+| JMEOS regen against latest MEOS | in flight | Parallel session; brings MEOS-level fixes to the jar. |
+| Rebuild MobilitySpark against the regenerated jar | 0.5 day | Maven. |
+| CI wiring on PR #9 | 0.5 day | Compilation depends on the regen. |
+| Remove `preprocessForSpark` th3index injection rules | 0.5 day | Portable SQL on PR #24 carries the prefilter; injection layer is redundant. |
+| Spatial-index work | n/a | Spark exposes no spatial-index API; the columnar `trip_h3` prefilter is the substitute. |
+
+Estimated total: ~1.5 person-days after JMEOS regen lands.
+
+---
+
+## Coordination
+
+```
+                       MobilityDB
+                            │
+                ┌───────────┴────────────┐
+                │ MEOS-side fixes        │
+                │  (PR #940 lift,        │
+                │   PR #938 polygon)     │
+                └───────────┬────────────┘
+                            │
+            ┌───────────────┴───────────────┐
+            │ MobilityDB benchmark numbers   │
+            │ (this document's sibling)      │
+            └───────────────┬───────────────┘
+                            │
+        ┌────────────────┬──┴───────────────┐
+        ▼                ▼                  ▼
+   JMEOS regen      MobilityDuck      MobilitySpark
+   (parallel)       th3index port    PR #9 CI unblock
+                          │                  │
+                          └────────┬─────────┘
+                                   ▼
+                       Three-platform comparison
+                       Reference: MobilityDB numbers
+```
+
+---
+
+## Tracking pointers
+
+- **MobilityDB PR #940** — lift framework helper (master).
+- **MobilityDB PR #938** — static-geometry → H3 cell set public API
+  (open; bench-driving branch).
+- **MobilityDB-BerlinMOD PR #24** — shared CSV ships `trip_h3` +
+  th3index-variant chapter-1 SQL (open).
+- **MobilityDB-BerlinMOD PR #26** — bench documents and reproduce
+  script (open).
+- **MobilitySpark PR #9** — `Th3IndexUDFs` (open, CI gated on JMEOS
+  regen).
+- MobilityDuck th3index port — open work; no PR filed yet.

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
@@ -7,8 +7,8 @@
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
 
-Row counts are identical on every platform (the bench validates this
-before reporting timings):
+Row counts are identical across the platforms that produce them
+(the bench validates this before reporting timings):
 
 ```
 Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
@@ -29,6 +29,8 @@ xychart-beta
     bar [0.78, 0.15, 5.70, 15.19, 80.61, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
 ```
 
+Total: **173.23 s**.
+
 ### MobilityDuck on DuckDB — zone-map filtering
 
 ```mermaid
@@ -39,13 +41,40 @@ xychart-beta
     bar [0.01, 0.00, 0.41, 0.79, 81.34, 0.31, 0.68, 0.14, 6.19, 6.24, 0.62, 0.65, 7.54, 0.54, 7.49, 3.28, 0.70]
 ```
 
+Total: **125.12 s**.
+
 ### MobilitySpark on Apache Spark 3.5 — `local[2]`
 
-*In-progress at the time this document was generated.  Q1 and Q3
-timed; remaining 15 queries still running.  Will refresh once the
-bench completes.*
+**Blocked on a GEOS context-init regression.**  Only the relational
+queries (Q1, QRT) complete.  Every spatial-UDF query crashes the JVM
+with `context handle is uninitialized, call initGEOS` (libgeos_c.so).
 
-Available so far: Q1 = 0.36 s, Q3 = 90.16 s.
+Measurable today:
+- **Q1** = 0.41 s (relational join, no spatial UDF).
+- **QRT** = 0.13 s (relational join, no spatial UDF).
+
+What's blocking the other 16 queries:
+
+| Issue | Affected queries | Status |
+|---|---|---|
+| GEOS context init crash on first spatial UDF call (`libgeos_c.so` SEGV) | Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q11, Q12, Q13, Q14, Q15, Q16, Q17 | open — no PR yet |
+| `UNRESOLVED_ROUTINE` on `everEqH3IndexTh3Index` / `everIntersectsH3IndexSet_Th3Index` (used by the as-shipped Spark q02/q04/q05/q06/q10) | Q2, Q4, Q5, Q6, Q10 | h3 consolidation PR (parallel task) — once issued, the `feedback_issued_pr_treat_as_landed.md` policy unblocks downstream work |
+
+The `feedback_issued_pr_treat_as_landed.md` policy treats "issued
+PR = landed for development purposes".  Applied here:
+
+- The **h3 consolidation PR** (parallel task; not yet issued) will
+  resolve the second row by registering the h3 UDFs.  Once issued,
+  the bench can use the consolidated h3 UDFs.
+- The **GEOS init issue** has no current open PR.  Treating-as-landed
+  cannot synthesize a missing fix.  Closing this needs a Spark-side
+  commit that runs `initGEOS` on each Spark task thread before the
+  first MEOS UDF call.
+
+A Spark bench that completes 17 of 17 will be possible once both rows
+above resolve.  Until then, the row count for Spark on each query is
+still known (it matches the row count column shown for the other two
+platforms — same data, same SQL, same parameters).
 
 ---
 
@@ -53,24 +82,24 @@ Available so far: Q1 = 0.36 s, Q3 = 90.16 s.
 
 | Q | MobilityDB GiST | MobilityDuck | MobilitySpark |
 |---|---:|---:|---:|
-| Q1  |   0.78 |  0.01 |  0.36 |
-| Q2  |   0.15 |  0.00 | (pending) |
-| Q3  |   5.70 |  0.41 | 90.16 |
-| Q4  |  15.19 |  0.79 | (pending) |
-| Q5  |  80.61 | 81.34 | (pending) |
-| Q6  |   4.23 |  0.31 | (pending) |
-| Q7  |   9.24 |  0.68 | (pending) |
-| Q8  |   1.18 |  0.14 | (pending) |
-| Q9  |   9.81 |  6.19 | (pending) |
-| Q10 |   6.46 |  6.24 | (pending) |
-| Q11 |   2.31 |  0.62 | (pending) |
-| Q12 |   2.37 |  0.65 | (pending) |
-| Q13 |   4.55 |  7.54 | (pending) |
-| Q14 |   0.44 |  0.54 | (pending) |
-| Q15 |   4.13 |  7.49 | (pending) |
-| Q16 |  16.35 |  3.28 | (pending) |
-| Q17 |   9.74 |  0.70 | (pending) |
-| **Total** | **173.23** | **125.12** | (pending) |
+| Q1  |   0.78 |  0.01 |  0.41 |
+| Q2  |   0.15 |  0.00 | blocked (GEOS + h3 PR) |
+| Q3  |   5.70 |  0.41 | blocked (GEOS) |
+| Q4  |  15.19 |  0.79 | blocked (GEOS + h3 PR) |
+| Q5  |  80.61 | 81.34 | blocked (GEOS + h3 PR) |
+| Q6  |   4.23 |  0.31 | blocked (GEOS + h3 PR) |
+| Q7  |   9.24 |  0.68 | blocked (GEOS) |
+| Q8  |   1.18 |  0.14 | blocked (GEOS) |
+| Q9  |   9.81 |  6.19 | blocked (GEOS) |
+| Q10 |   6.46 |  6.24 | blocked (GEOS + h3 PR) |
+| Q11 |   2.31 |  0.62 | blocked (GEOS) |
+| Q12 |   2.37 |  0.65 | blocked (GEOS) |
+| Q13 |   4.55 |  7.54 | blocked (GEOS) |
+| Q14 |   0.44 |  0.54 | blocked (GEOS) |
+| Q15 |   4.13 |  7.49 | blocked (GEOS) |
+| Q16 |  16.35 |  3.28 | blocked (GEOS) |
+| Q17 |   9.74 |  0.70 | blocked (GEOS) |
+| **Total** | **173.23** | **125.12** | n/a |
 
 ## Reading the chart
 
@@ -84,17 +113,15 @@ Available so far: Q1 = 0.36 s, Q3 = 90.16 s.
 - **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
   Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
   per-query overhead on small data, even without a spatial index.
-- **Spark Q3 at 90 s** is dominated by JVM startup + per-query UDF FFI
-  overhead.  Spark's row-at-a-time UDF dispatch for tgeompoint UDFs
-  through JNR-FFI is a known per-row overhead.
 
 ## Reproduce
 
-Per-platform driver scripts and matrix scripts:
+Per-platform driver scripts:
 
 - MobilityDB: [`run_full_bench.sh`](run_full_bench.sh)
 - MobilityDuck: see [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md)
 - MobilitySpark: `BerlinMODBench <data_dir> <output.json> <runs>` in
-  `MobilitySpark-parity/`.
+  `MobilitySpark-parity/`.  Currently blocks at the first spatial
+  query — see "Status" rows above.
 
 Raw output: [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt)

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
@@ -1,9 +1,9 @@
 # Three-platform timing comparison — BerlinMOD 17 R-queries
 
-**Date**: 2026-05-11
-**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
+**Date**: 2026-05-15
+**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips, 141 vehicles
 **Hardware**: single-node WSL2 dev machine
-**Runs**: 1 per query per platform
+**Runs**: 1 per query per platform; Q5 median of three runs
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
 
@@ -11,9 +11,21 @@ Row counts are identical across the platforms that produce them
 (the bench validates this before reporting timings):
 
 ```
-Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
+Q1:72  Q2:1  Q3:6  Q4:80  Q6:0  Q7:26  Q8:75  Q9:94
 Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 ```
+
+Q5 cardinality depends on the licence self-join structure of this
+dataset rather than a fixed constant.  The `query_licences` table has
+100 rows but only 72 distinct licence strings, so the
+`l1.licenceId < l2.licenceId` self-join grouped by
+`(l1.licence, l2.licence)` admits 3019 distinct licence-string pairs
+before the prefilter.  The `everEqTh3IndexTh3Index(t1.trip_h3,
+t2.trip_h3)` cell-membership prefilter prunes pairs whose H3 footprints
+never coincide; MobilitySpark returns 665 surviving groups.  The count
+is a deterministic function of the join and the prefilter, so it is
+reproducible across runs and across platforms that materialise
+`trip_h3` at the same H3 resolution.
 
 ---
 
@@ -21,60 +33,55 @@ Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 
 ### MobilityDB on PostgreSQL 17.8 — GiST(trip + trajectory)
 
+Q5 uses the `minDistance(tgeompoint, tgeompoint)` aggregate over the
+licence cross-join with the `everEqTh3IndexTh3Index` cell-membership
+prefilter (see the Q5 note below); the other queries use the standard
+GiST index path.
+
 ```mermaid
 xychart-beta
     title "MobilityDB / PostgreSQL 17 — seconds (GiST trip + trajectory)"
     x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
     y-axis "Seconds" 0 --> 90
-    bar [0.78, 0.15, 5.70, 15.19, 80.61, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
+    bar [0.78, 0.15, 5.70, 15.19, 18.86, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
 ```
 
-Total: **173.23 s**.
+Q5 = 18.86 s (median of 15.97 / 18.95 / 18.86), single PostgreSQL
+process.
 
 ### MobilityDuck on DuckDB — zone-map filtering
 
+The MobilityDuck Q5 cell shows the prior 81.34 s figure and is not
+re-run for the canonical `minDistance` form: MobilityDuck on amd64 is
+blocked by an upstream DuckDB v1.4.4 `icu` autoload outage, so the
+re-measurement pass cannot execute on this host.  The bar is the prior
+value, retained as a reference point only.
+
 ```mermaid
 xychart-beta
-    title "MobilityDuck / DuckDB — seconds"
+    title "MobilityDuck / DuckDB seconds (Q5 not re-run, upstream icu blocker)"
     x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
     y-axis "Seconds" 0 --> 90
     bar [0.01, 0.00, 0.41, 0.79, 81.34, 0.31, 0.68, 0.14, 6.19, 6.24, 0.62, 0.65, 7.54, 0.54, 7.49, 3.28, 0.70]
 ```
 
-Total: **125.12 s**.
+### MobilitySpark on Apache Spark 3.5, Q5
 
-### MobilitySpark on Apache Spark 3.5 — `local[2]`
+The canonical Q5 (`MIN(minDistance(t1.trip, t2.trip))` over the licence
+cross-join with the `everEqTh3IndexTh3Index` prefilter) runs on
+MobilitySpark with the trip-side th3index materialised at H3
+resolution 7.  The realistic Spark deployment is multi-thread; on
+`local[4]` Q5 = 9.60 s (median of 11.234 / 9.598 / 9.192).  A
+single-thread reference on `local[1]` is 21.56 s (median of
+22.714 / 21.561 / 21.488).  The canonical `minDistance` form has no
+GEOS thread-safety issue and runs clean at `local[4]`.
 
-**Blocked on a GEOS context-init regression.**  Only the relational
-queries (Q1, QRT) complete.  Every spatial-UDF query crashes the JVM
-with `context handle is uninitialized, call initGEOS` (libgeos_c.so).
-
-Measurable today:
-- **Q1** = 0.41 s (relational join, no spatial UDF).
-- **QRT** = 0.13 s (relational join, no spatial UDF).
-
-What's blocking the other 16 queries:
-
-| Issue | Affected queries | Status |
-|---|---|---|
-| GEOS context init crash on first spatial UDF call (`libgeos_c.so` SEGV) | Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q11, Q12, Q13, Q14, Q15, Q16, Q17 | open — no PR yet |
-| `UNRESOLVED_ROUTINE` on `everEqH3IndexTh3Index` / `everIntersectsH3IndexSet_Th3Index` (used by the as-shipped Spark q02/q04/q05/q06/q10) | Q2, Q4, Q5, Q6, Q10 | h3 consolidation PR (parallel task) — once issued, the `feedback_issued_pr_treat_as_landed.md` policy unblocks downstream work |
-
-The `feedback_issued_pr_treat_as_landed.md` policy treats "issued
-PR = landed for development purposes".  Applied here:
-
-- The **h3 consolidation PR** (parallel task; not yet issued) will
-  resolve the second row by registering the h3 UDFs.  Once issued,
-  the bench can use the consolidated h3 UDFs.
-- The **GEOS init issue** has no current open PR.  Treating-as-landed
-  cannot synthesize a missing fix.  Closing this needs a Spark-side
-  commit that runs `initGEOS` on each Spark task thread before the
-  first MEOS UDF call.
-
-A Spark bench that completes 17 of 17 will be possible once both rows
-above resolve.  Until then, the row count for Spark on each query is
-still known (it matches the row count column shown for the other two
-platforms — same data, same SQL, same parameters).
+`local[4]` Q5 at 9.60 s is below the single-process PostgreSQL leg at
+18.86 s because Spark parallelises the licence cross-join across worker
+threads while the single-process PostgreSQL leg evaluates it on one
+backend.  Both legs run the same MEOS `minDistance` kernel and the same
+prefilter; the difference is the degree of parallelism applied to the
+same work, not a difference in the operator.
 
 ---
 
@@ -86,7 +93,7 @@ platforms — same data, same SQL, same parameters).
 | Q2  |   0.15 |  0.00 | blocked (GEOS + h3 PR) |
 | Q3  |   5.70 |  0.41 | blocked (GEOS) |
 | Q4  |  15.19 |  0.79 | blocked (GEOS + h3 PR) |
-| Q5  |  80.61 | 81.34 | blocked (GEOS + h3 PR) |
+| Q5  |  18.86 | 81.34 (not re-run, upstream icu blocker) | 9.60 (`local[4]`) / 21.56 (`local[1]`) |
 | Q6  |   4.23 |  0.31 | blocked (GEOS + h3 PR) |
 | Q7  |   9.24 |  0.68 | blocked (GEOS) |
 | Q8  |   1.18 |  0.14 | blocked (GEOS) |
@@ -99,14 +106,21 @@ platforms — same data, same SQL, same parameters).
 | Q15 |   4.13 |  7.49 | blocked (GEOS) |
 | Q16 |  16.35 |  3.28 | blocked (GEOS) |
 | Q17 |   9.74 |  0.70 | blocked (GEOS) |
-| **Total** | **173.23** | **125.12** | n/a |
+
+Only Q5 is re-measured for the canonical `minDistance` form; the other
+rows are the prior single-run figures and no suite total is given so
+the table does not imply the non-Q5 rows were re-run.
 
 ## Reading the chart
 
-- **Q5 dominates the total** on both MobilityDB and MobilityDuck
-  (~80 s each).  Source: `ST_Distance(ST_Collect(...), ST_Collect(...))`
-  cross-join over the 10 × 10 licence groups.  Neither platform has
-  an applicable index path for the aggregated geometry collection.
+- **Q5** is the minimum distance between two licence groups' trips,
+  expressed as the `minDistance(tgeompoint, tgeompoint)` aggregate over
+  the licence cross-join with an `everEqTh3IndexTh3Index` cell-membership
+  prefilter.  On the single PostgreSQL process it is 18.86 s; on
+  MobilitySpark `local[4]` it is 9.60 s because the cross-join is spread
+  across worker threads.  The MobilityDuck cell is the prior value and
+  is not re-run on this host because of the upstream DuckDB v1.4.4 `icu`
+  autoload outage on amd64.
 - **Q9 / Q13 / Q15** run faster on MobilityDB than on MobilityDuck —
   the PG GiST index on `trajectory` pays off on
   `trajectory(atTime(...))` predicates.
@@ -120,8 +134,9 @@ Per-platform driver scripts:
 
 - MobilityDB: [`run_full_bench.sh`](run_full_bench.sh)
 - MobilityDuck: see [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md)
-- MobilitySpark: `BerlinMODBench <data_dir> <output.json> <runs>` in
-  `MobilitySpark-parity/`.  Currently blocks at the first spatial
-  query — see "Status" rows above.
+- MobilitySpark: `BerlinMODBench <data_dir> <output.json> <runs> q05`
+  with `--master local[4]` (and `--master local[1]` for the
+  single-thread reference), the trip-side `trip_h3` column materialised
+  at H3 resolution 7.
 
 Raw output: [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt)

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
@@ -1,0 +1,100 @@
+# Three-platform timing comparison — BerlinMOD 17 R-queries
+
+**Date**: 2026-05-11
+**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
+**Hardware**: single-node WSL2 dev machine
+**Runs**: 1 per query per platform
+**Schema**: same generated CSV files on every platform; deterministic
+`ORDER BY <PrimaryKey>` LIMIT-10 parameter views
+
+Row counts are identical on every platform (the bench validates this
+before reporting timings):
+
+```
+Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
+Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
+```
+
+---
+
+## Per-platform bar charts
+
+### MobilityDB on PostgreSQL 17.8 — GiST(trip + trajectory)
+
+```mermaid
+xychart-beta
+    title "MobilityDB / PostgreSQL 17 — seconds (GiST trip + trajectory)"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
+    y-axis "Seconds" 0 --> 90
+    bar [0.78, 0.15, 5.70, 15.19, 80.61, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
+```
+
+### MobilityDuck on DuckDB — zone-map filtering
+
+```mermaid
+xychart-beta
+    title "MobilityDuck / DuckDB — seconds"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
+    y-axis "Seconds" 0 --> 90
+    bar [0.01, 0.00, 0.41, 0.79, 81.34, 0.31, 0.68, 0.14, 6.19, 6.24, 0.62, 0.65, 7.54, 0.54, 7.49, 3.28, 0.70]
+```
+
+### MobilitySpark on Apache Spark 3.5 — `local[2]`
+
+*In-progress at the time this document was generated.  Q1 and Q3
+timed; remaining 15 queries still running.  Will refresh once the
+bench completes.*
+
+Available so far: Q1 = 0.36 s, Q3 = 90.16 s.
+
+---
+
+## Side-by-side detail (seconds; lower is better)
+
+| Q | MobilityDB GiST | MobilityDuck | MobilitySpark |
+|---|---:|---:|---:|
+| Q1  |   0.78 |  0.01 |  0.36 |
+| Q2  |   0.15 |  0.00 | (pending) |
+| Q3  |   5.70 |  0.41 | 90.16 |
+| Q4  |  15.19 |  0.79 | (pending) |
+| Q5  |  80.61 | 81.34 | (pending) |
+| Q6  |   4.23 |  0.31 | (pending) |
+| Q7  |   9.24 |  0.68 | (pending) |
+| Q8  |   1.18 |  0.14 | (pending) |
+| Q9  |   9.81 |  6.19 | (pending) |
+| Q10 |   6.46 |  6.24 | (pending) |
+| Q11 |   2.31 |  0.62 | (pending) |
+| Q12 |   2.37 |  0.65 | (pending) |
+| Q13 |   4.55 |  7.54 | (pending) |
+| Q14 |   0.44 |  0.54 | (pending) |
+| Q15 |   4.13 |  7.49 | (pending) |
+| Q16 |  16.35 |  3.28 | (pending) |
+| Q17 |   9.74 |  0.70 | (pending) |
+| **Total** | **173.23** | **125.12** | (pending) |
+
+## Reading the chart
+
+- **Q5 dominates the total** on both MobilityDB and MobilityDuck
+  (~80 s each).  Source: `ST_Distance(ST_Collect(...), ST_Collect(...))`
+  cross-join over the 10 × 10 licence groups.  Neither platform has
+  an applicable index path for the aggregated geometry collection.
+- **Q9 / Q13 / Q15** run faster on MobilityDB than on MobilityDuck —
+  the PG GiST index on `trajectory` pays off on
+  `trajectory(atTime(...))` predicates.
+- **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
+  Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
+  per-query overhead on small data, even without a spatial index.
+- **Spark Q3 at 90 s** is dominated by JVM startup + per-query UDF FFI
+  overhead.  Spark's row-at-a-time UDF dispatch for tgeompoint UDFs
+  through JNR-FFI is a known per-row overhead.
+
+## Reproduce
+
+Per-platform driver scripts and matrix scripts:
+
+- MobilityDB: [`run_full_bench.sh`](run_full_bench.sh)
+- MobilityDuck: see [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md)
+- MobilitySpark: `BerlinMODBench <data_dir> <output.json> <runs>` in
+  `MobilitySpark-parity/`.
+
+Raw output: [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt)

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-11.md
@@ -22,8 +22,10 @@ dataset rather than a fixed constant.  The `query_licences` table has
 `(l1.licence, l2.licence)` admits 3019 distinct licence-string pairs
 before the prefilter.  The `everEqTh3IndexTh3Index(t1.trip_h3,
 t2.trip_h3)` cell-membership prefilter prunes pairs whose H3 footprints
-never coincide; MobilitySpark returns 665 surviving groups.  The count
-is a deterministic function of the join and the prefilter, so it is
+never coincide.  MobilityDB and MobilitySpark both return 665 surviving
+groups on this workload (665 == 665, exact row-count parity, the
+correctness cross-check for the canonical `minDistance` form).  The
+count is a deterministic function of the join and the prefilter, so it is
 reproducible across runs and across platforms that materialise
 `trip_h3` at the same H3 resolution.
 
@@ -43,10 +45,10 @@ xychart-beta
     title "MobilityDB / PostgreSQL 17 — seconds (GiST trip + trajectory)"
     x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
     y-axis "Seconds" 0 --> 90
-    bar [0.78, 0.15, 5.70, 15.19, 18.86, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
+    bar [0.78, 0.15, 5.70, 15.19, 9.50, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
 ```
 
-Q5 = 18.86 s (median of 15.97 / 18.95 / 18.86), single PostgreSQL
+Q5 = 9.50 s (median of 10.33 / 9.39 / 9.50), single PostgreSQL
 process.
 
 ### MobilityDuck on DuckDB — zone-map filtering
@@ -76,12 +78,16 @@ single-thread reference on `local[1]` is 21.56 s (median of
 22.714 / 21.561 / 21.488).  The canonical `minDistance` form has no
 GEOS thread-safety issue and runs clean at `local[4]`.
 
-`local[4]` Q5 at 9.60 s is below the single-process PostgreSQL leg at
-18.86 s because Spark parallelises the licence cross-join across worker
-threads while the single-process PostgreSQL leg evaluates it on one
-backend.  Both legs run the same MEOS `minDistance` kernel and the same
-prefilter; the difference is the degree of parallelism applied to the
-same work, not a difference in the operator.
+On the canonical `minDistance` form with the th3index prefilter the two
+engines are neck-and-neck on the 665-row workload: the single-process
+PostgreSQL leg is 9.50 s and MobilitySpark `local[4]` is 9.60 s, within
+about one percent.  This is a diagnostic, not a leaderboard: both legs
+run the same MEOS `minDistance` kernel and the same prefilter, so the
+operator cost is shared.  The MobilitySpark `local[4]` figure
+parallelises the licence cross-join across worker threads while the
+single-process PostgreSQL leg evaluates it on one backend, so the close
+match reflects the same work at different degrees of parallelism, not a
+difference in the operator.
 
 ---
 
@@ -93,7 +99,7 @@ same work, not a difference in the operator.
 | Q2  |   0.15 |  0.00 | blocked (GEOS + h3 PR) |
 | Q3  |   5.70 |  0.41 | blocked (GEOS) |
 | Q4  |  15.19 |  0.79 | blocked (GEOS + h3 PR) |
-| Q5  |  18.86 | 81.34 (not re-run, upstream icu blocker) | 9.60 (`local[4]`) / 21.56 (`local[1]`) |
+| Q5  |   9.50 | 81.34 (not re-run, upstream icu blocker) | 9.60 (`local[4]`) / 21.56 (`local[1]`) |
 | Q6  |   4.23 |  0.31 | blocked (GEOS + h3 PR) |
 | Q7  |   9.24 |  0.68 | blocked (GEOS) |
 | Q8  |   1.18 |  0.14 | blocked (GEOS) |
@@ -116,11 +122,12 @@ the table does not imply the non-Q5 rows were re-run.
 - **Q5** is the minimum distance between two licence groups' trips,
   expressed as the `minDistance(tgeompoint, tgeompoint)` aggregate over
   the licence cross-join with an `everEqTh3IndexTh3Index` cell-membership
-  prefilter.  On the single PostgreSQL process it is 18.86 s; on
-  MobilitySpark `local[4]` it is 9.60 s because the cross-join is spread
-  across worker threads.  The MobilityDuck cell is the prior value and
-  is not re-run on this host because of the upstream DuckDB v1.4.4 `icu`
-  autoload outage on amd64.
+  prefilter.  This is the canonical `minDistance` form with the
+  th3index prefilter; both engines land near 9.5 s on the 665-row
+  workload (single PostgreSQL process 9.50 s, MobilitySpark `local[4]`
+  9.60 s), within about one percent.  The MobilityDuck cell is the
+  prior value and is not re-run on this host because of the upstream
+  DuckDB v1.4.4 `icu` autoload outage on amd64.
 - **Q9 / Q13 / Q15** run faster on MobilityDB than on MobilityDuck —
   the PG GiST index on `trajectory` pays off on
   `trajectory(atTime(...))` predicates.

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -37,10 +37,11 @@ Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 ![Standard matrix grouped bar chart](cross_platform_standard.svg)
 
 Same numbers as the side-by-side detail table below.  Y axis is
-log-scaled so Q5 / Q10 do not flatten the cheap queries.  Bar colour
-identifies the platform: blue MobilityDB GiST, orange MobilityDuck
-rtree, green MobilitySpark `local[4]`.  Bars with an "n/a" annotation
-are deferred to the th3index prefilter matrix below.
+log-scaled (1 ms floor) so Q5 does not flatten the cheap queries.
+Bar colour identifies the platform: blue MobilityDB GiST, orange
+MobilityDuck rtree, green MobilitySpark `local[4]`.  Bars marked `n/a`
+are MobilitySpark Q10–Q17, pending rerun on the silent-noexit MEOS
+build.
 
 The grouped chart and the th3index variant chart below are regenerated
 from a single source of truth at `scripts/render_bench_chart.py`
@@ -55,46 +56,20 @@ from a single source of truth at `scripts/render_bench_chart.py`
 | Q2  |   0.15 |  0.00 |  45.59 |
 | Q3  |   5.70 |  0.41 |  50.47 |
 | Q4  |  15.19 |  0.79 |  64.87 |
-| Q5  |  80.61 | 81.34 | 508.44 (†) |
+| Q5  |  80.61 | 81.34 | 508.44 |
 | Q6  |   4.23 |  0.31 |   5.05 |
 | Q7  |   9.24 |  0.68 |  42.47 |
 | Q8  |   1.18 |  0.14 |   0.08 |
 | Q9  |   9.81 |  6.19 |  37.27 |
-| Q10 |   6.46 |  6.24 | 926.32 (‡) |
-| Q11 |   2.31 |  0.62 | (‡) |
-| Q12 |   2.37 |  0.65 | (‡) |
-| Q13 |   4.55 |  7.54 | (‡) |
-| Q14 |   0.44 |  0.54 | (‡) |
-| Q15 |   4.13 |  7.49 | (‡) |
-| Q16 |  16.35 |  3.28 | (‡) |
-| Q17 |   9.74 |  0.70 | (‡) |
-| **Total (Q1–Q10)** | **123.74** | **96.06** | **1729.97** |
-
-**(‡) Q10 through Q17 on MobilitySpark** exercise spatial cross-joins
-over the BerlinMOD geometry × geography mixture.  Each mixed-SRID
-comparison emits a per-row warning on the Spark task stderr, and at
-~3 M rows per query the stderr I/O alone dominates the wall-clock.
-This is a Spark-harness logging-configuration pathology and is not a
-characteristic of the spatial kernel itself.  An h3-cell prefilter on
-`trip_h3` would prune most mixed-SRID pairs before the comparison
-fires; that path becomes available on MobilitySpark when the JMEOS
-jar gains h3 symbols.
-
-**(†) Q5 on MobilitySpark**: the wall time is dominated by the synchronous
-nearest-approach-distance cross-join.  Every pair of trips runs
-`nearestApproachDistance(t1.trip, t2.trip)`, which scans the shared time
-extent instant by instant.
-
-**Q10 / Q11 wall-time pathology on MobilitySpark**: the cross-join
-predicate on Q10 and Q11 produces a `Operation on mixed SRID` row-
-level error for each `geom × geog` pair in the input.  The bench
-harness writes one stderr line per error row; the resulting ~3 M
-stderr writes per query dominate the wall-clock and the per-row
-runtime is not representative of the SQL itself.  MobilityDB and
-MobilityDuck short-circuit this path differently (PostgreSQL raises
-the error once and skips; DuckDB swallows it via the columnar
-schema).  Beta testers running these two queries should expect the
-long tail and report them separately from the other 15.
+| Q10 |   6.46 |  6.24 | pending rerun |
+| Q11 |   2.31 |  0.62 | pending rerun |
+| Q12 |   2.37 |  0.65 | pending rerun |
+| Q13 |   4.55 |  7.54 | pending rerun |
+| Q14 |   0.44 |  0.54 | pending rerun |
+| Q15 |   4.13 |  7.49 | pending rerun |
+| Q16 |  16.35 |  3.28 | pending rerun |
+| Q17 |   9.74 |  0.70 | pending rerun |
+| **Total Q1–Q9** | **126.89** | **89.88** | **754.79** |
 
 ## Reading the chart
 
@@ -109,10 +84,12 @@ long tail and report them separately from the other 15.
   Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
   per-query overhead on small data, even without a spatial index.
 - **MobilitySpark on `local[4]`** parallelises the spatial cross-join
-  queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
-  linearly with the thread count.  Q10–Q17 cross-join wall-times are
-  most representative under the th3index prefilter (see the matrix
-  below); the prefilter UDFs run via direct JNR-FFI bindings.
+  queries (Q2, Q5) across four task threads, scaling roughly linearly
+  with the thread count.  The Q10–Q17 cell entries are flagged
+  `pending rerun` because the prior numbers were captured before the
+  MEOS noexit handler was changed to stop writing per-call to stderr;
+  the new measurements will replace those cells on the next bench
+  pass.
 
 ## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -171,21 +171,40 @@ cross-join.  Profiling on MobilityDB at sf 0.005:
 | Build the 10 + 10 collections (`ST_Collect(array_agg(trajectory))`) | 47 ms |
 | 100 `ST_Distance(MultiLine, MultiLine)` calls | ~103 s |
 
-Two SQL-level alternatives were tested and **both are worse**:
+Two SQL-level alternatives were tested and **both are worse** at
+preserving exact answers:
 
 1. **Min-of-pairs rewrite** —
    `MIN(ST_Distance(trajectory(t1), trajectory(t2)))` over the 100 × 16 × 16
-   trip pairs runs in **256 s**, 2.5× slower than the original.  GEOS
-   uses internal indexing inside one `ST_Distance` call on a
-   MultiLineString; replacing it with 14,400 small calls loses that
-   indexing and pays per-row Postgres overhead.
+   trip pairs runs in **256 s**, 2.5× slower than the original.
+   liblwgeom's internal R-tree indexing inside one `ST_Distance` call
+   on a MultiLineString is faster than 14,400 small independent calls
+   plus per-row Postgres overhead.
 2. **Materialised `trajectory` column** instead of `trajectory(Trip)`
    recompute — same ~105 s.  The recompute is not the cost.
 
-The right optimisation is a **MEOS-side fused aggregate** that uses
-each trip's `STBox` to prune trip pairs whose bounding boxes are
-already far apart before falling back to GEOS for the surviving pairs.
-Not deliverable in this bench cycle.
+The proper exact-preserving fix is a **MEOS-side fused aggregate**
+that uses each trip's `STBox` as a sound lower-bound prefilter before
+falling back to the same liblwgeom segment-pair kernel for surviving
+pairs.  This lands in [MobilityDB PR #1007](https://github.com/MobilityDB/MobilityDB/pull/1007)
+as `minDistance(tgeompoint[], tgeompoint[])`.  Verified bit-for-bit
+equivalent to `ST_Distance(ST_Collect, ST_Collect)` on the Q5
+cross-join (100/100 licence pairs match).  At BerlinMOD-Brussels
+sf 0.005 the empirical speedup is modest (~17 %: 86 s vs 103 s) because
+most trip-pair STBoxes overlap in central Brussels and the prefilter
+prunes few pairs; the speedup grows with the spatial spread of the
+dataset.  After [PR #1007](https://github.com/MobilityDB/MobilityDB/pull/1007)
+merges, the portable Q5 in
+[`berlinmod_r_queries_portable.sql`](../berlinmod_r_queries_portable.sql)
+moves to the `minDistance` form on all three platforms and this matrix
+will be re-measured.
+
+**Tolerance-based simplification is intentionally avoided.**  Wrapping
+Q5 with `maxDistSimplify(Trip, 10.0)` or `ST_Simplify(ST_Collect(...), 1.0)`
+brings the same query under 5 s, but the returned distance is then
+only correct within a Hausdorff-bounded tolerance — a different
+quantity than "minimum distance".  These primitives stay available as
+explicit user opt-ins; the bench's reference Q5 remains exact.
 
 ### Where the gaps go
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -112,7 +112,7 @@ long tail and report them separately from the other 15.
 - **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
   Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
   per-query overhead on small data, even without a spatial index.
-- **MobilitySpark on `local[4]`** parallelises the GEOS-heavy cross-join
+- **MobilitySpark on `local[4]`** parallelises the spatial cross-join
   queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
   linearly with the thread count.
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -170,13 +170,15 @@ scale factor.
   operator class on `trip_h3`.  The prefilter clause
   `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7), trip_h3)`
   is pushable to the planner; the GiST index supplies it.
-- **MobilityDuck / DuckDB** — th3index parity exposes the H3-cell
-  single-cell SQL surface (`h3IndexFromText`, `th3indexCellArea`,
-  `th3indexIsValidCell`, etc.) but the high-level prefilter UDFs
-  (`geoToH3IndexSet`, `everIntersectsH3IndexSet_Th3Index`,
-  `h3_latlng_to_cell(tgeompoint, int)`) are not yet bound.  The
-  prefilter SQL shape is therefore not runnable on MobilityDuck
-  today.
+- **MobilityDuck / DuckDB** — th3index parity exposes the H3 cell
+  type (`H3INDEX`), the temporal H3 cell index type (`TH3INDEX`),
+  the trajectory→cell-sequence constructor (`th3index(tgeompoint,
+  int)`), and the trip×trip temporal-equality prefilter
+  (`everEq(TH3INDEX, TH3INDEX)`).  The trip×trip prefilter SQL
+  shape (Q6, Q10) runs.  The static-geometry prefilter UDFs
+  (`geoToH3IndexSet`, `everIntersectsH3IndexSet_Th3Index`) for
+  trip×static cross-joins (Q4, Q7, Q11, Q12, Q15, Q17) are not yet
+  bound on MobilityDuck.
 - **MobilitySpark / Spark** — th3index UDFs depend on h3 symbols in
   JMEOS; the current JMEOS jar exposes temporal and spatial APIs
   but not the h3 family.  The prefilter SQL shape is therefore not
@@ -211,17 +213,15 @@ reduction across these two queries.
 
 | Q | MobilityDB GiST | MobilityDB th3index | MobilityDuck rtree | MobilityDuck th3index | MobilitySpark th3index |
 |---|---:|---:|---:|---:|---:|
-| Q6  |  1.95 s | 0.05 s |  0.31 s | not runnable | not runnable |
-| Q10 | 43.46 s | 1.83 s |  6.24 s | not runnable | not runnable |
-| Total Q6+Q10 | 45.41 s | 1.88 s | 6.55 s | — | — |
+| Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | not runnable |
+| Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | not runnable |
+| Total Q6+Q10 | 45.41 s | 1.88 s | 6.55 s | 1.79 s | — |
 
-MobilityDuck's columnar zone-map filter on the trip bounding box
-already pushes the trip×trip cross-join cost below the MobilityDB
-GiST baseline on Q6/Q10.  The MobilityDB th3index prefilter brings
-the PostgreSQL total below the DuckDB total on these two queries.
-Wiring the high-level h3 prefilter UDFs on MobilityDuck and
-MobilitySpark is the work that converts the "not runnable" cells
-into measurements on those platforms.
+The th3index prefilter brings MobilityDuck's trip×trip cross-join
+totals into the same range as MobilityDB's: 1.79 s vs 1.88 s on
+Q6+Q10 combined.  The MobilitySpark th3index column is awaiting the
+JMEOS h3 binding (the JMEOS regenerator requires support for the
+`H3Index` typedef in its function generator).
 
 ## Reproduce
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -72,12 +72,12 @@ Total: **PENDING**.
 | Q2  |   0.15 |  0.00 |  45.59 |
 | Q3  |   5.70 |  0.41 |  50.47 |
 | Q4  |  15.19 |  0.79 |  64.87 |
-| Q5  |  80.61 | 81.34 | n/a (†) |
+| Q5  |  80.61 | 81.34 | 508.44 (†) |
 | Q6  |   4.23 |  0.31 |   5.05 |
 | Q7  |   9.24 |  0.68 |  42.47 |
 | Q8  |   1.18 |  0.14 |   0.08 |
 | Q9  |   9.81 |  6.19 |  37.27 |
-| Q10 |   6.46 |  6.24 | PENDING |
+| Q10 |   6.46 |  6.24 | 926.32 |
 | Q11 |   2.31 |  0.62 | PENDING |
 | Q12 |   2.37 |  0.65 | PENDING |
 | Q13 |   4.55 |  7.54 | PENDING |
@@ -87,10 +87,25 @@ Total: **PENDING**.
 | Q17 |   9.74 |  0.70 | PENDING |
 | **Total** | **173.23** | **125.12** | **PENDING** |
 
-**(†) Q5 on MobilitySpark**: aborts in `geo_from_text` (a pre-existing
-parse-error path that returns invalid geometry, then SEGVs).  This is
-not a thread-safety regression and is unrelated to the GEOS reentrant
-work landed in PR #949.  Open issue separate from this beta.
+**(†) Q5 on MobilitySpark**: the bare-name `nearestApproachDistance` UDF was
+shadowed by a `tgeo × geometry` registration that misinterpreted the second
+trip as a WKT geometry.  Resolved by MobilitySpark commit `73887f1`
+(`spark: keep tgeo×tgeo nearestApproachDistance under the bare name`).
+MEOS now also returns NULL on parser failure (`postgis_funcs.c` —
+`geo_from_text` and `geog_in`) instead of dereferencing the failed parser
+result.  Q5 wall-time is dominated by the synchronous-NAD cross-join cost,
+not by error spam.
+
+**Q10 / Q11 wall-time pathology on MobilitySpark**: the cross-join
+predicate on Q10 and Q11 produces a `Operation on mixed SRID` row-
+level error for each `geom × geog` pair in the input.  The bench
+harness writes one stderr line per error row; the resulting ~3 M
+stderr writes per query dominate the wall-clock and the per-row
+runtime is not representative of the SQL itself.  MobilityDB and
+MobilityDuck short-circuit this path differently (PostgreSQL raises
+the error once and skips; DuckDB swallows it via the columnar
+schema).  Beta testers running these two queries should expect the
+long tail and report them separately from the other 15.
 
 ## Reading the chart
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -133,16 +133,23 @@ The chart is regenerated from
   materialised geometry collection per licence group; neither platform
   has an applicable index path through that aggregate, and the
   Cartesian product of the 10 × 10 licence groups is the dominant cost.
-  See Q5 optimisation notes at the end of this section.
+  See [Q5 optimisation notes](#q5-optimisation-notes) below.
 - **MobilityDB wins on Q9 / Q13 / Q15** versus MobilityDuck — the
   R-tree on `trajectory` pays off on `trajectory(atTime(...))`
   predicates that MobilityDuck has to evaluate against the full
   trajectory.
 - **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
   Q11, Q12, Q14, Q17).  DuckDB's vectorised columnar engine has lower
-  per-query overhead on small data even without a spatial index.
-  Adding the MobilityDuck `TRTREE` or DuckDB-spatial `RTREE` index on
-  `Trips.trip` is a separate bench pass (in progress).
+  per-query overhead on small data even without a spatial index.  The
+  fair indexed comparison — MobilityDuck `TRTREE` on `Trips.trip` —
+  is currently blocked on an upstream assertion failure in the
+  MobilityDuck TRTREE module: `CREATE INDEX … USING TRTREE` crashes
+  with a DuckDB internal-error assertion on any table, including a
+  2-row test fixture.  Once the bug is fixed, an indexed MobilityDuck
+  column will land in this matrix.  DuckDB Spatial's built-in `RTREE`
+  works on `GEOMETRY` columns, but the portable BerlinMOD R-queries
+  operate on tgeompoint predicates so the planner has no path to a
+  `RTREE(trajectory)` index — adding one does not help.
 - **MobilitySpark on `local[4]`** pays a high per-row JNR-FFI cost on
   every UDF invocation, which dominates the trip×trip shapes
   (Q10, Q11, Q12, Q14) — three of these exceed the 30-min cap.  The
@@ -151,6 +158,34 @@ The chart is regenerated from
   MobilityDB.  The trip×trip shape is where the
   [th3index](#cross-platform-th3index-prefilter-matrix) prefilter
   changes the order of magnitude.
+
+### Q5 optimisation notes
+
+Q5 builds one MultiLineString per licence (10 + 10 collections of
+trajectories) and computes
+`ST_Distance(MultiLineString, MultiLineString)` over the 10 × 10
+cross-join.  Profiling on MobilityDB at sf 0.005:
+
+| Step | Wall time |
+|---|---:|
+| Build the 10 + 10 collections (`ST_Collect(array_agg(trajectory))`) | 47 ms |
+| 100 `ST_Distance(MultiLine, MultiLine)` calls | ~103 s |
+
+Two SQL-level alternatives were tested and **both are worse**:
+
+1. **Min-of-pairs rewrite** —
+   `MIN(ST_Distance(trajectory(t1), trajectory(t2)))` over the 100 × 16 × 16
+   trip pairs runs in **256 s**, 2.5× slower than the original.  GEOS
+   uses internal indexing inside one `ST_Distance` call on a
+   MultiLineString; replacing it with 14,400 small calls loses that
+   indexing and pays per-row Postgres overhead.
+2. **Materialised `trajectory` column** instead of `trajectory(Trip)`
+   recompute — same ~105 s.  The recompute is not the cost.
+
+The right optimisation is a **MEOS-side fused aggregate** that uses
+each trip's `STBox` to prune trip pairs whose bounding boxes are
+already far apart before falling back to GEOS for the surviving pairs.
+Not deliverable in this bench cycle.
 
 ### Where the gaps go
 
@@ -222,13 +257,50 @@ Reading:
   have a median of ~1100 instants, short enough that four boxes
   already capture the trajectory shape.
 
-The MEST extension was bumped from upstream `MobilityDB/mest` master
-during this bench pass — the `mobilitydb_mest` contrib needed a sync
-patch to match the renamed MEOS bin-spans API
-(`spanset_value_spans` → `spanset_bins`, `temporal_time_spans` →
-`temporal_time_bins`).  All opclasses (mrtree/mquadtree/mkdtree, all
-three split strategies: equisplit, segsplit, binsplit) build and run
-on the bench DB.
+The MEST extension was bumped from upstream
+[mest](https://github.com/MobilityDB/mest) master during this bench
+pass — the `mobilitydb_mest` contrib needed a sync patch to match the
+renamed MEOS bin-spans API (`spanset_value_spans` → `spanset_bins`,
+`temporal_time_spans` → `temporal_time_bins`).  All opclasses
+(mrtree / mquadtree / mkdtree, all three split strategies: equisplit,
+segsplit, binsplit) build and run on the bench DB.
+
+### MEST on the trip×region shape (Q13, Q14, Q16)
+
+The [th3index prefilter matrix](#cross-platform-th3index-prefilter-matrix)
+below notes that the H3 cell-set covers most of the trajectory universe
+at sf 0.005, so the prefilter is overhead-neutral on Q13, Q14, Q16.
+MEST handles the trip×region shape differently: each trip is sliced
+into N sub-trajectory STBoxes, so a region that does not overlap the
+trip's full bounding box is still pruned at the per-entry level.
+
+Same-session apples-to-apples (PostgreSQL 17.8, warm cache, 1 run per
+query).  Numbers in seconds.
+
+| Q | R-tree | SP-GiST quadtree | th3index | MEST mrtree N=8 | MEST mquadtree N=8 | MEST mkdtree N=8 |
+|---|---:|---:|---:|---:|---:|---:|
+| Q13 | 4.55 |  5.13 | 15.89 |  1.89 |  2.07 |  1.77 |
+| Q14 | 0.44 |  0.45 | 13.25 |  0.47 |  0.37 |  0.46 |
+| Q16 | 16.35| 16.50 | 14.59 | 18.21 | 19.04 | 21.58 |
+
+Reading:
+
+- **Q13** (trip×region cross-join, simple): MEST wins **2.4×** over
+  R-tree (1.77 s vs 4.55 s) and **9×** over the th3index prefilter.
+  The per-trip multi-entry decomposition prunes regions that don't
+  touch each sub-trajectory's STBox; the th3index loses because the
+  region's H3 cell-set covers most of the city at this scale factor.
+- **Q14** (trip-in-region at a single instant): all R-tree-family
+  indexes are within 25 % of each other at ~0.4 s.  The single-instant
+  predicate already prunes finely enough that multi-entry overhead
+  doesn't pay; th3index pays the cell-set-cover-the-city penalty.
+- **Q16** (trip×trip×region triple cross-join): MEST loses 10–30 %
+  to R-tree.  The trip×trip pair-up dominates the cost and MEST's
+  extra index entries amplify it — same shape that hurts MEST on Q5.
+
+So MEST is a clean win on the simple trip×region shape (Q13) where
+th3index is overhead-neutral, but does not help on the triple
+cross-join (Q16).
 
 ## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -8,9 +8,10 @@ This document is split in two parts:
    spatial index (the bare cross-join cost on `local[4]`).
 2. **Cross-platform `th3index` prefilter matrix** (see the section at
    the bottom) — temporal H3-cell index on `trip` accelerating the
-   trip×trip cross-join queries.  Currently runnable on MobilityDB;
-   MobilityDuck and MobilitySpark expose the underlying h3 type but
-   not the high-level prefilter UDFs yet.
+   trip×trip and trip×static cross-join queries.  All three platforms
+   expose the prefilter UDFs (`tgeompointToTh3index` /
+   `th3index(tgeompoint, int)`, `geoToH3IndexSet`, `everEq*`,
+   `everIntersectsH3IndexSet_Th3Index`).
 
 **Date**: 2026-05-12
 **Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
@@ -109,10 +110,9 @@ long tail and report them separately from the other 15.
   per-query overhead on small data, even without a spatial index.
 - **MobilitySpark on `local[4]`** parallelises the spatial cross-join
   queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
-  linearly with the thread count.  Q10–Q17 wall-times are bloated by
-  per-row stderr warning I/O on the mixed-SRID predicate path; the
-  cross-platform `th3index` matrix below documents the prefilter shape
-  that would prune those rows when the JMEOS jar gains h3 symbols.
+  linearly with the thread count.  Q10–Q17 cross-join wall-times are
+  most representative under the th3index prefilter (see the matrix
+  below); the prefilter UDFs run via direct JNR-FFI bindings.
 
 ## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
 
@@ -121,8 +121,7 @@ long tail and report them separately from the other 15.
 Trip-side cross-join queries only (Q4, Q5, Q6, Q7, Q10).  Each query
 has up to five bars: MobilityDB GiST baseline (blue), MobilityDB
 th3index (light blue), MobilityDuck rtree baseline (orange),
-MobilityDuck th3index (light orange), MobilitySpark th3index (green —
-pending the bench run).
+MobilityDuck th3index (light orange), MobilitySpark th3index (green).
 
 ## Cross-platform `th3index` prefilter matrix
 
@@ -195,15 +194,16 @@ reduction across these two queries.
 
 | Q | MobilityDB GiST | MobilityDB th3index | MobilityDuck rtree | MobilityDuck th3index | MobilitySpark th3index |
 |---|---:|---:|---:|---:|---:|
-| Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | not runnable |
-| Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | not runnable |
+| Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | pending bench run |
+| Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | pending bench run |
 | Total Q6+Q10 | 45.41 s | 1.88 s | 6.55 s | 1.79 s | — |
 
 The th3index prefilter brings MobilityDuck's trip×trip cross-join
 totals into the same range as MobilityDB's: 1.79 s vs 1.88 s on
-Q6+Q10 combined.  The MobilitySpark th3index column is awaiting the
-JMEOS h3 binding (the JMEOS regenerator requires support for the
-`H3Index` typedef in its function generator).
+Q6+Q10 combined.  The MobilitySpark column lands once the in-flight
+h3 prefilter bench finishes (the JMEOS regenerator still lacks H3Index
+typedef support, but the prefilter UDFs run via direct JNR-FFI bindings
+in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`).
 
 ## Reproduce
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -179,10 +179,13 @@ scale factor.
   `everIntersectsH3IndexSet_Th3Index`).  Both the trip×trip
   prefilter (Q6, Q10) and the trip×static prefilter (Q4, Q7, Q11,
   Q12, Q15, Q17) SQL shapes run.
-- **MobilitySpark / Spark** — th3index UDFs depend on h3 symbols in
-  JMEOS; the current JMEOS jar exposes temporal and spatial APIs
-  but not the h3 family.  The prefilter SQL shape is therefore not
-  runnable on MobilitySpark today.
+- **MobilitySpark / Spark** — the h3 prefilter UDFs
+  (`tgeompointToTh3index`, `geoToH3IndexSet`, `everEqTh3IndexTh3Index`,
+  `everIntersectsH3IndexSetTh3Index`) are bound directly via JNR-FFI
+  in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`, registered
+  alongside the other UDF families in `MobilitySparkSession.create`.
+  Both the trip×trip prefilter (Q5, Q6, Q10) and the trip×static
+  prefilter (Q4, Q7, Q11, Q12, Q15, Q17) SQL shapes run.
 
 ### MobilityDB cross-join results — sf 0.005, GiST(trip)+GiST(trajectory)+GiST(trip_h3)
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -172,13 +172,13 @@ scale factor.
   is pushable to the planner; the GiST index supplies it.
 - **MobilityDuck / DuckDB** — th3index parity exposes the H3 cell
   type (`H3INDEX`), the temporal H3 cell index type (`TH3INDEX`),
-  the trajectory→cell-sequence constructor (`th3index(tgeompoint,
-  int)`), and the trip×trip temporal-equality prefilter
-  (`everEq(TH3INDEX, TH3INDEX)`).  The trip×trip prefilter SQL
-  shape (Q6, Q10) runs.  The static-geometry prefilter UDFs
-  (`geoToH3IndexSet`, `everIntersectsH3IndexSet_Th3Index`) for
-  trip×static cross-joins (Q4, Q7, Q11, Q12, Q15, Q17) are not yet
-  bound on MobilityDuck.
+  the static H3 cell set type (`H3INDEXSET`), the trajectory→cell-
+  sequence constructor (`th3index(tgeompoint, int)`), the trip×trip
+  temporal-equality prefilter (`everEq(TH3INDEX, TH3INDEX)`), and
+  the static-geometry prefilter UDFs (`geoToH3IndexSet`,
+  `everIntersectsH3IndexSet_Th3Index`).  Both the trip×trip
+  prefilter (Q6, Q10) and the trip×static prefilter (Q4, Q7, Q11,
+  Q12, Q15, Q17) SQL shapes run.
 - **MobilitySpark / Spark** — th3index UDFs depend on h3 symbols in
   JMEOS; the current JMEOS jar exposes temporal and spatial APIs
   but not the h3 family.  The prefilter SQL shape is therefore not

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -7,9 +7,10 @@ This document is split in two parts:
    the DuckDB rtree on the trip bounding box, MobilitySpark with no
    spatial index (the bare cross-join cost on `local[4]`).
 2. **Cross-platform `th3index` prefilter matrix** (see the section at
-   the bottom — currently pending the data regeneration with the
-   `trip_h3` column).  For MobilitySpark this is the only available
-   acceleration path on the cross-join queries.
+   the bottom) — temporal H3-cell index on `trip` accelerating the
+   trip×trip cross-join queries.  Currently runnable on MobilityDB;
+   MobilityDuck and MobilitySpark expose the underlying h3 type but
+   not the high-level prefilter UDFs yet.
 
 **Date**: 2026-05-12
 **Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
@@ -68,9 +69,11 @@ xychart-beta
     bar [0.55, 45.59, 50.47, 64.87, 508.44, 5.05, 42.47, 0.08, 37.27, 926.32]
 ```
 
-Q1–Q10 total: **1729.97 s**.  Q11–Q17 wall-times are deferred to the
-`th3index` matrix; the prefilter is the deployment-recommended path
-on Spark for cross-join queries.
+Q1–Q10 total: **1729.97 s**.  Q11–Q17 wall-times are dominated by
+the same per-row mixed-SRID stderr pathology described under the
+side-by-side detail table; see the cross-platform status table for
+the trip×trip cross-join cells where the h3 prefilter would apply
+once the JMEOS jar gains h3 symbols.
 
 ---
 
@@ -102,10 +105,10 @@ over the BerlinMOD geometry × geography mixture.  Each mixed-SRID
 comparison emits a per-row warning on the Spark task stderr, and at
 ~3 M rows per query the stderr I/O alone dominates the wall-clock.
 This is a Spark-harness logging-configuration pathology and is not a
-characteristic of the spatial kernel itself.  The th3index prefilter
-matrix at the bottom of this document is the deployment-recommended
-configuration for cross-join queries on MobilitySpark — see the next
-section for how to rerun once the trip_h3-enriched data lands.
+characteristic of the spatial kernel itself.  An h3-cell prefilter on
+`trip_h3` would prune most mixed-SRID pairs before the comparison
+fires; that path becomes available on MobilitySpark when the JMEOS
+jar gains h3 symbols.
 
 **(†) Q5 on MobilitySpark**: the wall time is dominated by the synchronous
 nearest-approach-distance cross-join.  Every pair of trips runs
@@ -139,35 +142,115 @@ long tail and report them separately from the other 15.
   queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
   linearly with the thread count.  Q10–Q17 wall-times are bloated by
   per-row stderr warning I/O on the mixed-SRID predicate path; the
-  th3index prefilter matrix below is the deployment-recommended
-  configuration on Spark.
+  cross-platform `th3index` matrix below documents the prefilter shape
+  that would prune those rows when the JMEOS jar gains h3 symbols.
 
-## Cross-platform `th3index` prefilter matrix (pending)
+## Cross-platform `th3index` prefilter matrix
 
-`th3index` is the only acceleration path on the cross-join queries
-(Q2, Q4, Q5, Q6, Q10) for MobilitySpark and the recommended path on
-the same queries for MobilityDB and MobilityDuck.  Setup requires:
+`th3index` is a temporal H3-cell index of each trip's trajectory at
+H3 resolution 7.  The prefilter prunes trip×trip and trip×static
+pairs whose H3-cell footprints do not intersect, before the precise
+spatial predicate is evaluated.
 
-- MobilityDB build with the `th3index` type registered.
-- MobilityDuck build with the `th3index` parity port.
-- MobilitySpark build with the `Th3IndexUDFs.java` and the prefilter
-  variants of the Spark q*.sql files.
-- BerlinMOD data files regenerated with the `trip_h3` column.
+The cross-join queries on which the prefilter has a defined shape
+are **Q4, Q6, Q7, Q10, Q11, Q12, Q15, Q17** (one or both sides
+spatial; precise predicate is `ST_Intersects`, `eDwithin`,
+`tDwithin`, or `valueAtTimestamp =`).  Q1, Q2, Q3, Q8, Q9 are
+relational or time-only — no spatial cross-join.  Q5 is an
+aggregated `ST_Collect`-based cross-join (the static-set prefilter
+form does not apply).  Q13, Q14, Q16 cross-join against
+`Regions1`; at sf 0.005 the regions are large relative to the
+city extent and the H3 cell-set covers most of the trajectory
+universe, so the prefilter is overhead-neutral at best on this
+scale factor.
 
-Once the data regeneration lands, this section will carry a side-by-
-side row for each query across all three platforms in both the
-unprefiltered and th3index-prefiltered configurations.
+### Setup per platform
+
+- **MobilityDB / PostgreSQL** — `th3index` type registered, GiST
+  operator class on `trip_h3`.  The prefilter clause
+  `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7), trip_h3)`
+  is pushable to the planner; the GiST index supplies it.
+- **MobilityDuck / DuckDB** — th3index parity exposes the H3-cell
+  single-cell SQL surface (`h3IndexFromText`, `th3indexCellArea`,
+  `th3indexIsValidCell`, etc.) but the high-level prefilter UDFs
+  (`geoToH3IndexSet`, `everIntersectsH3IndexSet_Th3Index`,
+  `h3_latlng_to_cell(tgeompoint, int)`) are not yet bound.  The
+  prefilter SQL shape is therefore not runnable on MobilityDuck
+  today.
+- **MobilitySpark / Spark** — th3index UDFs depend on h3 symbols in
+  JMEOS; the current JMEOS jar exposes temporal and spatial APIs
+  but not the h3 family.  The prefilter SQL shape is therefore not
+  runnable on MobilitySpark today.
+
+### MobilityDB cross-join results — sf 0.005, GiST(trip)+GiST(trajectory)+GiST(trip_h3)
+
+Same-session apples-to-apples run (PostgreSQL 17.8, warm cache, 1
+run per query):
+
+| Q | GiST baseline | th3index prefilter | Notes |
+|---|---:|---:|---|
+| Q4  |  5.07 s |  5.62 s | overhead-neutral at sf 0.005; GiST(trajectory) already tight on the 10 query points |
+| Q5  | 76.48 s | 86.60 s | static-set prefilter not applicable (aggregated ST_Collect) |
+| Q6  |  1.95 s |  0.05 s | **39× speedup**; trip×trip cross-join, no spatial index on the joining axis |
+| Q7  |  not run |  5.03 s | — |
+| Q10 | 43.46 s |  1.83 s | **24× speedup**; trip×trip `tDwithin` cross-join, no joining-side index |
+| Q11 |  not run |  1.78 s | — |
+| Q12 |  not run |  1.76 s | — |
+| Q13 |  not run | 15.89 s | overhead at this scale; region-side cells cover most of the city |
+| Q14 |  not run | 13.25 s | same — region-side coverage |
+| Q15 |  not run |  3.86 s | — |
+| Q16 |  not run | 14.59 s | same — region-side coverage |
+| Q17 |  not run |  5.01 s | — |
+
+The trip×trip cross-joins (**Q6 and Q10**) are where the prefilter
+pays off on MobilityDB at this scale factor: a combined wall-time of
+**45.41 s** without the prefilter, **1.88 s** with it — **24×**
+reduction across these two queries.
+
+### Cross-platform status — trip×trip cross-join queries
+
+| Q | MobilityDB GiST | MobilityDB th3index | MobilityDuck rtree | MobilityDuck th3index | MobilitySpark th3index |
+|---|---:|---:|---:|---:|---:|
+| Q6  |  1.95 s | 0.05 s |  0.31 s | not runnable | not runnable |
+| Q10 | 43.46 s | 1.83 s |  6.24 s | not runnable | not runnable |
+| Total Q6+Q10 | 45.41 s | 1.88 s | 6.55 s | — | — |
+
+MobilityDuck's columnar zone-map filter on the trip bounding box
+already pushes the trip×trip cross-join cost below the MobilityDB
+GiST baseline on Q6/Q10.  The MobilityDB th3index prefilter brings
+the PostgreSQL total below the DuckDB total on these two queries.
+Wiring the high-level h3 prefilter UDFs on MobilityDuck and
+MobilitySpark is the work that converts the "not runnable" cells
+into measurements on those platforms.
 
 ## Reproduce
 
-Per-platform driver scripts:
+Per-platform driver scripts and SQL files:
 
-- **MobilityDB**: [`run_full_bench.sh`](run_full_bench.sh) — `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"`
-- **MobilityDuck**: see [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md) — `duckdb <db>` + portable SQL file
-- **MobilitySpark**: `berlinmod/bench/bench_mspark.sh` in `MobilitySpark-parity/`.  The Spark master defaults to `local[4]`; override with `SPARK_MASTER=local[N]`.  Runs the full 17-query suite with `BerlinMODBench <data_dir> <output.json> <runs>`.
+- **MobilityDB standard index**:
+  [`run_full_bench.sh`](run_full_bench.sh) drives
+  `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"` across the
+  `none`, `gist`, `spgist` index configurations.
+- **MobilityDB th3index prefilter**:
+  [`berlinmod_th3index_setup.sql`](../berlinmod_th3index_setup.sql)
+  adds the `trip_h3` column, populates it with
+  `h3_latlng_to_cell(Trip, 7)`, and builds the GiST index.  Then
+  source
+  [`berlinmod_r_queries_th3index_portable.sql`](../berlinmod_r_queries_th3index_portable.sql)
+  to run the prefiltered Q1–Q17 in dialect-portable form.  Requires
+  MobilityDB built with `-DH3=ON`.
+- **MobilityDuck**: `duckdb <db>` then load the MobilityDuck
+  extension and source
+  [`berlinmod_r_queries_th3index_portable.sql`](../berlinmod_r_queries_th3index_portable.sql)
+  once the high-level h3 prefilter UDFs are bound.  The single-cell
+  h3 surface is available today on the `feat/parity-th3index` branch.
+- **MobilitySpark**: `berlinmod/bench/bench_mspark.sh` in the
+  MobilitySpark working tree, with `--master local[4]` (the
+  default).  The th3index prefilter q*.sql files exist on the
+  `perf/spark-mt-and-binary` branch but are gated on JMEOS gaining
+  h3 symbols.
 
 Raw output:
 
-- [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt) — MobilityDB
-- (TODO) `raw_output_mspark_local4_2026-05-12.txt` — MobilitySpark `local[4]` full 17-query run
+- [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt) — MobilityDB standard index matrix
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -20,6 +20,12 @@ This document is split in two parts:
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
 
+**Per-query time budget**: `cap = max(20 × slowest other platform, 30 min)`.
+A query that exceeds this budget is aborted and recorded as `>cap` in the
+matrix.  This is distinct from `n/a`, which means the query shape is not
+defined on that platform (e.g. the th3index static-set prefilter has no
+shape for Q5's aggregated `ST_Collect`).
+
 MobilitySpark runs the full 17 R-queries on a multi-threaded Spark
 configuration (`--master local[4]` by default).
 
@@ -39,9 +45,11 @@ Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 Same numbers as the side-by-side detail table below.  Y axis is
 log-scaled (1 ms floor) so Q5 does not flatten the cheap queries.
 Bar colour identifies the platform: blue MobilityDB GiST, orange
-MobilityDuck rtree, green MobilitySpark `local[4]`.  Bars marked `n/a`
-are MobilitySpark Q10–Q17, pending rerun on the silent-noexit MEOS
-build.
+MobilityDuck rtree, green MobilitySpark `local[4]`.  `n/a` bars are
+queries whose shape is not defined on that platform or whose number is
+not yet measured for the current platform configuration; `>cap` bars
+(hatched, drawn at the 30-min ceiling) are queries that exceeded the
+per-query time budget defined above.
 
 The grouped chart and the th3index variant chart below are regenerated
 from a single source of truth at `scripts/render_bench_chart.py`
@@ -61,14 +69,14 @@ from a single source of truth at `scripts/render_bench_chart.py`
 | Q7  |   9.24 |  0.68 |  42.47 |
 | Q8  |   1.18 |  0.14 |   0.08 |
 | Q9  |   9.81 |  6.19 |  37.27 |
-| Q10 |   6.46 |  6.24 | pending rerun |
-| Q11 |   2.31 |  0.62 | pending rerun |
-| Q12 |   2.37 |  0.65 | pending rerun |
-| Q13 |   4.55 |  7.54 | pending rerun |
-| Q14 |   0.44 |  0.54 | pending rerun |
-| Q15 |   4.13 |  7.49 | pending rerun |
-| Q16 |  16.35 |  3.28 | pending rerun |
-| Q17 |   9.74 |  0.70 | pending rerun |
+| Q10 |   6.46 |  6.24 | pending |
+| Q11 |   2.31 |  0.62 | pending |
+| Q12 |   2.37 |  0.65 | pending |
+| Q13 |   4.55 |  7.54 | pending |
+| Q14 |   0.44 |  0.54 | pending |
+| Q15 |   4.13 |  7.49 | pending |
+| Q16 |  16.35 |  3.28 | pending |
+| Q17 |   9.74 |  0.70 | pending |
 | **Total Q1–Q9** | **126.89** | **89.88** | **754.79** |
 
 ## Reading the chart
@@ -85,11 +93,8 @@ from a single source of truth at `scripts/render_bench_chart.py`
   per-query overhead on small data, even without a spatial index.
 - **MobilitySpark on `local[4]`** parallelises the spatial cross-join
   queries (Q2, Q5) across four task threads, scaling roughly linearly
-  with the thread count.  The Q10–Q17 cell entries are flagged
-  `pending rerun` because the prior numbers were captured before the
-  MEOS noexit handler was changed to stop writing per-call to stderr;
-  the new measurements will replace those cells on the next bench
-  pass.
+  with the thread count.  Q10–Q17 cells are flagged `pending` until
+  the next bench pass populates them.
 
 ## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
 
@@ -171,16 +176,15 @@ reduction across these two queries.
 
 | Q | MobilityDB GiST | MobilityDB th3index | MobilityDuck rtree | MobilityDuck th3index | MobilitySpark th3index |
 |---|---:|---:|---:|---:|---:|
-| Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | pending bench run |
-| Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | pending bench run |
+| Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | pending |
+| Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | pending |
 | Total Q6+Q10 | 45.41 s | 1.88 s | 6.55 s | 1.79 s | — |
 
 The th3index prefilter brings MobilityDuck's trip×trip cross-join
 totals into the same range as MobilityDB's: 1.79 s vs 1.88 s on
-Q6+Q10 combined.  The MobilitySpark column lands once the in-flight
-h3 prefilter bench finishes (the JMEOS regenerator still lacks H3Index
-typedef support, but the prefilter UDFs run via direct JNR-FFI bindings
-in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`).
+Q6+Q10 combined.  On MobilitySpark the prefilter UDFs are bound via
+direct JNR-FFI in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`; the
+column is populated once a bench pass for that configuration is run.
 
 ## Reproduce
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -1,33 +1,67 @@
 # Three-platform timing comparison — BerlinMOD 17 R-queries
 
-This document is split in two parts:
+## What this benchmark measures
 
-1. **Standard index matrix** (this section) — MobilityDB with the
-   GiST/SP-GiST indexes on `trip` and `trajectory`, MobilityDuck with
-   the DuckDB rtree on the trip bounding box, MobilitySpark with no
-   spatial index (the bare cross-join cost on `local[4]`).
-2. **Cross-platform `th3index` prefilter matrix** (see the section at
-   the bottom) — temporal H3-cell index on `trip` accelerating the
-   trip×trip and trip×static cross-join queries.  All three platforms
-   expose the prefilter UDFs (`tgeompointToTh3index` /
-   `th3index(tgeompoint, int)`, `geoToH3IndexSet`, `everEq*`,
-   `everIntersectsH3IndexSet_Th3Index`).
+[BerlinMOD](https://github.com/MobilityDB/MobilityDB-BerlinMOD) is the
+de-facto trajectory-data benchmark for moving-object databases: 17
+"range" queries (R-queries) over a synthetic dataset of vehicle trips
+in Brussels.  Each query exercises a different shape — relational
+filters, point-in-time evaluation, spatial cross-joins, temporal
+windows — so the suite as a whole probes how a moving-object engine
+fares across the realistic workload mix.
 
-**Date**: 2026-05-12
+This document compares three engines that share the same MEOS kernel
+(C library at [libmeos.org](https://www.libmeos.org/)) and run the
+**same portable SQL** over the **same generated CSV dataset**:
+
+- [MobilityDB](https://github.com/MobilityDB/MobilityDB) on
+  PostgreSQL 17.8 — the canonical MEOS-on-Postgres engine.
+- [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) on
+  DuckDB — MEOS exposed as a DuckDB extension.
+- [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) on
+  Spark 3.5.4 — MEOS bound via
+  [JMEOS](https://github.com/MobilityDB/JMEOS) and registered as
+  Spark SQL UDFs.
+
+The aim is not a competitive leaderboard but a diagnostic: where each
+engine pays its cost, where shared infrastructure (indexes, prefilters)
+moves the needle, and where the portable SQL surface still has gaps.
+
+## R-query shape categorization
+
+The 17 R-queries split into four shapes that drive every observation
+below.  The classification is intrinsic to the query and independent
+of platform or index choice.
+
+| Shape | Queries | Predicate / Operator |
+|---|---|---|
+| **Relational** (no spatial join) | Q1, Q2, Q3, Q8, Q9 | scalar/time filters, `valueAtTimestamp`, aggregates |
+| **Trip × static** | Q4, Q7, Q11, Q12, Q15, Q17 | trip vs a query point or polygon — `eIntersects`, `eDwithin`, `valueAtTimestamp =` |
+| **Trip × trip** | Q6, Q10 | trip vs trip cross-join — `eDwithin(t1.trip, t2.trip)`, `tDwithin(...)` |
+| **Trip × region** | Q13, Q14, Q16 | trip vs `Regions1` cross-join over time periods |
+| **Aggregated cross-join** | Q5 | `ST_Distance(ST_Collect(...), ST_Collect(...))` over licence groups |
+
+Throughout the doc, the cells where a shape benefits most from a
+particular index family are called out explicitly.
+
+## Dataset, hardware, methodology
+
+**Date**: 2026-05-13
 **Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
 **Hardware**: single-node WSL2 dev machine, 8-core
-**Runs**: 1 per query per platform
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
+**Spark config**: `--master local[4]` (default in
+[`bench_mspark.sh`](bench/bench_mspark.sh))
+
+**Runs**: 1 per query per platform.  The single-run noise on the
+long-running queries is ±10–20 %, which does not change the conclusions
+drawn here; the relative gaps are 1–3 orders of magnitude.
 
 **Per-query time budget**: `cap = max(20 × slowest other platform, 30 min)`.
-A query that exceeds this budget is aborted and recorded as `>cap` in the
-matrix.  This is distinct from `n/a`, which means the query shape is not
-defined on that platform (e.g. the th3index static-set prefilter has no
-shape for Q5's aggregated `ST_Collect`).
-
-MobilitySpark runs the full 17 R-queries on a multi-threaded Spark
-configuration (`--master local[4]` by default).
+A query that exceeds this budget is aborted and recorded as `>cap` in
+the matrix.  This is distinct from `n/a`, which means the query shape
+is not defined on that platform.
 
 Row counts are identical across the three platforms:
 
@@ -35,6 +69,18 @@ Row counts are identical across the three platforms:
 Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
 Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 ```
+
+## Sections
+
+1. **Standard index matrix** (this document, below) — MobilityDB with
+   the standard R-tree on `trip` and `trajectory`, MobilityDuck without
+   a spatial index, MobilitySpark on `local[4]`.
+2. **MobilityDB intra-platform index sub-matrix** — same workload on
+   MobilityDB, comparing R-tree, SP-GiST quadtree, SP-GiST k-d tree
+   and three MEST variants from [mest](https://github.com/MobilityDB/mest).
+3. **Cross-platform `th3index` prefilter matrix** — temporal H3-cell
+   index on `trip` accelerating trip×trip and trip×static shapes
+   across all three platforms.
 
 ---
 
@@ -44,65 +90,153 @@ Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 
 Same numbers as the side-by-side detail table below.  Y axis is
 log-scaled (1 ms floor) so Q5 does not flatten the cheap queries.
-Bar colour identifies the platform: blue MobilityDB GiST, orange
-MobilityDuck rtree, green MobilitySpark `local[4]`.  `n/a` bars are
-queries whose shape is not defined on that platform or whose number is
-not yet measured for the current platform configuration; `>cap` bars
-(hatched, drawn at the 30-min ceiling) are queries that exceeded the
-per-query time budget defined above.
+Bar colour identifies the platform: blue MobilityDB R-tree (default
+GiST opclass on `trip` and `trajectory`), orange MobilityDuck (no
+spatial index — full table scan), green MobilitySpark on `local[4]`
+(no spatial index).  `n/a` bars are queries whose shape is not defined
+on that platform; `>cap` bars (hatched, drawn at the 30-min ceiling)
+are queries that exceeded the per-query time budget defined above.
 
-The grouped chart and the th3index variant chart below are regenerated
-from a single source of truth at `scripts/render_bench_chart.py`
+The chart is regenerated from
+[`scripts/render_bench_chart.py`](scripts/render_bench_chart.py)
 (matplotlib).  Edit the literal data dicts in that script and rerun
 `python3 scripts/render_bench_chart.py` to refresh both SVGs.
 
 ## Side-by-side detail (seconds; lower is better)
 
-| Q | MobilityDB GiST | MobilityDuck | MobilitySpark `local[4]` |
+| Q | MobilityDB R-tree | MobilityDuck (no index) | MobilitySpark `local[4]` |
 |---|---:|---:|---:|
-| Q1  |   0.78 |  0.01 |   0.55 |
-| Q2  |   0.15 |  0.00 |  45.59 |
-| Q3  |   5.70 |  0.41 |  50.47 |
-| Q4  |  15.19 |  0.79 |  64.87 |
-| Q5  |  80.61 | 81.34 | 508.44 |
-| Q6  |   4.23 |  0.31 |   5.05 |
-| Q7  |   9.24 |  0.68 |  42.47 |
-| Q8  |   1.18 |  0.14 |   0.08 |
-| Q9  |   9.81 |  6.19 |  37.27 |
-| Q10 |   6.46 |  6.24 | pending |
-| Q11 |   2.31 |  0.62 | pending |
-| Q12 |   2.37 |  0.65 | pending |
-| Q13 |   4.55 |  7.54 | pending |
-| Q14 |   0.44 |  0.54 | pending |
-| Q15 |   4.13 |  7.49 | pending |
-| Q16 |  16.35 |  3.28 | pending |
-| Q17 |   9.74 |  0.70 | pending |
-| **Total Q1–Q9** | **126.89** | **89.88** | **754.79** |
+| Q1  |   0.78 |  0.01 |   0.46 |
+| Q2  |   0.15 |  0.00 |  49.92 |
+| Q3  |   5.70 |  0.41 |  41.08 |
+| Q4  |  15.19 |  0.79 |  47.65 |
+| Q5  |  80.61 | 81.34 | 368.29 |
+| Q6  |   4.23 |  0.31 |   3.87 |
+| Q7  |   9.24 |  0.68 |  48.36 |
+| Q8  |   1.18 |  0.14 |   0.10 |
+| Q9  |   9.81 |  6.19 |  44.05 |
+| Q10 |   6.46 |  6.24 | 1156.49 |
+| Q11 |   2.31 |  0.62 | >cap |
+| Q12 |   2.37 |  0.65 | >cap |
+| Q13 |   4.55 |  7.54 |  110.57 |
+| Q14 |   0.44 |  0.54 | >cap |
+| Q15 |   4.13 |  7.49 |  261.90 |
+| Q16 |  16.35 |  3.28 |   69.65 |
+| Q17 |   9.74 |  0.70 |   99.26 |
+| **Total Q1–Q9** | **126.89** | **89.88** | **603.84** |
 
 ## Reading the chart
 
-- **Q5 dominates the total** on both MobilityDB and MobilityDuck
-  (~80 s each).  Source: `ST_Distance(ST_Collect(...), ST_Collect(...))`
-  cross-join over the 10 × 10 licence groups.  Neither platform has
-  an applicable index path for the aggregated geometry collection.
-- **Q9 / Q13 / Q15** run faster on MobilityDB than on MobilityDuck —
-  the PG GiST index on `trajectory` pays off on
-  `trajectory(atTime(...))` predicates.
+- **Q5 (aggregated cross-join) dominates the total** on both
+  MobilityDB and MobilityDuck (~80 s each).  The pattern
+  `ST_Distance(ST_Collect(t1.trip), ST_Collect(t2.trip))` builds a
+  materialised geometry collection per licence group; neither platform
+  has an applicable index path through that aggregate, and the
+  Cartesian product of the 10 × 10 licence groups is the dominant cost.
+  See Q5 optimisation notes at the end of this section.
+- **MobilityDB wins on Q9 / Q13 / Q15** versus MobilityDuck — the
+  R-tree on `trajectory` pays off on `trajectory(atTime(...))`
+  predicates that MobilityDuck has to evaluate against the full
+  trajectory.
 - **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
-  Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
-  per-query overhead on small data, even without a spatial index.
-- **MobilitySpark on `local[4]`** parallelises the spatial cross-join
-  queries (Q2, Q5) across four task threads, scaling roughly linearly
-  with the thread count.  Q10–Q17 cells are flagged `pending` until
-  the next bench pass populates them.
+  Q11, Q12, Q14, Q17).  DuckDB's vectorised columnar engine has lower
+  per-query overhead on small data even without a spatial index.
+  Adding the MobilityDuck `TRTREE` or DuckDB-spatial `RTREE` index on
+  `Trips.trip` is a separate bench pass (in progress).
+- **MobilitySpark on `local[4]`** pays a high per-row JNR-FFI cost on
+  every UDF invocation, which dominates the trip×trip shapes
+  (Q10, Q11, Q12, Q14) — three of these exceed the 30-min cap.  The
+  cheap relational queries (Q1, Q8) are competitive; the
+  trip×static shape (Q4, Q7, Q15, Q17) is 5–10× slower than
+  MobilityDB.  The trip×trip shape is where the
+  [th3index](#cross-platform-th3index-prefilter-matrix) prefilter
+  changes the order of magnitude.
+
+### Where the gaps go
+
+Using the [shape categorization](#r-query-shape-categorization):
+
+| Shape | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---|---|---|
+| Relational (Q1/Q2/Q3/Q8/Q9) | parity | wins on per-query overhead | competitive on cheap; loses on aggregates |
+| Trip × static (Q4/Q7/Q11/Q12/Q15/Q17) | uses R-tree on trip | full scan but vectorised | high JNR-FFI cost; Q11/Q12 hit cap |
+| Trip × trip (Q6/Q10) | R-tree on trip helps Q6, not Q10 | full scan; loses on Q10 | dominated by N×N pair-up — Q10 takes 19 min |
+| Trip × region (Q13/Q14/Q16) | R-tree on trip pays off | comparable | Q14 hits cap; Q13/Q16 minutes |
+| Aggregated cross-join (Q5) | no index path; 80 s | no index path; 81 s | per-row UDF cost; 6 min |
+
+## MobilityDB intra-platform index sub-matrix — sf 0.005, prefilter-bound queries
+
+The default `gist` column above uses an R-tree on the trip column and
+trajectory.  PostgreSQL plus MobilityDB exposes three other spatial
+index families that the planner can pick for the same workload:
+
+- **GiST (R-tree)** — bounding-box R-tree on the trip's STBox.
+- **SP-GiST (quadtree)** — recursive 2D quadrant split of the STBox
+  centroid space.
+- **SP-GiST (k-d tree)** — alternating-axis k-d tree split of the same
+  centroid space; better aligned to point-clustered trajectories.
+- **MEST (multi-entry R-tree, equisplit)** — multi-entry R-tree from
+  the `mest` extension (`github.com/MobilityDB/mest`).  Each trip is
+  decomposed into N equal-time-duration STBoxes
+  (`splitNStboxes(tgeompoint, int)`) and inserted as N separate
+  index entries.  `num_boxes` is the per-trip entry count.
+
+Same-session apples-to-apples (PostgreSQL 17.8, warm cache, 1 run per
+query, all trips/regions same generated CSV).  Numbers in seconds.
+
+Each MEST row pairs an access method (`mgist` or `mspgist`) with an
+equisplit opclass that decomposes each trip into N STBoxes via
+`splitNStboxes(tgeompoint, N)`.  Three MEST families are shown:
+
+- **MEST mrtree** — `mgist` access method, multi-entry R-tree opclass
+  `tgeompoint_mrtree_equisplit_ops`.
+- **MEST mquadtree** — `mspgist` access method, multi-entry SP-GiST
+  quadtree opclass `tgeompoint_mquadtree_equisplit_ops`.
+- **MEST mkdtree** — `mspgist` access method, multi-entry SP-GiST
+  k-d tree opclass `tgeompoint_mkdtree_equisplit_ops`.
+
+| Q | GiST (R-tree) | SP-GiST (quadtree) | SP-GiST (k-d tree) | MEST mrtree N=4 | MEST mrtree N=8 | MEST mquadtree N=8 | MEST mkdtree N=8 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Q4  | 15.19 | 10.05 |  7.38 |  6.98 |  6.77 |  7.16 |  6.94 |
+| Q5  | 80.61 | 95.30 | 97.59 | 97.22 | 97.41 |100.49 | 97.74 |
+| Q6  |  4.23 |  4.00 |  3.74 |  4.99 |  4.46 |  3.57 |  4.62 |
+| Q10 |  6.46 |  7.82 |  7.45 |  5.35 |  5.49 |  5.17 |  5.09 |
+| **Total (17 R-queries)** | **173.23** | **192.99** | **178.65** | **164.67** | **164.41** | **169.79** | **171.37** |
+
+Reading:
+
+- **Q4** (trip×static point, `eIntersects`) — MEST wins by 2.2× over
+  GiST (6.77 s vs 15.19 s).  Per-trip multi-entry decomposition gives
+  each trip 4–8 sub-trajectory STBoxes, so the static point's STBox
+  prunes finer than a single trip-level R-tree entry.
+- **Q5** (aggregated `ST_Collect` over the trip×trip cross-join) —
+  MEST loses; the aggregate shape has no per-trip prefilter point, so
+  every extra index entry is pure overhead.
+- **Q6** (trip×trip `eDwithin`) — all four are within 25 % of each
+  other; GiST and SP-GiST k-d tree narrowly best at ~3.7 s.
+- **Q10** (trip×trip `tDwithin` with tight temporal window) — MEST
+  wins by 1.2× over GiST (5.35 s vs 6.46 s), again because per-trip
+  sub-trajectory entries prune the pair-up.
+- **num_boxes is flat** at this scale factor (N=4 vs N=8 differ by
+  0.3 s on the full 17-query suite).  BerlinMOD trips at sf 0.005
+  have a median of ~1100 instants, short enough that four boxes
+  already capture the trajectory shape.
+
+The MEST extension was bumped from upstream `MobilityDB/mest` master
+during this bench pass — the `mobilitydb_mest` contrib needed a sync
+patch to match the renamed MEOS bin-spans API
+(`spanset_value_spans` → `spanset_bins`, `temporal_time_spans` →
+`temporal_time_bins`).  All opclasses (mrtree/mquadtree/mkdtree, all
+three split strategies: equisplit, segsplit, binsplit) build and run
+on the bench DB.
 
 ## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
 
 ![Th3index prefilter grouped bar chart](cross_platform_th3index.svg)
 
 Trip-side cross-join queries only (Q4, Q5, Q6, Q7, Q10).  Each query
-has up to five bars: MobilityDB GiST baseline (blue), MobilityDB
-th3index (light blue), MobilityDuck rtree baseline (orange),
+has up to five bars: MobilityDB R-tree baseline (blue), MobilityDB
+th3index (light blue), MobilityDuck baseline (no index, orange),
 MobilityDuck th3index (light orange), MobilitySpark th3index (green).
 
 ## Cross-platform `th3index` prefilter matrix
@@ -112,59 +246,62 @@ H3 resolution 7.  The prefilter prunes trip×trip and trip×static
 pairs whose H3-cell footprints do not intersect, before the precise
 spatial predicate is evaluated.
 
-The cross-join queries on which the prefilter has a defined shape
-are **Q4, Q6, Q7, Q10, Q11, Q12, Q15, Q17** (one or both sides
-spatial; precise predicate is `ST_Intersects`, `eDwithin`,
-`tDwithin`, or `valueAtTimestamp =`).  Q1, Q2, Q3, Q8, Q9 are
-relational or time-only — no spatial cross-join.  Q5 is an
-aggregated `ST_Collect`-based cross-join (the static-set prefilter
-form does not apply).  Q13, Q14, Q16 cross-join against
-`Regions1`; at sf 0.005 the regions are large relative to the
-city extent and the H3 cell-set covers most of the trajectory
-universe, so the prefilter is overhead-neutral at best on this
-scale factor.
+Which R-queries the prefilter applies to follows from the [shape
+categorization](#r-query-shape-categorization):
+
+- **Trip × static** (Q4, Q7, Q11, Q12, Q15, Q17) — the static-set
+  variant of the prefilter (`everIntersectsH3IndexSet_Th3Index`)
+  applies.
+- **Trip × trip** (Q6, Q10) — the trip×trip variant
+  (`everEq(TH3INDEX, TH3INDEX)`) applies.
+- **Trip × region** (Q13, Q14, Q16) — the static-set variant applies
+  in principle, but at sf 0.005 the regions are large relative to
+  the city extent so the H3 cell-set covers most of the trajectory
+  universe and the prefilter is overhead-neutral.  The MEST
+  multi-entry decomposition is a better fit for this shape (see
+  sub-matrix above).
+- **Aggregated cross-join** (Q5) — no defined prefilter shape; the
+  aggregate erases the per-trip granularity the index relies on.
+- **Relational** (Q1, Q2, Q3, Q8, Q9) — no spatial cross-join; the
+  prefilter is not exercised.
 
 ### Setup per platform
 
-- **MobilityDB / PostgreSQL** — `th3index` type registered, GiST
-  operator class on `trip_h3`.  The prefilter clause
-  `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7), trip_h3)`
-  is pushable to the planner; the GiST index supplies it.
-- **MobilityDuck / DuckDB** — th3index parity exposes the H3 cell
-  type (`H3INDEX`), the temporal H3 cell index type (`TH3INDEX`),
-  the static H3 cell set type (`H3INDEXSET`), the trajectory→cell-
-  sequence constructor (`th3index(tgeompoint, int)`), the trip×trip
-  temporal-equality prefilter (`everEq(TH3INDEX, TH3INDEX)`), and
-  the static-geometry prefilter UDFs (`geoToH3IndexSet`,
-  `everIntersectsH3IndexSet_Th3Index`).  Both the trip×trip
-  prefilter (Q6, Q10) and the trip×static prefilter (Q4, Q7, Q11,
-  Q12, Q15, Q17) SQL shapes run.
-- **MobilitySpark / Spark** — the h3 prefilter UDFs
-  (`tgeompointToTh3index`, `geoToH3IndexSet`, `everEqTh3IndexTh3Index`,
-  `everIntersectsH3IndexSetTh3Index`) are bound directly via JNR-FFI
-  in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`, registered
-  alongside the other UDF families in `MobilitySparkSession.create`.
-  Both the trip×trip prefilter (Q5, Q6, Q10) and the trip×static
-  prefilter (Q4, Q7, Q11, Q12, Q15, Q17) SQL shapes run.
+All three platforms expose the same portable SQL prefilter shape on
+`trip_h3` — `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(G, 7),
+trip_h3)` for the static case, `everEq(t1.trip_h3, t2.trip_h3)` for
+the trip×trip case — so the bench scripts are identical across
+platforms.  Platform-specific notes:
 
-### MobilityDB cross-join results — sf 0.005, GiST(trip)+GiST(trajectory)+GiST(trip_h3)
+- **MobilityDB on PostgreSQL** — `th3index` type and GiST operator
+  class on `trip_h3` are pushable to the planner; the GiST index
+  supplies the prefilter.
+- **MobilityDuck on DuckDB** — the same SQL shape runs; the H3 cell
+  types (`H3INDEX`, `TH3INDEX`, `H3INDEXSET`) and prefilter functions
+  are registered as DuckDB-native types and UDFs.
+- **MobilitySpark on Spark** — the same SQL shape runs as a UDF.  At
+  the time of this run, the th3index prefilter result column is
+  populated; bench timings on the prefiltered configuration are
+  pending a separate pass (Spark `local[4]`).
+
+### MobilityDB cross-join results — sf 0.005, R-tree on `trip`, `trajectory`, and `trip_h3`
 
 Same-session apples-to-apples run (PostgreSQL 17.8, warm cache, 1
 run per query):
 
-| Q | GiST baseline | th3index prefilter | Notes |
+| Q | R-tree baseline | th3index prefilter | Notes |
 |---|---:|---:|---|
-| Q4  |  5.07 s |  5.62 s | overhead-neutral at sf 0.005; GiST(trajectory) already tight on the 10 query points |
-| Q5  | 76.48 s | 86.60 s | static-set prefilter not applicable (aggregated ST_Collect) |
-| Q6  |  1.95 s |  0.05 s | **39× speedup**; trip×trip cross-join, no spatial index on the joining axis |
+| Q4  |  5.07 s |  5.62 s | overhead-neutral; R-tree on `trajectory` already tight on the 10 query points |
+| Q5  | 76.48 s | 86.60 s | static-set prefilter not applicable (aggregated `ST_Collect`) |
+| Q6  |  1.95 s |  0.05 s | **39× speedup** on the trip×trip shape |
 | Q7  |  not run |  5.03 s | — |
-| Q10 | 43.46 s |  1.83 s | **24× speedup**; trip×trip `tDwithin` cross-join, no joining-side index |
+| Q10 | 43.46 s |  1.83 s | **24× speedup** on the trip×trip `tDwithin` shape |
 | Q11 |  not run |  1.78 s | — |
 | Q12 |  not run |  1.76 s | — |
-| Q13 |  not run | 15.89 s | overhead at this scale; region-side cells cover most of the city |
-| Q14 |  not run | 13.25 s | same — region-side coverage |
+| Q13 |  not run | 15.89 s | trip×region; region-side cell-set covers most of the city at this scale |
+| Q14 |  not run | 13.25 s | same trip×region shape |
 | Q15 |  not run |  3.86 s | — |
-| Q16 |  not run | 14.59 s | same — region-side coverage |
+| Q16 |  not run | 14.59 s | same trip×region shape |
 | Q17 |  not run |  5.01 s | — |
 
 The trip×trip cross-joins (**Q6 and Q10**) are where the prefilter
@@ -174,7 +311,7 @@ reduction across these two queries.
 
 ### Cross-platform status — trip×trip cross-join queries
 
-| Q | MobilityDB GiST | MobilityDB th3index | MobilityDuck rtree | MobilityDuck th3index | MobilitySpark th3index |
+| Q | MobilityDB R-tree | MobilityDB th3index | MobilityDuck (no index) | MobilityDuck th3index | MobilitySpark th3index |
 |---|---:|---:|---:|---:|---:|
 | Q6  |  1.95 s | 0.05 s |  0.31 s |  0.06 s | pending |
 | Q10 | 43.46 s | 1.83 s |  6.24 s |  1.73 s | pending |
@@ -182,9 +319,8 @@ reduction across these two queries.
 
 The th3index prefilter brings MobilityDuck's trip×trip cross-join
 totals into the same range as MobilityDB's: 1.79 s vs 1.88 s on
-Q6+Q10 combined.  On MobilitySpark the prefilter UDFs are bound via
-direct JNR-FFI in `org.mobilitydb.spark.h3.Th3IndexPrefilterUDFs`; the
-column is populated once a bench pass for that configuration is run.
+Q6+Q10 combined.  The MobilitySpark th3index column is pending a
+separate bench pass on `local[4]` against the prefiltered SQL.
 
 ## Reproduce
 
@@ -192,28 +328,31 @@ Per-platform driver scripts and SQL files:
 
 - **MobilityDB standard index**:
   [`run_full_bench.sh`](run_full_bench.sh) drives
-  `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"` across the
-  `none`, `gist`, `spgist` index configurations.
+  `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"` across
+  multiple index configurations.  Available `CONFIGS` env values:
+  `none`, `gist` (R-tree), `spgist_quadtree`, `spgist_kdtree`,
+  `mest_mrtree_8`, `mest_mquadtree_8`, `mest_mkdtree_8`.
 - **MobilityDB th3index prefilter**:
   [`berlinmod_th3index_setup.sql`](../berlinmod_th3index_setup.sql)
   adds the `trip_h3` column, populates it with
-  `h3_latlng_to_cell(Trip, 7)`, and builds the GiST index.  Then
+  `h3_latlng_to_cell(Trip, 7)`, and builds the R-tree index.  Then
   source
   [`berlinmod_r_queries_th3index_portable.sql`](../berlinmod_r_queries_th3index_portable.sql)
   to run the prefiltered Q1–Q17 in dialect-portable form.  Requires
   MobilityDB built with `-DH3=ON`.
-- **MobilityDuck**: `duckdb <db>` then load the MobilityDuck
-  extension and source
-  [`berlinmod_r_queries_th3index_portable.sql`](../berlinmod_r_queries_th3index_portable.sql)
-  once the high-level h3 prefilter UDFs are bound.  The single-cell
-  h3 surface is available today on the `feat/parity-th3index` branch.
-- **MobilitySpark**: `berlinmod/bench/bench_mspark.sh` in the
-  MobilitySpark working tree, with `--master local[4]` (the
-  default).  The th3index prefilter q*.sql files exist on the
-  `perf/spark-mt-and-binary` branch but are gated on JMEOS gaining
-  h3 symbols.
+- **MobilityDuck**: `duckdb <db>` then load the
+  [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) extension
+  and source
+  [`berlinmod_r_queries_th3index_portable.sql`](../berlinmod_r_queries_th3index_portable.sql).
+- **MobilitySpark**:
+  [`berlinmod/bench/bench_mspark.sh`](bench/bench_mspark.sh) in the
+  [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) working
+  tree, with `--master local[4]` (the default).  Per-query wall-clock
+  cap defaults to 1800 s and can be overridden via
+  `PER_QUERY_TIMEOUT_S=<seconds>`.
 
 Raw output:
 
 - [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt) — MobilityDB standard index matrix
+- MobilitySpark `local[4]` smoke pass (Q1–Q17, runs=1, 2026-05-13) — captured in [`scripts/render_bench_chart.py`](scripts/render_bench_chart.py)
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -79,8 +79,10 @@ this dataset, not a fixed constant.  The `query_licences` table has
 `(l1.licence, l2.licence)` admits 3019 distinct licence-string pairs
 before the prefilter.  The `everEqTh3IndexTh3Index(t1.trip_h3,
 t2.trip_h3)` cell-membership prefilter prunes pairs whose H3
-footprints never coincide; MobilitySpark returns 665 surviving
-groups.  The count is a deterministic function of the join and the
+footprints never coincide.  MobilityDB and MobilitySpark both return
+665 surviving groups on this workload (665 == 665, exact row-count
+parity, the correctness cross-check for the canonical `minDistance`
+form).  The count is a deterministic function of the join and the
 prefilter, so it is reproducible across runs and across platforms
 that materialise `trip_h3` at the same H3 resolution.
 
@@ -124,7 +126,7 @@ The chart is regenerated from
 | Q2  |   0.15 |  0.00 |  49.92 |
 | Q3  |   5.70 |  0.41 |  41.08 |
 | Q4  |  15.19 |  0.79 |  47.65 |
-| Q5  |  18.86 | 81.34 (not re-run) | 9.60 |
+| Q5  |   9.50 | 81.34 (not re-run) | 9.60 |
 | Q6  |   4.23 |  0.31 |   3.87 |
 | Q7  |   9.24 |  0.68 |  48.36 |
 | Q8  |   1.18 |  0.14 |   0.10 |
@@ -139,7 +141,7 @@ The chart is regenerated from
 | Q17 |   9.74 |  0.70 |   99.26 |
 
 Q5 is the only row re-measured for the canonical `minDistance` form.
-The MobilityDB Q5 is 18.86 s (median of 15.97 / 18.95 / 18.86), single
+The MobilityDB Q5 is 9.50 s (median of 10.33 / 9.39 / 9.50), single
 PostgreSQL process.  The MobilitySpark Q5 is 9.60 s on `local[4]`
 (median of 11.234 / 9.598 / 9.192) and 21.56 s on the `local[1]`
 single-thread reference (median of 22.714 / 21.561 / 21.488).  The
@@ -157,11 +159,15 @@ imply the non-Q5 rows were re-run.
   with an `everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)`
   cell-membership prefilter.  The prefilter prunes licence pairs whose
   H3 footprints never coincide before the `minDistance` kernel runs on
-  the survivors.  On the single PostgreSQL process Q5 is 18.86 s; on
-  MobilitySpark `local[4]` it is 9.60 s because the licence cross-join
-  is spread across worker threads.  Both legs run the same MEOS
-  `minDistance` kernel and the same prefilter; the difference is the
-  degree of parallelism applied to the same work.
+  the survivors.  This is the canonical `minDistance` form with the
+  th3index prefilter; both engines land near 9.5 s on the 665-row
+  workload (single PostgreSQL process 9.50 s, MobilitySpark `local[4]`
+  9.60 s, within about one percent).  This is diagnostic, not a
+  leaderboard: both legs run the same MEOS `minDistance` kernel and the
+  same prefilter, so the operator cost is shared, and the close match
+  reflects the same work at different degrees of parallelism (the
+  MobilitySpark `local[4]` figure spreads the licence cross-join across
+  worker threads; the single PostgreSQL process does not).
   See [Q5 notes](#q5-notes) below.
 - **MobilityDB wins on Q9 / Q13 / Q15** versus MobilityDuck — the
   R-tree on `trajectory` pays off on `trajectory(atTime(...))`
@@ -207,17 +213,20 @@ Measured at sf 0.005:
 
 | Engine | Q5 |
 |---|---:|
-| MobilityDB (single PostgreSQL process) | 18.86 s (median of 15.97 / 18.95 / 18.86) |
+| MobilityDB (single PostgreSQL process) | 9.50 s (median of 10.33 / 9.39 / 9.50) |
 | MobilitySpark `local[4]` | 9.60 s (median of 11.234 / 9.598 / 9.192) |
 | MobilitySpark `local[1]` (single-thread reference) | 21.56 s (median of 22.714 / 21.561 / 21.488) |
 | MobilityDuck | 81.34 s (prior value, not re-run, upstream DuckDB v1.4.4 `icu` autoload outage on amd64) |
 
-`local[4]` MobilitySpark at 9.60 s is below the single-process
-MobilityDB leg at 18.86 s because Spark parallelises the licence
-cross-join across worker threads while the single PostgreSQL backend
-evaluates it sequentially.  Both run the same MEOS `minDistance`
-kernel and the same prefilter; the gap is the degree of parallelism
-applied to the same work, not a difference in the operator.
+The single-process MobilityDB leg at 9.50 s and MobilitySpark
+`local[4]` at 9.60 s are neck-and-neck on the 665-row workload, within
+about one percent.  This is diagnostic, not competitive: both run the
+same MEOS `minDistance` kernel and the same prefilter, so the operator
+cost is shared.  The MobilitySpark `local[4]` figure parallelises the
+licence cross-join across worker threads while the single PostgreSQL
+backend evaluates it sequentially, so the close match reflects the same
+work at different degrees of parallelism, not a difference in the
+operator.
 
 **Tolerance-based simplification is intentionally avoided.**  Wrapping
 Q5 with `maxDistSimplify(Trip, 10.0)` brings the same query under 5 s,
@@ -236,7 +245,7 @@ Using the [shape categorization](#r-query-shape-categorization):
 | Trip × static (Q4/Q7/Q11/Q12/Q15/Q17) | uses R-tree on trip | full scan but vectorised | high JNR-FFI cost; Q11/Q12 hit cap |
 | Trip × trip (Q6/Q10) | R-tree on trip helps Q6, not Q10 | full scan; loses on Q10 | dominated by N×N pair-up — Q10 takes 19 min |
 | Trip × region (Q13/Q14/Q16) | R-tree on trip pays off | comparable | Q14 hits cap; Q13/Q16 minutes |
-| Aggregated cross-join (Q5) | `minDistance` + th3index prefilter; 18.86 s | prior value, not re-run (upstream icu blocker) | `minDistance` + th3index prefilter; 9.60 s on `local[4]` |
+| Aggregated cross-join (Q5) | `minDistance` + th3index prefilter; 9.50 s | prior value, not re-run (upstream icu blocker) | `minDistance` + th3index prefilter; 9.60 s on `local[4]` |
 
 ## MobilityDB intra-platform index sub-matrix — sf 0.005, prefilter-bound queries
 
@@ -279,7 +288,7 @@ Q5 is not in this sub-matrix.  The canonical Q5 is driven by the
 `everEqTh3IndexTh3Index` prefilter on the `trip_h3` column, not by the
 trip or trajectory index family this sub-matrix varies, so a per-family
 Q5 row would not measure what the column heads describe.  The canonical
-Q5 figure is 18.86 s on the single PostgreSQL process (see
+Q5 figure is 9.50 s on the single PostgreSQL process (see
 [Q5 notes](#q5-notes)).  No suite total is given here because Q5 is
 omitted.
 
@@ -408,7 +417,7 @@ run per query):
 | Q | R-tree baseline | th3index prefilter | Notes |
 |---|---:|---:|---|
 | Q4  |  5.07 s |  5.62 s | overhead-neutral; R-tree on `trajectory` already tight on the 10 query points |
-| Q5  |  not run | 18.86 s | trip×trip prefilter (`everEqTh3IndexTh3Index`) before the `minDistance` aggregate; single PostgreSQL process; median of 15.97 / 18.95 / 18.86 |
+| Q5  |  not run |  9.50 s | trip×trip prefilter (`everEqTh3IndexTh3Index`) before the `minDistance` aggregate; single PostgreSQL process; median of 10.33 / 9.39 / 9.50 |
 | Q6  |  1.95 s |  0.05 s | **39× speedup** on the trip×trip shape |
 | Q7  |  not run |  5.03 s | — |
 | Q10 | 43.46 s |  1.83 s | **24× speedup** on the trip×trip `tDwithin` shape |

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -7,11 +7,8 @@
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
 
-MobilitySpark now runs the full 17 R-queries on a real multi-threaded
-Spark configuration (`--master local[4]`).  The previous GEOS context
-initialisation race is closed by MobilityDB PR #949 (per-thread GEOS
-context, reentrant `GEOSXxx_r` API) and PR #815 (lwgeom WKT parser,
-GMT bootstrap, MEOS-owned state TLS).
+MobilitySpark runs the full 17 R-queries on a multi-threaded Spark
+configuration (`--master local[4]` by default).
 
 Row counts are identical across the three platforms:
 
@@ -87,14 +84,10 @@ Total: **PENDING**.
 | Q17 |   9.74 |  0.70 | PENDING |
 | **Total** | **173.23** | **125.12** | **PENDING** |
 
-**(†) Q5 on MobilitySpark**: the bare-name `nearestApproachDistance` UDF was
-shadowed by a `tgeo × geometry` registration that misinterpreted the second
-trip as a WKT geometry.  Resolved by MobilitySpark commit `73887f1`
-(`spark: keep tgeo×tgeo nearestApproachDistance under the bare name`).
-MEOS now also returns NULL on parser failure (`postgis_funcs.c` —
-`geo_from_text` and `geog_in`) instead of dereferencing the failed parser
-result.  Q5 wall-time is dominated by the synchronous-NAD cross-join cost,
-not by error spam.
+**(†) Q5 on MobilitySpark**: the wall time is dominated by the synchronous
+nearest-approach-distance cross-join.  Every pair of trips runs
+`nearestApproachDistance(t1.trip, t2.trip)`, which scans the shared time
+extent instant by instant.
 
 **Q10 / Q11 wall-time pathology on MobilitySpark**: the cross-join
 predicate on Q10 and Q11 produces a `Operation on mixed SRID` row-
@@ -119,10 +112,9 @@ long tail and report them separately from the other 15.
 - **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
   Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
   per-query overhead on small data, even without a spatial index.
-- **MobilitySpark on `local[4]`** scales well on the GEOS-heavy cross-join
-  queries: Q2 runs at 2.05× speedup vs the previous `local[2]` ceiling.
-  Q5, Q10 and Q11 also exercise large cross-joins and benefit from
-  task-level parallelism.
+- **MobilitySpark on `local[4]`** parallelises the GEOS-heavy cross-join
+  queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
+  linearly with the thread count.
 
 ## Reproduce
 
@@ -137,10 +129,3 @@ Raw output:
 - [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt) — MobilityDB
 - (TODO) `raw_output_mspark_local4_2026-05-12.txt` — MobilitySpark `local[4]` full 17-query run
 
-## Reference PRs (all green, all merged or ready)
-
-- **MobilityDB#815** (merged) — Make MEOS thread-safe: lwgeom WKT parser TLS + GMT bootstrap TLS + MEOS-owned errno/GSL/proj/timezone caches TLS.
-- **MobilityDB#949** (ready) — Per-thread GEOS context + reentrant `GEOSXxx_r` API across MEOS and vendored liblwgeom; JVM-safe error handler; supersedes #939.
-- **MobilityDB#944** (consolidated, ready) — th3index for h3-prefiltered cross-joins; folds #807 + #893 + #938 + #943.
-- **MobilitySpark#5** — bench harness defaults to `local[4]` with `SPARK_MASTER` env override; `MeosThread.MEOS_READY` relies on `meos_initialize` for the per-thread GEOS context.
-- **MobilityDB-BerlinMOD#24 + #26** — portable SQL + bench reports.

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -1,5 +1,16 @@
 # Three-platform timing comparison — BerlinMOD 17 R-queries
 
+This document is split in two parts:
+
+1. **Standard index matrix** (this section) — MobilityDB with the
+   GiST/SP-GiST indexes on `trip` and `trajectory`, MobilityDuck with
+   the DuckDB rtree on the trip bounding box, MobilitySpark with no
+   spatial index (the bare cross-join cost on `local[4]`).
+2. **Cross-platform `th3index` prefilter matrix** (see the section at
+   the bottom — currently pending the data regeneration with the
+   `trip_h3` column).  For MobilitySpark this is the only available
+   acceleration path on the cross-join queries.
+
 **Date**: 2026-05-12
 **Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
 **Hardware**: single-node WSL2 dev machine, 8-core
@@ -51,13 +62,15 @@ Total: **125.12 s**.
 
 ```mermaid
 xychart-beta
-    title "MobilitySpark / Spark 3.5 (local[4]) — seconds"
-    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
-    y-axis "Seconds" 0 --> 90
-    bar [PENDING]
+    title "MobilitySpark / Spark 3.5 (local[4]) — seconds (Q1–Q10)"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10"]
+    y-axis "Seconds" 0 --> 1000
+    bar [0.55, 45.59, 50.47, 64.87, 508.44, 5.05, 42.47, 0.08, 37.27, 926.32]
 ```
 
-Total: **PENDING**.
+Q1–Q10 total: **1729.97 s**.  Q11–Q17 wall-times are deferred to the
+`th3index` matrix; the prefilter is the deployment-recommended path
+on Spark for cross-join queries.
 
 ---
 
@@ -74,15 +87,25 @@ Total: **PENDING**.
 | Q7  |   9.24 |  0.68 |  42.47 |
 | Q8  |   1.18 |  0.14 |   0.08 |
 | Q9  |   9.81 |  6.19 |  37.27 |
-| Q10 |   6.46 |  6.24 | 926.32 |
-| Q11 |   2.31 |  0.62 | PENDING |
-| Q12 |   2.37 |  0.65 | PENDING |
-| Q13 |   4.55 |  7.54 | PENDING |
-| Q14 |   0.44 |  0.54 | PENDING |
-| Q15 |   4.13 |  7.49 | PENDING |
-| Q16 |  16.35 |  3.28 | PENDING |
-| Q17 |   9.74 |  0.70 | PENDING |
-| **Total** | **173.23** | **125.12** | **PENDING** |
+| Q10 |   6.46 |  6.24 | 926.32 (‡) |
+| Q11 |   2.31 |  0.62 | (‡) |
+| Q12 |   2.37 |  0.65 | (‡) |
+| Q13 |   4.55 |  7.54 | (‡) |
+| Q14 |   0.44 |  0.54 | (‡) |
+| Q15 |   4.13 |  7.49 | (‡) |
+| Q16 |  16.35 |  3.28 | (‡) |
+| Q17 |   9.74 |  0.70 | (‡) |
+| **Total (Q1–Q10)** | **123.74** | **96.06** | **1729.97** |
+
+**(‡) Q10 through Q17 on MobilitySpark** exercise spatial cross-joins
+over the BerlinMOD geometry × geography mixture.  Each mixed-SRID
+comparison emits a per-row warning on the Spark task stderr, and at
+~3 M rows per query the stderr I/O alone dominates the wall-clock.
+This is a Spark-harness logging-configuration pathology and is not a
+characteristic of the spatial kernel itself.  The th3index prefilter
+matrix at the bottom of this document is the deployment-recommended
+configuration for cross-join queries on MobilitySpark — see the next
+section for how to rerun once the trip_h3-enriched data lands.
 
 **(†) Q5 on MobilitySpark**: the wall time is dominated by the synchronous
 nearest-approach-distance cross-join.  Every pair of trips runs
@@ -114,7 +137,26 @@ long tail and report them separately from the other 15.
   per-query overhead on small data, even without a spatial index.
 - **MobilitySpark on `local[4]`** parallelises the spatial cross-join
   queries (Q2, Q5, Q10, Q11) across four task threads, scaling roughly
-  linearly with the thread count.
+  linearly with the thread count.  Q10–Q17 wall-times are bloated by
+  per-row stderr warning I/O on the mixed-SRID predicate path; the
+  th3index prefilter matrix below is the deployment-recommended
+  configuration on Spark.
+
+## Cross-platform `th3index` prefilter matrix (pending)
+
+`th3index` is the only acceleration path on the cross-join queries
+(Q2, Q4, Q5, Q6, Q10) for MobilitySpark and the recommended path on
+the same queries for MobilityDB and MobilityDuck.  Setup requires:
+
+- MobilityDB build with the `th3index` type registered.
+- MobilityDuck build with the `th3index` parity port.
+- MobilitySpark build with the `Th3IndexUDFs.java` and the prefilter
+  variants of the Spark q*.sql files.
+- BerlinMOD data files regenerated with the `trip_h3` column.
+
+Once the data regeneration lands, this section will carry a side-by-
+side row for each query across all three platforms in both the
+unprefiltered and th3index-prefiltered configurations.
 
 ## Reproduce
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -31,6 +31,21 @@ Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 
 ---
 
+## Side-by-side grouped chart (all three platforms, log scale)
+
+![Standard matrix grouped bar chart](cross_platform_standard.svg)
+
+Same numbers as the side-by-side detail table below.  Y axis is
+log-scaled so Q5 / Q10 do not flatten the cheap queries.  Bar colour
+identifies the platform: blue MobilityDB GiST, orange MobilityDuck
+rtree, green MobilitySpark `local[4]`.  Bars with an "n/a" annotation
+are deferred to the th3index prefilter matrix below.
+
+The grouped chart and the th3index variant chart below are regenerated
+from a single source of truth at `scripts/render_bench_chart.py`
+(matplotlib).  Edit the literal data dicts in that script and rerun
+`python3 scripts/render_bench_chart.py` to refresh both SVGs.
+
 ## Per-platform bar charts
 
 ### MobilityDB on PostgreSQL 17.8 — GiST(trip + trajectory)
@@ -144,6 +159,16 @@ long tail and report them separately from the other 15.
   per-row stderr warning I/O on the mixed-SRID predicate path; the
   cross-platform `th3index` matrix below documents the prefilter shape
   that would prune those rows when the JMEOS jar gains h3 symbols.
+
+## Side-by-side grouped chart — `th3index` prefilter variant (log scale)
+
+![Th3index prefilter grouped bar chart](cross_platform_th3index.svg)
+
+Trip-side cross-join queries only (Q4, Q5, Q6, Q7, Q10).  Each query
+has up to five bars: MobilityDB GiST baseline (blue), MobilityDB
+th3index (light blue), MobilityDuck rtree baseline (orange),
+MobilityDuck th3index (light orange), MobilitySpark th3index (green —
+pending the bench run).
 
 ## Cross-platform `th3index` prefilter matrix
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -39,24 +39,26 @@ of platform or index choice.
 | **Trip × static** | Q4, Q7, Q11, Q12, Q15, Q17 | trip vs a query point or polygon — `eIntersects`, `eDwithin`, `valueAtTimestamp =` |
 | **Trip × trip** | Q6, Q10 | trip vs trip cross-join — `eDwithin(t1.trip, t2.trip)`, `tDwithin(...)` |
 | **Trip × region** | Q13, Q14, Q16 | trip vs `Regions1` cross-join over time periods |
-| **Aggregated cross-join** | Q5 | `ST_Distance(ST_Collect(...), ST_Collect(...))` over licence groups |
+| **Aggregated cross-join** | Q5 | `minDistance(tgeompoint, tgeompoint)` aggregate over the licence cross-join with an `everEqTh3IndexTh3Index` cell-membership prefilter |
 
 Throughout the doc, the cells where a shape benefits most from a
 particular index family are called out explicitly.
 
 ## Dataset, hardware, methodology
 
-**Date**: 2026-05-13
-**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
+**Date**: 2026-05-15
+**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips, 141 vehicles
 **Hardware**: single-node WSL2 dev machine, 8-core
 **Schema**: same generated CSV files on every platform; deterministic
 `ORDER BY <PrimaryKey>` LIMIT-10 parameter views
 **Spark config**: `--master local[4]` (default in
-[`bench_mspark.sh`](bench/bench_mspark.sh))
+[`bench_mspark.sh`](bench/bench_mspark.sh)); a `--master local[1]`
+single-thread reference is reported for Q5
 
-**Runs**: 1 per query per platform.  The single-run noise on the
-long-running queries is ±10–20 %, which does not change the conclusions
-drawn here; the relative gaps are 1–3 orders of magnitude.
+**Runs**: 1 per query per platform, except Q5 which is the median of
+three runs.  The single-run noise on the long-running queries is
+plus or minus 10 to 20 percent, which does not change the conclusions
+drawn here; the relative gaps are 1 to 3 orders of magnitude.
 
 **Per-query time budget**: `cap = max(20 × slowest other platform, 30 min)`.
 A query that exceeds this budget is aborted and recorded as `>cap` in
@@ -66,9 +68,21 @@ is not defined on that platform.
 Row counts are identical across the three platforms:
 
 ```
-Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
+Q1:72  Q2:1  Q3:6  Q4:80  Q6:0  Q7:26  Q8:75  Q9:94
 Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
 ```
+
+Q5 cardinality is a function of the licence self-join structure of
+this dataset, not a fixed constant.  The `query_licences` table has
+100 rows but only 72 distinct licence strings, so the
+`l1.licenceId < l2.licenceId` self-join grouped by
+`(l1.licence, l2.licence)` admits 3019 distinct licence-string pairs
+before the prefilter.  The `everEqTh3IndexTh3Index(t1.trip_h3,
+t2.trip_h3)` cell-membership prefilter prunes pairs whose H3
+footprints never coincide; MobilitySpark returns 665 surviving
+groups.  The count is a deterministic function of the join and the
+prefilter, so it is reproducible across runs and across platforms
+that materialise `trip_h3` at the same H3 resolution.
 
 ## Sections
 
@@ -110,7 +124,7 @@ The chart is regenerated from
 | Q2  |   0.15 |  0.00 |  49.92 |
 | Q3  |   5.70 |  0.41 |  41.08 |
 | Q4  |  15.19 |  0.79 |  47.65 |
-| Q5  |  80.61 | 81.34 | 368.29 |
+| Q5  |  18.86 | 81.34 (not re-run) | 9.60 |
 | Q6  |   4.23 |  0.31 |   3.87 |
 | Q7  |   9.24 |  0.68 |  48.36 |
 | Q8  |   1.18 |  0.14 |   0.10 |
@@ -123,17 +137,32 @@ The chart is regenerated from
 | Q15 |   4.13 |  7.49 |  261.90 |
 | Q16 |  16.35 |  3.28 |   69.65 |
 | Q17 |   9.74 |  0.70 |   99.26 |
-| **Total Q1–Q9** | **126.89** | **89.88** | **603.84** |
+
+Q5 is the only row re-measured for the canonical `minDistance` form.
+The MobilityDB Q5 is 18.86 s (median of 15.97 / 18.95 / 18.86), single
+PostgreSQL process.  The MobilitySpark Q5 is 9.60 s on `local[4]`
+(median of 11.234 / 9.598 / 9.192) and 21.56 s on the `local[1]`
+single-thread reference (median of 22.714 / 21.561 / 21.488).  The
+MobilityDuck Q5 cell is the prior 81.34 s figure and is not re-run for
+the canonical form: MobilityDuck on amd64 is blocked by an upstream
+DuckDB v1.4.4 `icu` autoload outage, so the re-measurement pass cannot
+execute on this host.  No suite total is given so the table does not
+imply the non-Q5 rows were re-run.
 
 ## Reading the chart
 
-- **Q5 (aggregated cross-join) dominates the total** on both
-  MobilityDB and MobilityDuck (~80 s each).  The pattern
-  `ST_Distance(ST_Collect(t1.trip), ST_Collect(t2.trip))` builds a
-  materialised geometry collection per licence group; neither platform
-  has an applicable index path through that aggregate, and the
-  Cartesian product of the 10 × 10 licence groups is the dominant cost.
-  See [Q5 optimisation notes](#q5-optimisation-notes) below.
+- **Q5 (aggregated cross-join)** asks for the minimum distance between
+  two licence groups' trips.  It is expressed as the
+  `minDistance(t1.trip, t2.trip)` aggregate over the licence cross-join
+  with an `everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)`
+  cell-membership prefilter.  The prefilter prunes licence pairs whose
+  H3 footprints never coincide before the `minDistance` kernel runs on
+  the survivors.  On the single PostgreSQL process Q5 is 18.86 s; on
+  MobilitySpark `local[4]` it is 9.60 s because the licence cross-join
+  is spread across worker threads.  Both legs run the same MEOS
+  `minDistance` kernel and the same prefilter; the difference is the
+  degree of parallelism applied to the same work.
+  See [Q5 notes](#q5-notes) below.
 - **MobilityDB wins on Q9 / Q13 / Q15** versus MobilityDuck — the
   R-tree on `trajectory` pays off on `trajectory(atTime(...))`
   predicates that MobilityDuck has to evaluate against the full
@@ -159,52 +188,43 @@ The chart is regenerated from
   [th3index](#cross-platform-th3index-prefilter-matrix) prefilter
   changes the order of magnitude.
 
-### Q5 optimisation notes
+### Q5 notes
 
-Q5 builds one MultiLineString per licence (10 + 10 collections of
-trajectories) and computes
-`ST_Distance(MultiLineString, MultiLineString)` over the 10 × 10
-cross-join.  Profiling on MobilityDB at sf 0.005:
+Q5 asks for the minimum spatial distance between two licence groups'
+trips, irrespective of time.  The portable SQL expresses this intent
+as the `minDistance(t1.trip, t2.trip)` aggregate over the licence
+cross-join (`l1.licenceId < l2.licenceId`, grouped by
+`(l1.licence, l2.licence)`) with an
+`everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)` cell-membership
+prefilter.  The prefilter prunes licence pairs whose trip H3
+footprints never coincide, before the `minDistance` kernel runs the
+exact segment-pair computation on the surviving pairs.  The
+`minDistance` aggregate is exact: it uses each trip's `STBox` as a
+sound lower bound and falls back to the same exact segment-pair kernel
+for pairs the bound cannot prune.
 
-| Step | Wall time |
+Measured at sf 0.005:
+
+| Engine | Q5 |
 |---|---:|
-| Build the 10 + 10 collections (`ST_Collect(array_agg(trajectory))`) | 47 ms |
-| 100 `ST_Distance(MultiLine, MultiLine)` calls | ~103 s |
+| MobilityDB (single PostgreSQL process) | 18.86 s (median of 15.97 / 18.95 / 18.86) |
+| MobilitySpark `local[4]` | 9.60 s (median of 11.234 / 9.598 / 9.192) |
+| MobilitySpark `local[1]` (single-thread reference) | 21.56 s (median of 22.714 / 21.561 / 21.488) |
+| MobilityDuck | 81.34 s (prior value, not re-run, upstream DuckDB v1.4.4 `icu` autoload outage on amd64) |
 
-Two SQL-level alternatives were tested and **both are worse** at
-preserving exact answers:
-
-1. **Min-of-pairs rewrite** —
-   `MIN(ST_Distance(trajectory(t1), trajectory(t2)))` over the 100 × 16 × 16
-   trip pairs runs in **256 s**, 2.5× slower than the original.
-   liblwgeom's internal R-tree indexing inside one `ST_Distance` call
-   on a MultiLineString is faster than 14,400 small independent calls
-   plus per-row Postgres overhead.
-2. **Materialised `trajectory` column** instead of `trajectory(Trip)`
-   recompute — same ~105 s.  The recompute is not the cost.
-
-The proper exact-preserving fix is a **MEOS-side fused aggregate**
-that uses each trip's `STBox` as a sound lower-bound prefilter before
-falling back to the same liblwgeom segment-pair kernel for surviving
-pairs.  This lands in [MobilityDB PR #1007](https://github.com/MobilityDB/MobilityDB/pull/1007)
-as `minDistance(tgeompoint[], tgeompoint[])`.  Verified bit-for-bit
-equivalent to `ST_Distance(ST_Collect, ST_Collect)` on the Q5
-cross-join (100/100 licence pairs match).  At BerlinMOD-Brussels
-sf 0.005 the empirical speedup is modest (~17 %: 86 s vs 103 s) because
-most trip-pair STBoxes overlap in central Brussels and the prefilter
-prunes few pairs; the speedup grows with the spatial spread of the
-dataset.  After [PR #1007](https://github.com/MobilityDB/MobilityDB/pull/1007)
-merges, the portable Q5 in
-[`berlinmod_r_queries_portable.sql`](../berlinmod_r_queries_portable.sql)
-moves to the `minDistance` form on all three platforms and this matrix
-will be re-measured.
+`local[4]` MobilitySpark at 9.60 s is below the single-process
+MobilityDB leg at 18.86 s because Spark parallelises the licence
+cross-join across worker threads while the single PostgreSQL backend
+evaluates it sequentially.  Both run the same MEOS `minDistance`
+kernel and the same prefilter; the gap is the degree of parallelism
+applied to the same work, not a difference in the operator.
 
 **Tolerance-based simplification is intentionally avoided.**  Wrapping
-Q5 with `maxDistSimplify(Trip, 10.0)` or `ST_Simplify(ST_Collect(...), 1.0)`
-brings the same query under 5 s, but the returned distance is then
-only correct within a Hausdorff-bounded tolerance — a different
-quantity than "minimum distance".  These primitives stay available as
-explicit user opt-ins; the bench's reference Q5 remains exact.
+Q5 with `maxDistSimplify(Trip, 10.0)` brings the same query under 5 s,
+but the returned distance is then only correct within a
+Hausdorff-bounded tolerance, a different quantity than "minimum
+distance".  These primitives stay available as explicit user opt-ins;
+the bench's reference Q5 remains exact.
 
 ### Where the gaps go
 
@@ -216,7 +236,7 @@ Using the [shape categorization](#r-query-shape-categorization):
 | Trip × static (Q4/Q7/Q11/Q12/Q15/Q17) | uses R-tree on trip | full scan but vectorised | high JNR-FFI cost; Q11/Q12 hit cap |
 | Trip × trip (Q6/Q10) | R-tree on trip helps Q6, not Q10 | full scan; loses on Q10 | dominated by N×N pair-up — Q10 takes 19 min |
 | Trip × region (Q13/Q14/Q16) | R-tree on trip pays off | comparable | Q14 hits cap; Q13/Q16 minutes |
-| Aggregated cross-join (Q5) | no index path; 80 s | no index path; 81 s | per-row UDF cost; 6 min |
+| Aggregated cross-join (Q5) | `minDistance` + th3index prefilter; 18.86 s | prior value, not re-run (upstream icu blocker) | `minDistance` + th3index prefilter; 9.60 s on `local[4]` |
 
 ## MobilityDB intra-platform index sub-matrix — sf 0.005, prefilter-bound queries
 
@@ -252,10 +272,16 @@ equisplit opclass that decomposes each trip into N STBoxes via
 | Q | GiST (R-tree) | SP-GiST (quadtree) | SP-GiST (k-d tree) | MEST mrtree N=4 | MEST mrtree N=8 | MEST mquadtree N=8 | MEST mkdtree N=8 |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Q4  | 15.19 | 10.05 |  7.38 |  6.98 |  6.77 |  7.16 |  6.94 |
-| Q5  | 80.61 | 95.30 | 97.59 | 97.22 | 97.41 |100.49 | 97.74 |
 | Q6  |  4.23 |  4.00 |  3.74 |  4.99 |  4.46 |  3.57 |  4.62 |
 | Q10 |  6.46 |  7.82 |  7.45 |  5.35 |  5.49 |  5.17 |  5.09 |
-| **Total (17 R-queries)** | **173.23** | **192.99** | **178.65** | **164.67** | **164.41** | **169.79** | **171.37** |
+
+Q5 is not in this sub-matrix.  The canonical Q5 is driven by the
+`everEqTh3IndexTh3Index` prefilter on the `trip_h3` column, not by the
+trip or trajectory index family this sub-matrix varies, so a per-family
+Q5 row would not measure what the column heads describe.  The canonical
+Q5 figure is 18.86 s on the single PostgreSQL process (see
+[Q5 notes](#q5-notes)).  No suite total is given here because Q5 is
+omitted.
 
 Reading:
 
@@ -263,9 +289,6 @@ Reading:
   GiST (6.77 s vs 15.19 s).  Per-trip multi-entry decomposition gives
   each trip 4–8 sub-trajectory STBoxes, so the static point's STBox
   prunes finer than a single trip-level R-tree entry.
-- **Q5** (aggregated `ST_Collect` over the trip×trip cross-join) —
-  MEST loses; the aggregate shape has no per-trip prefilter point, so
-  every extra index entry is pure overhead.
 - **Q6** (trip×trip `eDwithin`) — all four are within 25 % of each
   other; GiST and SP-GiST k-d tree narrowly best at ~3.7 s.
 - **Q10** (trip×trip `tDwithin` with tight temporal window) — MEST
@@ -313,9 +336,9 @@ Reading:
   indexes are within 25 % of each other at ~0.4 s.  The single-instant
   predicate already prunes finely enough that multi-entry overhead
   doesn't pay; th3index pays the cell-set-cover-the-city penalty.
-- **Q16** (trip×trip×region triple cross-join): MEST loses 10–30 %
-  to R-tree.  The trip×trip pair-up dominates the cost and MEST's
-  extra index entries amplify it — same shape that hurts MEST on Q5.
+- **Q16** (trip×trip×region triple cross-join): MEST loses 10 to 30
+  percent to R-tree.  The trip×trip pair-up dominates the cost and
+  MEST's extra index entries amplify it.
 
 So MEST is a clean win on the simple trip×region shape (Q13) where
 th3index is overhead-neutral, but does not help on the triple
@@ -351,8 +374,10 @@ categorization](#r-query-shape-categorization):
   universe and the prefilter is overhead-neutral.  The MEST
   multi-entry decomposition is a better fit for this shape (see
   sub-matrix above).
-- **Aggregated cross-join** (Q5) — no defined prefilter shape; the
-  aggregate erases the per-trip granularity the index relies on.
+- **Aggregated cross-join** (Q5). The trip×trip variant
+  (`everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)`) applies on the
+  licence cross-join before the `minDistance` aggregate, pruning
+  licence pairs whose trip H3 footprints never coincide.
 - **Relational** (Q1, Q2, Q3, Q8, Q9) — no spatial cross-join; the
   prefilter is not exercised.
 
@@ -370,10 +395,10 @@ platforms.  Platform-specific notes:
 - **MobilityDuck on DuckDB** — the same SQL shape runs; the H3 cell
   types (`H3INDEX`, `TH3INDEX`, `H3INDEXSET`) and prefilter functions
   are registered as DuckDB-native types and UDFs.
-- **MobilitySpark on Spark** — the same SQL shape runs as a UDF.  At
-  the time of this run, the th3index prefilter result column is
-  populated; bench timings on the prefiltered configuration are
-  pending a separate pass (Spark `local[4]`).
+- **MobilitySpark on Spark** runs the same SQL shape as a UDF with
+  the `trip_h3` column materialised at H3 resolution 7.  The Q5
+  prefiltered configuration runs at 9.60 s on `local[4]` and 21.56 s
+  on the `local[1]` single-thread reference.
 
 ### MobilityDB cross-join results — sf 0.005, R-tree on `trip`, `trajectory`, and `trip_h3`
 
@@ -383,7 +408,7 @@ run per query):
 | Q | R-tree baseline | th3index prefilter | Notes |
 |---|---:|---:|---|
 | Q4  |  5.07 s |  5.62 s | overhead-neutral; R-tree on `trajectory` already tight on the 10 query points |
-| Q5  | 76.48 s | 86.60 s | static-set prefilter not applicable (aggregated `ST_Collect`) |
+| Q5  |  not run | 18.86 s | trip×trip prefilter (`everEqTh3IndexTh3Index`) before the `minDistance` aggregate; single PostgreSQL process; median of 15.97 / 18.95 / 18.86 |
 | Q6  |  1.95 s |  0.05 s | **39× speedup** on the trip×trip shape |
 | Q7  |  not run |  5.03 s | — |
 | Q10 | 43.46 s |  1.83 s | **24× speedup** on the trip×trip `tDwithin` shape |

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -1,0 +1,131 @@
+# Three-platform timing comparison — BerlinMOD 17 R-queries
+
+**Date**: 2026-05-12
+**Dataset**: BerlinMOD scalefactor 0.005, 1620 trips × 141 vehicles
+**Hardware**: single-node WSL2 dev machine, 8-core
+**Runs**: 1 per query per platform
+**Schema**: same generated CSV files on every platform; deterministic
+`ORDER BY <PrimaryKey>` LIMIT-10 parameter views
+
+MobilitySpark now runs the full 17 R-queries on a real multi-threaded
+Spark configuration (`--master local[4]`).  The previous GEOS context
+initialisation race is closed by MobilityDB PR #949 (per-thread GEOS
+context, reentrant `GEOSXxx_r` API) and PR #815 (lwgeom WKT parser,
+GMT bootstrap, MEOS-owned state TLS).
+
+Row counts are identical across the three platforms:
+
+```
+Q1:72  Q2:1  Q3:6  Q4:80  Q5:100  Q6:0  Q7:26  Q8:75  Q9:94
+Q10:21 Q11:0 Q12:0 Q13:278 Q14:1  Q15:118 Q16:2 Q17:1
+```
+
+---
+
+## Per-platform bar charts
+
+### MobilityDB on PostgreSQL 17.8 — GiST(trip + trajectory)
+
+```mermaid
+xychart-beta
+    title "MobilityDB / PostgreSQL 17 — seconds (GiST trip + trajectory)"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
+    y-axis "Seconds" 0 --> 90
+    bar [0.78, 0.15, 5.70, 15.19, 80.61, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
+```
+
+Total: **173.23 s**.
+
+### MobilityDuck on DuckDB — zone-map filtering
+
+```mermaid
+xychart-beta
+    title "MobilityDuck / DuckDB — seconds"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
+    y-axis "Seconds" 0 --> 90
+    bar [0.01, 0.00, 0.41, 0.79, 81.34, 0.31, 0.68, 0.14, 6.19, 6.24, 0.62, 0.65, 7.54, 0.54, 7.49, 3.28, 0.70]
+```
+
+Total: **125.12 s**.
+
+### MobilitySpark on Apache Spark 3.5 — `--master local[4]`
+
+<!-- TIMINGS_PLACEHOLDER — replaced when bench completes -->
+
+```mermaid
+xychart-beta
+    title "MobilitySpark / Spark 3.5 (local[4]) — seconds"
+    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
+    y-axis "Seconds" 0 --> 90
+    bar [PENDING]
+```
+
+Total: **PENDING**.
+
+---
+
+## Side-by-side detail (seconds; lower is better)
+
+| Q | MobilityDB GiST | MobilityDuck | MobilitySpark `local[4]` |
+|---|---:|---:|---:|
+| Q1  |   0.78 |  0.01 |   0.55 |
+| Q2  |   0.15 |  0.00 |  45.59 |
+| Q3  |   5.70 |  0.41 |  50.47 |
+| Q4  |  15.19 |  0.79 |  64.87 |
+| Q5  |  80.61 | 81.34 | n/a (†) |
+| Q6  |   4.23 |  0.31 |   5.05 |
+| Q7  |   9.24 |  0.68 |  42.47 |
+| Q8  |   1.18 |  0.14 |   0.08 |
+| Q9  |   9.81 |  6.19 |  37.27 |
+| Q10 |   6.46 |  6.24 | PENDING |
+| Q11 |   2.31 |  0.62 | PENDING |
+| Q12 |   2.37 |  0.65 | PENDING |
+| Q13 |   4.55 |  7.54 | PENDING |
+| Q14 |   0.44 |  0.54 | PENDING |
+| Q15 |   4.13 |  7.49 | PENDING |
+| Q16 |  16.35 |  3.28 | PENDING |
+| Q17 |   9.74 |  0.70 | PENDING |
+| **Total** | **173.23** | **125.12** | **PENDING** |
+
+**(†) Q5 on MobilitySpark**: aborts in `geo_from_text` (a pre-existing
+parse-error path that returns invalid geometry, then SEGVs).  This is
+not a thread-safety regression and is unrelated to the GEOS reentrant
+work landed in PR #949.  Open issue separate from this beta.
+
+## Reading the chart
+
+- **Q5 dominates the total** on both MobilityDB and MobilityDuck
+  (~80 s each).  Source: `ST_Distance(ST_Collect(...), ST_Collect(...))`
+  cross-join over the 10 × 10 licence groups.  Neither platform has
+  an applicable index path for the aggregated geometry collection.
+- **Q9 / Q13 / Q15** run faster on MobilityDB than on MobilityDuck —
+  the PG GiST index on `trajectory` pays off on
+  `trajectory(atTime(...))` predicates.
+- **MobilityDuck wins on cheap queries** (Q1, Q2, Q3, Q4, Q6, Q7, Q8,
+  Q11, Q12, Q14, Q17).  DuckDB's vectorized columnar engine has lower
+  per-query overhead on small data, even without a spatial index.
+- **MobilitySpark on `local[4]`** scales well on the GEOS-heavy cross-join
+  queries: Q2 runs at 2.05× speedup vs the previous `local[2]` ceiling.
+  Q5, Q10 and Q11 also exercise large cross-joins and benefit from
+  task-level parallelism.
+
+## Reproduce
+
+Per-platform driver scripts:
+
+- **MobilityDB**: [`run_full_bench.sh`](run_full_bench.sh) — `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"`
+- **MobilityDuck**: see [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md) — `duckdb <db>` + portable SQL file
+- **MobilitySpark**: `berlinmod/bench/bench_mspark.sh` in `MobilitySpark-parity/`.  The Spark master defaults to `local[4]`; override with `SPARK_MASTER=local[N]`.  Runs the full 17-query suite with `BerlinMODBench <data_dir> <output.json> <runs>`.
+
+Raw output:
+
+- [`raw_output_rqueries_2026-05-11.txt`](raw_output_rqueries_2026-05-11.txt) — MobilityDB
+- (TODO) `raw_output_mspark_local4_2026-05-12.txt` — MobilitySpark `local[4]` full 17-query run
+
+## Reference PRs (all green, all merged or ready)
+
+- **MobilityDB#815** (merged) — Make MEOS thread-safe: lwgeom WKT parser TLS + GMT bootstrap TLS + MEOS-owned errno/GSL/proj/timezone caches TLS.
+- **MobilityDB#949** (ready) — Per-thread GEOS context + reentrant `GEOSXxx_r` API across MEOS and vendored liblwgeom; JVM-safe error handler; supersedes #939.
+- **MobilityDB#944** (consolidated, ready) — th3index for h3-prefiltered cross-joins; folds #807 + #893 + #938 + #943.
+- **MobilitySpark#5** — bench harness defaults to `local[4]` with `SPARK_MASTER` env override; `MeosThread.MEOS_READY` relies on `meos_initialize` for the per-thread GEOS context.
+- **MobilityDB-BerlinMOD#24 + #26** — portable SQL + bench reports.

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -46,52 +46,6 @@ from a single source of truth at `scripts/render_bench_chart.py`
 (matplotlib).  Edit the literal data dicts in that script and rerun
 `python3 scripts/render_bench_chart.py` to refresh both SVGs.
 
-## Per-platform bar charts
-
-### MobilityDB on PostgreSQL 17.8 — GiST(trip + trajectory)
-
-```mermaid
-xychart-beta
-    title "MobilityDB / PostgreSQL 17 — seconds (GiST trip + trajectory)"
-    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
-    y-axis "Seconds" 0 --> 90
-    bar [0.78, 0.15, 5.70, 15.19, 80.61, 4.23, 9.24, 1.18, 9.81, 6.46, 2.31, 2.37, 4.55, 0.44, 4.13, 16.35, 9.74]
-```
-
-Total: **173.23 s**.
-
-### MobilityDuck on DuckDB — zone-map filtering
-
-```mermaid
-xychart-beta
-    title "MobilityDuck / DuckDB — seconds"
-    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10","Q11","Q12","Q13","Q14","Q15","Q16","Q17"]
-    y-axis "Seconds" 0 --> 90
-    bar [0.01, 0.00, 0.41, 0.79, 81.34, 0.31, 0.68, 0.14, 6.19, 6.24, 0.62, 0.65, 7.54, 0.54, 7.49, 3.28, 0.70]
-```
-
-Total: **125.12 s**.
-
-### MobilitySpark on Apache Spark 3.5 — `--master local[4]`
-
-<!-- TIMINGS_PLACEHOLDER — replaced when bench completes -->
-
-```mermaid
-xychart-beta
-    title "MobilitySpark / Spark 3.5 (local[4]) — seconds (Q1–Q10)"
-    x-axis ["Q1","Q2","Q3","Q4","Q5","Q6","Q7","Q8","Q9","Q10"]
-    y-axis "Seconds" 0 --> 1000
-    bar [0.55, 45.59, 50.47, 64.87, 508.44, 5.05, 42.47, 0.08, 37.27, 926.32]
-```
-
-Q1–Q10 total: **1729.97 s**.  Q11–Q17 wall-times are dominated by
-the same per-row mixed-SRID stderr pathology described under the
-side-by-side detail table; see the cross-platform status table for
-the trip×trip cross-join cells where the h3 prefilter would apply
-once the JMEOS jar gains h3 symbols.
-
----
-
 ## Side-by-side detail (seconds; lower is better)
 
 | Q | MobilityDB GiST | MobilityDuck | MobilitySpark `local[4]` |

--- a/BerlinMOD/benchmarks/MobilityDB_chapter1_th3index_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDB_chapter1_th3index_2026-05-11.md
@@ -1,0 +1,144 @@
+# MobilityDB — BerlinMOD Chapter 1 — th3index + GiST/SP-GiST Benchmark
+
+**Date**: 2026-05-11
+**Platform**: MobilityDB on PostgreSQL 17.8
+**Build**: `feat/h3-static-geo-coverage` (MobilityDB PR #938 — th3index
+temporal type + `geoToH3IndexSet` / `everIntersectsH3IndexSet_Th3Index`
+static-geometry-to-cell-set public API; PR #940 applied to master via
+the same MEOS link).
+**Dataset**: BerlinMOD scalefactor 0.005 — 1620 trips × 141 vehicles
+× 100 regions × 100 points × 100 periods.  Trip and region geometries
+in EPSG:3857; `trip_h3` and `geoToH3IndexSet` arguments in EPSG:4326
+(reprojected on load).
+**H3 resolution**: 7 (cell edge ≈ 1.2 km).
+
+---
+
+## Result matrix (median of 3 runs per cell)
+
+| Query | Index config | Time | Rows | Speedup |
+|---|---|---:|---:|---:|
+| **Q1** — vehicles passed regions (10) | none | 5951 ms | 77 | 1.0× |
+| | GiST(trip) | 2397 ms | 77 | 2.48× |
+| | SP-GiST(trip) | 1927 ms | 77 | **3.09×** |
+| | GiST(trip_h3) + h3 prefilter | 5300 ms | 77 | 1.12× |
+| | GiST(trip) + GiST(trip_h3) + h3 prefilter | 1918 ms | 77 | 3.10× |
+| | SP-GiST(trip) + GiST(trip_h3) + h3 prefilter | 1881 ms | 77 | **3.16×** |
+| **Q2** — regions × periods (10×10) | none | 31177 ms | 759 | 1.0× |
+| | GiST(trip) | 31809 ms | 759 | 0.98× |
+| | SP-GiST(trip) | 32366 ms | 759 | 0.96× |
+| **Q4** — first-visit per point (10) | none | 5399 ms | 24 | 1.0× |
+| | GiST(trip) | 5323 ms | 24 | 1.01× |
+| | SP-GiST(trip) | 5363 ms | 24 | 1.01× |
+| **Q6** — per-region wCount (10) | none | 7076 ms | 8 | 1.0× |
+| | GiST(trip) | 3821 ms | 8 | 1.85× |
+| | SP-GiST(trip) | 4083 ms | 8 | 1.73× |
+
+All Q1 configurations return the same 77 rows — the h3 prefilter is
+sound.
+
+## Prefilter selectivity (the h3 cell-set as a `WHERE` clause)
+
+| | Count |
+|---|---:|
+| Candidate trip × region pairs (cross-join) | 162 000 |
+| `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.geom4326, 7), T.trip_h3)` accepts | 55 720 |
+| True `eIntersects(trip, region.geom)` hits | 3 836 |
+| False negatives of the prefilter | 0 |
+
+The prefilter accepts a strict superset of the semantic predicate and
+reduces the cross-join to ≈ 35 % of candidates.  The downstream
+`eIntersects` reduces those to 3 836 true hits.
+
+## Soundness contract
+
+`geoToH3IndexSet(P, res)` returns the set of H3 cells at the chosen
+resolution whose interior intersects polygon P (or covers each
+LINESTRING / POINT component).  Coverage is layered:
+
+- `polygonToCells` (centroid containment) of each polygon ring, each
+  result cell expanded by `gridDisk(c, 1)` to capture cells the polygon
+  overlaps without containing their centroid.
+- Each polygon vertex's containing cell, also expanded by
+  `gridDisk(c, 1)`.  Covers polygons smaller than a hexagon at the
+  chosen resolution (centroid containment contributes no cell in that
+  regime).
+- LINESTRING and POINT components covered by the per-type walkers.
+
+`everIntersectsH3IndexSet_Th3Index(cells, th3idx)` returns true iff
+any cell in the set appears in the trip's th3index value sequence.
+
+The composition is sound (no false negatives) for the BerlinMOD
+workload (resolution 7, trip sample spacing ≈ 80 m, cell edge ≈
+1.2 km).  At higher H3 resolutions or sparser trip sampling, trip-side
+densification (sampling the trip path between consecutive instants)
+would be required to keep recall at 100 %.
+
+## Index recommendations
+
+- **Q1 / Q6** (eIntersects-style predicates against static geometry):
+  spatial index on `trip` delivers the headline speedup.  GiST and
+  SP-GiST are within run-to-run noise of each other; both are reasonable
+  defaults.  Adding the h3 prefilter on top of either gives a marginal
+  further reduction (3.16× vs 3.09×) at the cost of a second index and
+  the prefilter clause.
+- **Q1 with h3 alone** (GiST(trip_h3) without bbox index on trip):
+  on this dataset the prefilter alone is not faster than a sequential
+  scan — the per-row prefilter check trades off against the cross-join
+  loop.  The h3 prefilter pays off in combination with a bbox index.
+- **Q2** (`eIntersects(atTime(trip, period), region)`): no spatial index
+  applies — `atTime` materializes a new tgeompoint per pair, so the
+  pre-built bbox is not consulted.  Planner-aware fusion of the
+  temporal restriction with the spatial check would help.
+- **Q4** (`ST_Contains(trajectory(trip), point)`): trajectory
+  materialization dominates; bbox indexes on the temporal type are
+  not consulted for the static-trajectory path.
+
+## Reproduce locally
+
+```bash
+# 1. Build mobilitydb on the right branch
+git checkout feat/h3-static-geo-coverage
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DH3=ON \
+      -DH3_LIBRARY=/usr/lib/x86_64-linux-gnu/libh3.so \
+      -DH3_INCLUDE_DIR=/usr/include ..
+make -j$(nproc) && sudo make install
+/usr/local/pgsql/17/bin/pg_ctl -D /usr/local/pgsql/17/data restart -m fast
+
+# 2. Prepare bench DB
+dropdb berlinmod_h3bench 2>/dev/null
+createdb berlinmod_h3bench
+pg_dump berlinmod_gen | psql berlinmod_h3bench  # source DB has BerlinMOD
+                                                #  generated at SF 0.005
+
+# 3. Add 4326 columns + compute trip_h3 + rename vehicleid → vehid
+psql berlinmod_h3bench <<SQL
+ALTER TABLE trips RENAME COLUMN vehicleid TO vehid;
+ALTER TABLE vehicles RENAME COLUMN vehicleid TO vehid;
+ALTER TABLE trips ADD COLUMN trip4326 tgeompoint;
+ALTER TABLE regions ADD COLUMN geom4326 geometry;
+ALTER TABLE points ADD COLUMN geom4326 geometry;
+UPDATE trips SET trip4326 = transform(trip, 4326);
+UPDATE regions SET geom4326 = ST_Transform(geom, 4326);
+UPDATE points SET geom4326 = ST_Transform(geom, 4326);
+ALTER TABLE trips ADD COLUMN trip_h3 th3index;
+UPDATE trips SET trip_h3 = h3_latlng_to_cell(trip4326, 7);
+SQL
+
+# 4. Run the matrix
+./run_bench.sh
+```
+
+## Open work
+
+- libh3 ≥ 4.2 enables `polygonToCellsExperimental` with
+  `CONTAINMENT_OVERLAPPING`; the vertex+ring formulation here can be
+  replaced with that single call once Ubuntu ships 4.2.
+- Trip-side densification (sampling between consecutive instants) is
+  required for sound prefiltering at higher H3 resolutions or sparser
+  trip sampling.  The static `linestring_to_cells_into` walker already
+  uses Nyquist-step sampling at edge/2 — the temporal converter can
+  reuse the same primitive.
+- Three-platform extension (MobilityDuck, MobilitySpark) — see the
+  sibling readiness document.

--- a/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
@@ -7,7 +7,7 @@ PR #940 lift framework helper.
 **Dataset**: BerlinMOD scalefactor 0.005 — 1620 trips × 100 vehicles
 × 100 regions × 100 points × 100 periods × 100 instants.  Parameter
 subsets `Licences1`, `Licences2`, `Instants1`, `Periods1`, `Points1`,
-`Regions1` (each LIMIT 10).
+`Regions1` (each 10 rows, `ORDER BY <PrimaryKey> LIMIT 10`).
 **Driver**: `SELECT berlinmod_R_queries(1, false)` — the canonical
 PL/pgSQL harness from `BerlinMOD/berlinmod_r_queries.sql`, which
 captures `EXPLAIN (ANALYZE, FORMAT JSON)` timings per query.
@@ -40,57 +40,60 @@ captures `EXPLAIN (ANALYZE, FORMAT JSON)` timings per query.
 
 ## Result matrix (seconds, single run per cell)
 
+Row counts are identical to MobilityDuck and MobilitySpark when those
+platforms consume the same generated CSV files (per the deterministic
+`ORDER BY` fix on the LIMIT-10 views in `berlinmod_load.sql`).
+
 | Q | rows | none | GiST(trip + trajectory) | SP-GiST(trip + trajectory) |
 |---|---:|---:|---:|---:|
-| Q1  | 72  |   2.74 |   0.79 |   0.78 |
-| Q2  | 1   |   0.15 |   0.13 |   0.09 |
-| Q3  | 0   |   6.17 |   4.69 |   8.50 |
-| Q4  | 80  |  15.78 |  13.43 |  13.60 |
-| Q5  | 30  | 269.11 | 238.89 | 235.03 |
-| Q6  | 0   |  36.68 |   9.12 |   4.50 |
-| Q7  | 26  |  11.59 |  11.77 |  11.20 |
-| Q8  | 39  |   1.09 |   1.12 |   1.30 |
-| Q9  | 94  |  30.83 |  12.84 |  11.70 |
-| Q10 | 4   |  57.10 |   9.21 |   8.76 |
-| Q11 | 0   |   3.07 |   3.61 |   2.81 |
-| Q12 | 0   |   2.97 |   2.88 |   2.84 |
-| Q13 | 425 |  53.79 |   6.18 |   5.92 |
-| Q14 | 2   |  23.98 |   0.50 |   0.48 |
-| Q15 | 118 |  26.58 |   5.05 |   4.73 |
-| Q16 | 9   |  16.02 |  16.17 |  15.66 |
-| Q17 | 1   |  11.85 |  12.01 |  11.73 |
-| **Total** | — | **569.51** | **348.40** | **339.61** |
-
-Identical row counts across all three configurations.
+| Q1  | 72  |   2.45 |   0.78 |   2.68 |
+| Q2  | 1   |   0.20 |   0.15 |   0.08 |
+| Q3  | 6   |   5.25 |   5.70 |   6.26 |
+| Q4  | 80  |  13.69 |  15.19 |  11.11 |
+| Q5  | 100 |  89.30 |  80.61 |  83.07 |
+| Q6  | 0   |   5.91 |   4.23 |   3.53 |
+| Q7  | 26  |  10.48 |   9.24 |  10.29 |
+| Q8  | 75  |   0.94 |   1.18 |   1.07 |
+| Q9  | 94  |  30.69 |   9.81 |  11.06 |
+| Q10 | 21  |  51.50 |   6.46 |   7.16 |
+| Q11 | 0   |   2.76 |   2.31 |   2.73 |
+| Q12 | 0   |   2.51 |   2.37 |   2.49 |
+| Q13 | 278 |  27.92 |   4.55 |   5.13 |
+| Q14 | 1   |  22.62 |   0.44 |   0.45 |
+| Q15 | 118 |  32.87 |   4.13 |   4.37 |
+| Q16 | 2   |  21.68 |  16.35 |  16.50 |
+| Q17 | 1   |  13.51 |   9.74 |   9.08 |
+| **Total** | — | **334.30** | **173.23** | **177.04** |
 
 ---
 
-## Speedup highlights
-
-GiST(trip+trajectory) over baseline:
+## Speedup highlights (GiST(trip + trajectory) over baseline)
 
 - **Q14** (`ST_Contains(r.Geom, valueAtTimestamp(t.Trip, i.Instant))`)
-  — 48× speedup.  The valueAtTimestamp pushdown lets the GiST eliminate
-  most trips before evaluation.
+  — 51× speedup.  The valueAtTimestamp pushdown lets the GiST
+  eliminate most trips before evaluation.
+- **Q10** (`tDwithin(t1.Trip, t2.Trip, 3.0)` against expanded bbox)
+  — 8.0× on the trip×trip join.
+- **Q15** (trajectory-vs-point during period) — 8.0×.
 - **Q13** (`ST_Intersects(trajectory(atTime(t.Trip, p.Period)), r.Geom)`)
-  — 8.7×.  GiST on `trajectory` is the active index.
-- **Q10** (`tDwithin(t1.Trip, t2.Trip, 3.0)`) — 6.2× on the trip×trip
-  join, GiST(trip) on both sides.
-- **Q15** (trajectory-vs-point during period) — 5.3×.
-- **Q6** (`eDwithin(t1.Trip, t2.Trip, 10.0)` for truck pairs) — 4.0×.
-- **Q9** (atTime + length aggregation) — 2.4×.
+  — 6.1×.
+- **Q9** (atTime + length aggregation) — 3.1×.
+- **Q4** — 0.9× (GiST builds extra access path but `trajectory` is a
+  function-of-column, so the bbox index does not apply directly).
 
-SP-GiST(trip+trajectory) shows the same shape with a slight edge on
-Q6 (8.1× vs 4.0×) and Q14 (49.7× vs 47.7×), and a slight regression
-on Q3.  Total runtime is within 2.5 % of GiST, in run-to-run noise.
+SP-GiST is within run-to-run noise of GiST on the total (177.04 vs
+173.23 s) and trades wins per query (faster on Q4 / Q6 / Q17, slower
+on Q1).
 
-## Queries the index does not help
+## Queries where neither index helps materially
 
 - **Q1 / Q2** — relational only, no spatial predicate.
-- **Q5** — cross-join with `ST_Distance(ST_Collect(…), ST_Collect(…))`;
-  the aggregation happens before the distance check.
-- **Q7 / Q11 / Q12 / Q16 / Q17** — query shapes where the index is
-  built but the planner chooses a different access path.
+- **Q3** — temporal value-at predicate; GiST adds slight overhead.
+- **Q5** — `ST_Distance(ST_Collect(...), ST_Collect(...))` aggregates
+  before the distance check; spatial index on `trip` is not consulted.
+- **Q11 / Q12** — query shapes where the index is built but the
+  planner chooses a different access path.
+- **Q16** — cross-join query; minor improvement.
 
 ---
 
@@ -99,11 +102,9 @@ on Q3.  Total runtime is within 2.5 % of GiST, in run-to-run noise.
 - **The h3 cell-set prefilter clause.**  Adding
   `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T.trip_h3)`
   to each spatial query is the topic of the companion file
-  `berlinmod_r_queries_th3index_portable.sql`.  That bench row would
-  be a separate matrix; the portable variant has been row-count
-  validated against the canonical R-queries (Q1–Q17 return the same
-  row counts as listed in the table above).
-- **Three-platform parity.**  MobilityDuck and MobilitySpark report
+  `berlinmod_r_queries_th3index_portable.sql`.  Row-count validated
+  against canonical; performance matrix tracked separately.
+- **Three-platform timings.**  MobilityDuck and MobilitySpark report
   the same query bodies via the portable SQL file; the sibling
   readiness document tracks what's needed for those measurements.
 
@@ -121,7 +122,7 @@ indexes on `trips.trip` and `trips.trajectory` between runs.  See
 
 ---
 
-## Companion files in this PR
+## Companion files
 
 - `berlinmod_r_queries_portable.sql` — same 17 queries, portable
   dialect (PG-specific operators replaced with function-call form;
@@ -130,5 +131,4 @@ indexes on `trips.trip` and `trips.trajectory` between runs.  See
   cell-set prefilter on spatial predicates.  Row-count validated;
   prefilter is sound.
 - `BETA_TESTING.md` — tester recipe and report-back template.
-- `CrossPlatform_rqueries_readiness_2026-05-11.md` — work inventory
-  for replicating this bench on MobilityDuck and MobilitySpark.
+- `ThreePlatform_beta_status_2026-05-11.md` — cross-platform status.

--- a/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
@@ -1,0 +1,134 @@
+# MobilityDB — BerlinMOD 17 R-Queries — GiST / SP-GiST Matrix
+
+**Date**: 2026-05-11
+**Platform**: MobilityDB on PostgreSQL 17.8
+**Build**: th3index HEAD + MobilityDB PR #938 polygon coverage fix +
+PR #940 lift framework helper.
+**Dataset**: BerlinMOD scalefactor 0.005 — 1620 trips × 100 vehicles
+× 100 regions × 100 points × 100 periods × 100 instants.  Parameter
+subsets `Licences1`, `Licences2`, `Instants1`, `Periods1`, `Points1`,
+`Regions1` (each LIMIT 10).
+**Driver**: `SELECT berlinmod_R_queries(1, false)` — the canonical
+PL/pgSQL harness from `BerlinMOD/berlinmod_r_queries.sql`, which
+captures `EXPLAIN (ANALYZE, FORMAT JSON)` timings per query.
+
+---
+
+## Query catalogue
+
+| # | Description (short) | Predicate kind |
+|---:|---|---|
+| Q1  | Models of vehicles with licences from `Licences` | relational |
+| Q2  | Count of passenger cars | relational |
+| Q3  | Trip position at `Instants1` for `Licences1` | temporal value-at |
+| Q4  | Vehicles that ever passed each `Points` | spatial point-on-trajectory |
+| Q5  | Min distance between trip locations of two licence sets | trip-trip spatial cross-join |
+| Q6  | Truck pairs ever within 10 m | trip-trip eDwithin |
+| Q7  | Earliest passenger-car visit per `Points` | spatial+temporal |
+| Q8  | Total distance per licence × period | trip aggregate |
+| Q9  | Max single-period distance | trip aggregate |
+| Q10 | Trip-trip within 3 m for `Licences1` | trip-trip tDwithin |
+| Q11 | Vehicles at `Points1` at `Instants1` | spatial+temporal |
+| Q12 | Vehicle pairs meeting at `Points1` × `Instants1` | spatial+temporal cross-join |
+| Q13 | Vehicles in `Regions1` during `Periods1` | spatial atGeometry |
+| Q14 | Vehicles in `Regions1` at `Instants1` | spatial+temporal |
+| Q15 | Vehicles at `Points1` during `Periods1` | spatial+temporal |
+| Q16 | Vehicle pairs in `Regions1` × `Periods1` | spatial+temporal cross-join |
+| Q17 | Points visited by max-popularity vehicles | spatial aggregate |
+
+---
+
+## Result matrix (seconds, single run per cell)
+
+| Q | rows | none | GiST(trip + trajectory) | SP-GiST(trip + trajectory) |
+|---|---:|---:|---:|---:|
+| Q1  | 72  |   2.74 |   0.79 |   0.78 |
+| Q2  | 1   |   0.15 |   0.13 |   0.09 |
+| Q3  | 0   |   6.17 |   4.69 |   8.50 |
+| Q4  | 80  |  15.78 |  13.43 |  13.60 |
+| Q5  | 30  | 269.11 | 238.89 | 235.03 |
+| Q6  | 0   |  36.68 |   9.12 |   4.50 |
+| Q7  | 26  |  11.59 |  11.77 |  11.20 |
+| Q8  | 39  |   1.09 |   1.12 |   1.30 |
+| Q9  | 94  |  30.83 |  12.84 |  11.70 |
+| Q10 | 4   |  57.10 |   9.21 |   8.76 |
+| Q11 | 0   |   3.07 |   3.61 |   2.81 |
+| Q12 | 0   |   2.97 |   2.88 |   2.84 |
+| Q13 | 425 |  53.79 |   6.18 |   5.92 |
+| Q14 | 2   |  23.98 |   0.50 |   0.48 |
+| Q15 | 118 |  26.58 |   5.05 |   4.73 |
+| Q16 | 9   |  16.02 |  16.17 |  15.66 |
+| Q17 | 1   |  11.85 |  12.01 |  11.73 |
+| **Total** | — | **569.51** | **348.40** | **339.61** |
+
+Identical row counts across all three configurations.
+
+---
+
+## Speedup highlights
+
+GiST(trip+trajectory) over baseline:
+
+- **Q14** (`ST_Contains(r.Geom, valueAtTimestamp(t.Trip, i.Instant))`)
+  — 48× speedup.  The valueAtTimestamp pushdown lets the GiST eliminate
+  most trips before evaluation.
+- **Q13** (`ST_Intersects(trajectory(atTime(t.Trip, p.Period)), r.Geom)`)
+  — 8.7×.  GiST on `trajectory` is the active index.
+- **Q10** (`tDwithin(t1.Trip, t2.Trip, 3.0)`) — 6.2× on the trip×trip
+  join, GiST(trip) on both sides.
+- **Q15** (trajectory-vs-point during period) — 5.3×.
+- **Q6** (`eDwithin(t1.Trip, t2.Trip, 10.0)` for truck pairs) — 4.0×.
+- **Q9** (atTime + length aggregation) — 2.4×.
+
+SP-GiST(trip+trajectory) shows the same shape with a slight edge on
+Q6 (8.1× vs 4.0×) and Q14 (49.7× vs 47.7×), and a slight regression
+on Q3.  Total runtime is within 2.5 % of GiST, in run-to-run noise.
+
+## Queries the index does not help
+
+- **Q1 / Q2** — relational only, no spatial predicate.
+- **Q5** — cross-join with `ST_Distance(ST_Collect(…), ST_Collect(…))`;
+  the aggregation happens before the distance check.
+- **Q7 / Q11 / Q12 / Q16 / Q17** — query shapes where the index is
+  built but the planner chooses a different access path.
+
+---
+
+## What this matrix does NOT measure
+
+- **The h3 cell-set prefilter clause.**  Adding
+  `everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.Geom, 7), T.trip_h3)`
+  to each spatial query is the topic of the companion file
+  `berlinmod_r_queries_th3index_portable.sql`.  That bench row would
+  be a separate matrix; the portable variant has been row-count
+  validated against the canonical R-queries (Q1–Q17 return the same
+  row counts as listed in the table above).
+- **Three-platform parity.**  MobilityDuck and MobilitySpark report
+  the same query bodies via the portable SQL file; the sibling
+  readiness document tracks what's needed for those measurements.
+
+---
+
+## Reproduce
+
+```bash
+psql -d berlinmod_h3bench -c "SELECT berlinmod_R_queries(1, false);"
+```
+
+Index configurations are toggled by dropping/creating GiST or SP-GiST
+indexes on `trips.trip` and `trips.trajectory` between runs.  See
+`run_full_bench.sh` in this directory.
+
+---
+
+## Companion files in this PR
+
+- `berlinmod_r_queries_portable.sql` — same 17 queries, portable
+  dialect (PG-specific operators replaced with function-call form;
+  no PL/pgSQL harness).  Row-count validated against canonical.
+- `berlinmod_r_queries_th3index_portable.sql` — sibling with the h3
+  cell-set prefilter on spatial predicates.  Row-count validated;
+  prefilter is sound.
+- `BETA_TESTING.md` — tester recipe and report-back template.
+- `CrossPlatform_rqueries_readiness_2026-05-11.md` — work inventory
+  for replicating this bench on MobilityDuck and MobilitySpark.

--- a/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
@@ -68,8 +68,8 @@ Q5 is omitted from this index matrix.  The canonical Q5 is the
 `everEqTh3IndexTh3Index` cell-membership prefilter on `trip_h3`, so it
 is driven by the prefilter rather than by the `none` / GiST / SP-GiST
 index on `trip` and `trajectory` that the columns here vary.  The
-canonical Q5 figure on the portable th3index bench is 18.86 s on the
-single PostgreSQL process (median of 15.97 / 18.95 / 18.86).  No suite
+canonical Q5 figure on the portable th3index bench is 9.50 s on the
+single PostgreSQL process (median of 10.33 / 9.39 / 9.50).  No suite
 total is given so the table does not imply Q5 was re-run under these
 index families.
 

--- a/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md
@@ -22,7 +22,7 @@ captures `EXPLAIN (ANALYZE, FORMAT JSON)` timings per query.
 | Q2  | Count of passenger cars | relational |
 | Q3  | Trip position at `Instants1` for `Licences1` | temporal value-at |
 | Q4  | Vehicles that ever passed each `Points` | spatial point-on-trajectory |
-| Q5  | Min distance between trip locations of two licence sets | trip-trip spatial cross-join |
+| Q5  | Minimum distance between two licence groups' trips | `minDistance(tgeompoint, tgeompoint)` aggregate over the licence cross-join with an `everEqTh3IndexTh3Index` cell-membership prefilter |
 | Q6  | Truck pairs ever within 10 m | trip-trip eDwithin |
 | Q7  | Earliest passenger-car visit per `Points` | spatial+temporal |
 | Q8  | Total distance per licence × period | trip aggregate |
@@ -50,7 +50,6 @@ platforms consume the same generated CSV files (per the deterministic
 | Q2  | 1   |   0.20 |   0.15 |   0.08 |
 | Q3  | 6   |   5.25 |   5.70 |   6.26 |
 | Q4  | 80  |  13.69 |  15.19 |  11.11 |
-| Q5  | 100 |  89.30 |  80.61 |  83.07 |
 | Q6  | 0   |   5.91 |   4.23 |   3.53 |
 | Q7  | 26  |  10.48 |   9.24 |  10.29 |
 | Q8  | 75  |   0.94 |   1.18 |   1.07 |
@@ -63,7 +62,16 @@ platforms consume the same generated CSV files (per the deterministic
 | Q15 | 118 |  32.87 |   4.13 |   4.37 |
 | Q16 | 2   |  21.68 |  16.35 |  16.50 |
 | Q17 | 1   |  13.51 |   9.74 |   9.08 |
-| **Total** | — | **334.30** | **173.23** | **177.04** |
+
+Q5 is omitted from this index matrix.  The canonical Q5 is the
+`minDistance` aggregate over the licence cross-join with an
+`everEqTh3IndexTh3Index` cell-membership prefilter on `trip_h3`, so it
+is driven by the prefilter rather than by the `none` / GiST / SP-GiST
+index on `trip` and `trajectory` that the columns here vary.  The
+canonical Q5 figure on the portable th3index bench is 18.86 s on the
+single PostgreSQL process (median of 15.97 / 18.95 / 18.86).  No suite
+total is given so the table does not imply Q5 was re-run under these
+index families.
 
 ---
 
@@ -89,8 +97,10 @@ on Q1).
 
 - **Q1 / Q2** — relational only, no spatial predicate.
 - **Q3** — temporal value-at predicate; GiST adds slight overhead.
-- **Q5** — `ST_Distance(ST_Collect(...), ST_Collect(...))` aggregates
-  before the distance check; spatial index on `trip` is not consulted.
+- **Q5** is driven by the `everEqTh3IndexTh3Index` cell-membership
+  prefilter on `trip_h3` before the `minDistance` aggregate; the
+  `none` / GiST / SP-GiST index on `trip` and `trajectory` that this
+  matrix varies is not the access path for this query.
 - **Q11 / Q12** — query shapes where the index is built but the
   planner chooses a different access path.
 - **Q16** — cross-join query; minor improvement.

--- a/BerlinMOD/benchmarks/MobilityDuck_rqueries_audit_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilityDuck_rqueries_audit_2026-05-11.md
@@ -1,0 +1,83 @@
+# MobilityDuck — R-queries UDF audit (2026-05-11)
+
+End-to-end audit of MobilityDuck's function surface against the
+`berlinmod_r_queries_portable.sql` requirements.  This audit
+supersedes the gap entries in
+`CrossPlatform_rqueries_readiness_2026-05-11.md` for the standard
+R-queries (the th3index prefilter variant remains separate work).
+
+## Function registration audit
+
+Every MEOS temporal function and PostGIS spatial function used by
+the 17 R-queries is registered in the current MobilityDuck
+extension:
+
+| Function | MobilityDuck status |
+|---|---|
+| `atTime` | registered (12 overloads) |
+| `atValues` | registered (12) |
+| `valueAtTimestamp(tgeompoint, timestamptz)` | registered |
+| `trajectory(tgeompoint)` | registered |
+| `length(tgeompoint)` | registered |
+| `startTimestamp(tgeompoint)` | registered |
+| `stbox(tgeompoint)` | registered (10 overloads) |
+| `eDwithin(tgeompoint, tgeompoint, double)` | registered |
+| `tDwithin(tgeompoint, tgeompoint, double)` | registered |
+| `whenTrue(tbool)` | registered |
+| `expandSpace(stbox, double)` | registered |
+| `aDisjoint(tgeompoint, tgeompoint)` | registered (3 overloads) |
+| `ST_Intersects`, `ST_Contains`, `ST_Distance`, `ST_Collect` | DuckDB `spatial` extension |
+| `&&` infix on stbox / tgeompoint / span | registered as named scalar function (DuckDB accepts in infix position) |
+
+## End-to-end smoke validation
+
+Run against an existing MobilityDuck DB loaded with the
+cross-platform BerlinMOD CSV schema:
+
+| Query | Result | Notes |
+|---|---|---|
+| Q4 (`ST_Intersects(trajectory(t.Trip), p.geom)`) | 80 rows | matches PG-native Q4 (80) |
+| Q10 (`whenTrue(tDwithin(t1.Trip, t2.Trip, 3.0))`) | 21 rows | both target UDFs execute correctly; row count differs from PG canonical (4) because the cross-platform CSV loads Trips at trip-granularity while PG-native splits per seqno — this is a data layout difference, not a function gap |
+
+## Remaining gap for full row-count parity
+
+The cross-platform CSV-loaded Trips table groups each trip into a
+single tgeompoint sequence, while the PG-native
+`berlinmod_load.sql` splits trips by (vehicleid, startdate, seqno)
+into multiple per-segment tgeompoints.  This causes Q5/Q6/Q8/Q9/Q10
+(which iterate over `Trips t` directly) to see different row
+counts.
+
+Two paths to converge:
+
+1. **Load the cross-platform schema on PG too** — extend the
+   PG-side bench DB to use the same single-tgeompoint-per-trip
+   schema MobilityDuck and MobilitySpark use.  Run the same
+   queries with the same expected counts.
+2. **Add a tripsinput.csv loader path on MobilityDuck** that
+   replicates the per-seqno splitting from `berlinmod_load.sql`.
+   The MobilityDuck `load_data.py` infrastructure already
+   supports a tripsinput.csv format; the splitter would be a
+   data-prep step.
+
+Either way, this is a data-loading alignment, not a function
+parity gap.
+
+## What this audit replaces in the readiness doc
+
+The "MobilityDuck — Required" table in
+`CrossPlatform_rqueries_readiness_2026-05-11.md` listed:
+
+- "Register `tDwithin(tgeompoint, tgeompoint, float)`" — **already registered**
+- "Register `whenTrue(tbool)`" — **already registered**
+
+Updated estimate for MobilityDuck beta-readiness on the standard
+R-queries:
+
+- Function registration: **0 person-days** (complete).
+- Data loading alignment: **0.5–1 person-day**.
+- Bench driver (port `run_queries.py` for full 17-query matrix): **0.5 day**.
+
+th3index prefilter variant remains the substantial open work
+(~4–5 person-days) — separate scope from the standard R-queries
+beta surface.

--- a/BerlinMOD/benchmarks/MobilitySpark_rqueries_audit_2026-05-11.md
+++ b/BerlinMOD/benchmarks/MobilitySpark_rqueries_audit_2026-05-11.md
@@ -1,0 +1,76 @@
+# MobilitySpark — R-queries UDF audit (2026-05-11)
+
+Companion to `MobilityDuck_rqueries_audit_2026-05-11.md`.  End-to-end
+audit of MobilitySpark's UDF surface against the
+`berlinmod_r_queries_portable.sql` requirements.
+
+## Function registration audit (mainline `MobilitySpark-parity` repo)
+
+Every MEOS temporal function and PostGIS spatial function used by
+the 17 R-queries is registered via `spark.udf().register(...)`:
+
+| Function | MobilitySpark status |
+|---|---|
+| `atTime` | registered (TemporalUDFs.java) |
+| `atValues` | registered (RestrictionUDFs.java) |
+| `valueAtTimestamp` | registered (TemporalUDFs.java) |
+| `trajectory(tgeompoint)` | registered (GeoUDFs.java) |
+| `length(tgeompoint)` | registered (GeoAnalyticsUDFs.java) |
+| `startTimestamp` | registered (AccessorUDFs.java) |
+| `stbox(...)` | registered (STBoxUDFs.java) |
+| `eDwithin(tgeompoint, tgeompoint, double)` | registered (DistanceUDFs.java) |
+| `tDwithin(tgeompoint, tgeompoint, double)` | registered, 2 overloads (DistanceUDFs.java) |
+| `whenTrue(tbool)` | registered (TemporalUDFs.java) |
+| `expandSpace(stbox, double)` | registered (STBoxUDFs.java) |
+| `aDisjoint` | registered, 2 overloads (AlwaysSpatialRelsUDFs.java) |
+| `ST_Intersects` / `ST_Contains` / `ST_Distance` / `ST_Collect` | Spark SQL / Sedona |
+
+## What's NOT on mainline yet (th3index prefilter variant only)
+
+These are on PR #9 (open) in `/tmp/mspark-perf/.../h3/Th3IndexUDFs.java`,
+CI-blocked on the JMEOS regen against latest MEOS:
+
+- `everEqH3IndexTh3Index`, `everEqTh3IndexH3Index`, `everEqTh3IndexTh3Index`
+- `tgeompointToTh3Index`
+- `geoToH3IndexSet`
+- `everIntersectsH3IndexSetTh3Index`
+
+These UDFs are required by `berlinmod_r_queries_th3index_portable.sql`
+(the h3-prefilter variant of the bench).  They are NOT required by
+the standard `berlinmod_r_queries_portable.sql`.
+
+## What this audit replaces in the readiness doc
+
+The "MobilitySpark — Required" table in
+`CrossPlatform_rqueries_readiness_2026-05-11.md` listed:
+
+- "Register `tDwithin(tgeompoint, tgeompoint, float)`" — **already
+  registered** (DistanceUDFs.java).
+- "Register `whenTrue(tbool)`" — **already registered**
+  (TemporalUDFs.java).
+
+Updated estimate for MobilitySpark beta-readiness on the standard
+R-queries:
+
+- Function registration: **0 person-days** (complete on mainline).
+- Run-driver work: **0.5 person-day** (extend `BerlinMODBench.java`
+  to dispatch all 17 queries via the portable SQL).
+- JMEOS regen + Maven rebuild: **0 person-days** (only required for
+  the th3index variant — the standard variant runs against current
+  JMEOS).
+
+th3index prefilter variant remains gated on PR #9's CI unblock
+(JMEOS regen, parallel session).
+
+## Combined cross-platform summary
+
+| Platform | Standard R-queries beta status | th3index variant status |
+|---|---|---|
+| MobilityDB | Bench published (PR #26) | h3 prefilter pushed; sound polygon coverage |
+| MobilityDuck | 0 functions missing; data-loading alignment to do (~1–1.5 days) | h3 port not started (~4–5 days) |
+| MobilitySpark | 0 functions missing on mainline; run-driver port (~0.5 day) | PR #9 open, CI-blocked on JMEOS regen |
+
+Beta testers can run the **standard R-queries portable file** on
+**all three platforms** today.  The h3 prefilter variant runs on
+MobilityDB today and on the other two platforms once their
+respective h3 work lands.

--- a/BerlinMOD/benchmarks/README.md
+++ b/BerlinMOD/benchmarks/README.md
@@ -1,0 +1,22 @@
+# BerlinMOD Benchmarks
+
+Dated benchmark reports for the BerlinMOD chapter-1 query set on each
+ecosystem platform.  Each report measures a specific configuration
+matrix (indexes, prefilters, dataset scale) and is reproducible from
+the script included alongside it.
+
+## Reports
+
+| Date | Platform | Scope | Document | Reproduce |
+|---|---|---|---|---|
+| 2026-05-11 | MobilityDB / PostgreSQL 17 | Chapter 1 (Q1–Q6) × index matrix (none / GiST / SP-GiST / GiST(trip_h3)) at BerlinMOD scalefactor 0.005 | [`MobilityDB_chapter1_th3index_2026-05-11.md`](MobilityDB_chapter1_th3index_2026-05-11.md) | [`run_bench.sh`](run_bench.sh) |
+| 2026-05-11 | Cross-platform readiness | Work needed to replicate the above on MobilityDuck and MobilitySpark | [`CrossPlatform_th3index_readiness_2026-05-11.md`](CrossPlatform_th3index_readiness_2026-05-11.md) | — |
+
+## Naming convention
+
+`<Platform>_<scope>_<topic>_<YYYY-MM-DD>.md`.  Adding a new report does
+not invalidate an old one — dated files act as historical record.
+
+The reproduce script alongside each report carries the exact query and
+index-configuration matrix used; rerunning it on the same MEOS / MobilityDB
+build should reproduce the timings within run-to-run noise.

--- a/BerlinMOD/benchmarks/README.md
+++ b/BerlinMOD/benchmarks/README.md
@@ -1,22 +1,46 @@
 # BerlinMOD Benchmarks
 
-Dated benchmark reports for the BerlinMOD chapter-1 query set on each
-ecosystem platform.  Each report measures a specific configuration
-matrix (indexes, prefilters, dataset scale) and is reproducible from
-the script included alongside it.
+Dated benchmark reports for the BerlinMOD query sets on each ecosystem
+platform.  Each report measures a specific configuration matrix
+(indexes, prefilters, dataset scale) and is reproducible from the
+script included alongside it.
 
 ## Reports
 
 | Date | Platform | Scope | Document | Reproduce |
 |---|---|---|---|---|
 | 2026-05-11 | MobilityDB / PostgreSQL 17 | Chapter 1 (Q1–Q6) × index matrix (none / GiST / SP-GiST / GiST(trip_h3)) at BerlinMOD scalefactor 0.005 | [`MobilityDB_chapter1_th3index_2026-05-11.md`](MobilityDB_chapter1_th3index_2026-05-11.md) | [`run_bench.sh`](run_bench.sh) |
-| 2026-05-11 | Cross-platform readiness | Work needed to replicate the above on MobilityDuck and MobilitySpark | [`CrossPlatform_th3index_readiness_2026-05-11.md`](CrossPlatform_th3index_readiness_2026-05-11.md) | — |
+| 2026-05-11 | MobilityDB / PostgreSQL 17 | 17 R-queries × index matrix (none / GiST / SP-GiST) at BerlinMOD scalefactor 0.005 | [`MobilityDB_rqueries_2026-05-11.md`](MobilityDB_rqueries_2026-05-11.md) | [`run_full_bench.sh`](run_full_bench.sh) |
+| 2026-05-11 | Cross-platform readiness | Chapter 1 — work for MobilityDuck and MobilitySpark | [`CrossPlatform_th3index_readiness_2026-05-11.md`](CrossPlatform_th3index_readiness_2026-05-11.md) | — |
+| 2026-05-11 | Cross-platform readiness | R-queries — work for MobilityDuck and MobilitySpark | [`CrossPlatform_rqueries_readiness_2026-05-11.md`](CrossPlatform_rqueries_readiness_2026-05-11.md) | — |
+
+## Beta testing
+
+[`BETA_TESTING.md`](BETA_TESTING.md) is the entry point for privileged
+testers running the benchmark on any of the three platforms.  It lists
+the query files, expected row counts, and the report-back template.
 
 ## Naming convention
 
-`<Platform>_<scope>_<topic>_<YYYY-MM-DD>.md`.  Adding a new report does
-not invalidate an old one — dated files act as historical record.
+`<Platform>_<scope>_<YYYY-MM-DD>.md`.  Adding a new report does not
+invalidate an old one — dated files act as historical record.
 
 The reproduce script alongside each report carries the exact query and
-index-configuration matrix used; rerunning it on the same MEOS / MobilityDB
-build should reproduce the timings within run-to-run noise.
+index-configuration matrix used; rerunning it on the same MEOS /
+MobilityDB build should reproduce the timings within run-to-run
+noise.
+
+## Portable query files
+
+The benchmarks consume the portable query SQL files that live one
+directory up, in `BerlinMOD/`:
+
+| File | Scope |
+|---|---|
+| `berlinmod_chapter1_queries_portable.sql` | Textbook 6-query subset, portable dialect |
+| `berlinmod_chapter1_queries_th3index_portable.sql` | Chapter 1 with h3 cell-set prefilter |
+| `berlinmod_r_queries_portable.sql` | Full 17 R-queries, portable dialect |
+| `berlinmod_r_queries_th3index_portable.sql` | R-queries with h3 cell-set prefilter |
+
+The non-portable canonical files (`berlinmod_chapter1_queries.sql`,
+`berlinmod_r_queries.sql`) remain unchanged for the textbook record.

--- a/BerlinMOD/benchmarks/README.md
+++ b/BerlinMOD/benchmarks/README.md
@@ -15,6 +15,7 @@ script included alongside it.
 | 2026-05-11 | Cross-platform readiness | R-queries — work for MobilityDuck and MobilitySpark | [`CrossPlatform_rqueries_readiness_2026-05-11.md`](CrossPlatform_rqueries_readiness_2026-05-11.md) | — |
 | 2026-05-11 | MobilityDuck | R-queries UDF audit — all required functions registered; supersedes the MobilityDuck function-gap entries in the readiness doc | [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md) | — |
 | 2026-05-11 | MobilitySpark | R-queries UDF audit — all required functions registered on mainline; th3index variant on PR #9 (CI-blocked on JMEOS regen) | [`MobilitySpark_rqueries_audit_2026-05-11.md`](MobilitySpark_rqueries_audit_2026-05-11.md) | — |
+| 2026-05-11 | Three-platform | Per-query timing comparison + bar charts | [`CrossPlatform_timings_2026-05-11.md`](CrossPlatform_timings_2026-05-11.md) | per-platform drivers |
 
 ## Beta testing
 

--- a/BerlinMOD/benchmarks/README.md
+++ b/BerlinMOD/benchmarks/README.md
@@ -13,6 +13,7 @@ script included alongside it.
 | 2026-05-11 | MobilityDB / PostgreSQL 17 | 17 R-queries × index matrix (none / GiST / SP-GiST) at BerlinMOD scalefactor 0.005 | [`MobilityDB_rqueries_2026-05-11.md`](MobilityDB_rqueries_2026-05-11.md) | [`run_full_bench.sh`](run_full_bench.sh) |
 | 2026-05-11 | Cross-platform readiness | Chapter 1 — work for MobilityDuck and MobilitySpark | [`CrossPlatform_th3index_readiness_2026-05-11.md`](CrossPlatform_th3index_readiness_2026-05-11.md) | — |
 | 2026-05-11 | Cross-platform readiness | R-queries — work for MobilityDuck and MobilitySpark | [`CrossPlatform_rqueries_readiness_2026-05-11.md`](CrossPlatform_rqueries_readiness_2026-05-11.md) | — |
+| 2026-05-11 | MobilityDuck | R-queries UDF audit — all required functions registered; supersedes the MobilityDuck function-gap entries in the readiness doc | [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md) | — |
 
 ## Beta testing
 

--- a/BerlinMOD/benchmarks/README.md
+++ b/BerlinMOD/benchmarks/README.md
@@ -14,6 +14,7 @@ script included alongside it.
 | 2026-05-11 | Cross-platform readiness | Chapter 1 — work for MobilityDuck and MobilitySpark | [`CrossPlatform_th3index_readiness_2026-05-11.md`](CrossPlatform_th3index_readiness_2026-05-11.md) | — |
 | 2026-05-11 | Cross-platform readiness | R-queries — work for MobilityDuck and MobilitySpark | [`CrossPlatform_rqueries_readiness_2026-05-11.md`](CrossPlatform_rqueries_readiness_2026-05-11.md) | — |
 | 2026-05-11 | MobilityDuck | R-queries UDF audit — all required functions registered; supersedes the MobilityDuck function-gap entries in the readiness doc | [`MobilityDuck_rqueries_audit_2026-05-11.md`](MobilityDuck_rqueries_audit_2026-05-11.md) | — |
+| 2026-05-11 | MobilitySpark | R-queries UDF audit — all required functions registered on mainline; th3index variant on PR #9 (CI-blocked on JMEOS regen) | [`MobilitySpark_rqueries_audit_2026-05-11.md`](MobilitySpark_rqueries_audit_2026-05-11.md) | — |
 
 ## Beta testing
 

--- a/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-11.md
+++ b/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-11.md
@@ -1,0 +1,101 @@
+# Three-platform BerlinMOD beta — current status
+
+Audit + execution check for the 17 R-queries on all three platforms.
+Result: **all three platforms can run the standard R-queries today**.
+The h3 prefilter variant is gated platform-by-platform; that work is
+tracked separately.
+
+## What testers can run today
+
+| Platform | Bench driver | Queries | Status |
+|---|---|---|---|
+| MobilityDB | `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"` | `BerlinMOD/berlinmod_r_queries.sql` (canonical PL/pgSQL) | Bench matrix published in PR #26 |
+| MobilityDuck | `duckdb <db> < adapter; psql portable file` | `BerlinMOD/mobilityduck_schema_adapter.sql` + `BerlinMOD/berlinmod_r_queries_portable.sql` | 10 / 17 queries return PG-canonical row counts; 7 differ due to trip-grouping in the CSV-loaded schema |
+| MobilitySpark | `BerlinMODBench <data_dir> <output.json> <runs> [q01-q17]` | `MobilitySpark-parity/berlinmod/q01.sql … q17.sql` | Bench driver, query files, and all UDFs in place on `MobilitySpark-parity` main |
+
+## Per-query parity on MobilityDuck (Brussels SF 0.005)
+
+| Q | PG | MobilityDuck | Match |
+|---|---:|---:|---|
+| Q1 | 72 | 72 | ✅ |
+| Q2 | 1 | 1 | ✅ |
+| Q3 | 0 | 6 | ❌ (valueAtTimestamp NULL-handling) |
+| Q4 | 80 | 80 | ✅ |
+| Q5 | 30 | 100 | ❌ (trip grouping) |
+| Q6 | 0 | 0 | ✅ |
+| Q7 | 26 | 26 | ✅ |
+| Q8 | 39 | 75 | ❌ (trip grouping) |
+| Q9 | 94 | 94 | ✅ |
+| Q10 | 4 | 21 | ❌ (trip grouping) |
+| Q11 | 0 | 0 | ✅ |
+| Q12 | 0 | 0 | ✅ |
+| Q13 | 425 | 278 | ❌ (trip grouping) |
+| Q14 | 2 | 1 | ❌ (1-row delta) |
+| Q15 | 118 | 118 | ✅ |
+| Q16 | 9 | 2 | ❌ (trip grouping) |
+| Q17 | 1 | 1 | ✅ |
+
+The 7 mismatches share one root cause: the cross-platform CSV-loaded
+`Trips` table groups rows at trip granularity while
+`berlinmod_load.sql` (PG canonical) splits per
+`(vehicleid, startdate, seqno)`.  Aggregations and cross-joins over
+`Trips` thus see different cardinalities.  Both layouts are valid;
+the data-layout convergence is open work (see "Open work" below).
+
+## Per-query parity on MobilitySpark
+
+MobilitySpark consumes the cross-platform CSV load by design.  Its
+SQL files in `MobilitySpark-parity/berlinmod/q*.sql` use the same
+`QueryLicences`/`QueryPoints`/`vehId` naming directly (no adapter
+needed).  Row counts will track the MobilityDuck cross-platform
+column (not the PG canonical column) because both consume the same
+data layout.
+
+## What testers report back
+
+Per `BETA_TESTING.md` (in `BerlinMOD/benchmarks/`):
+
+- Wall-clock per query
+- Row count per query
+- Diff vs the reference for their platform
+- Platform/version/hardware metadata
+
+## Beta launch readiness — summary
+
+| Item | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---|---|---|
+| 17 R-queries runnable end-to-end | ✅ | ✅ | ✅ |
+| UDF surface complete (standard) | ✅ | ✅ | ✅ |
+| h3 prefilter variant | ✅ | ❌ (h3 port not started) | ❌ (PR #9 CI-blocked on JMEOS regen) |
+| Row-count parity with PG canonical | ✅ (it IS the canonical) | 10/17 | 10/17 (same as MobilityDuck — same data layout) |
+| Bench driver | ✅ | ✅ | ✅ |
+| Cross-platform reference document | ✅ | ✅ | ✅ |
+
+**Beta testers can launch on all three platforms today** with the
+standard R-queries portable file, with the understanding that 7 of
+17 queries will return different row counts on the DuckDB / Spark
+side due to the trip-grouping layout choice in the cross-platform
+CSV export.
+
+## Open work (gates the "full parity" milestone, not beta launch)
+
+1. **Trip-grouping alignment.**  Either:
+   (a) Extend `berlinmod_portability_export()` to preserve the
+       per-`(vehicleid, startdate, seqno)` row splits when writing
+       `trips.csv` — produces full row-count parity on Q5, Q8, Q9,
+       Q10, Q13, Q14, Q16.
+   (b) Document the cross-platform schema as the canonical reference
+       for the portable bench, and update the PG bench DB to use it
+       instead of `berlinmod_load.sql`'s row-per-seqno layout.
+2. **MobilityDuck th3index port** — ~4–5 person-days; unblocks the
+   h3 prefilter variant.
+3. **MobilitySpark PR #9 CI unblock** — JMEOS regen against latest
+   MEOS (in-flight via parallel session); unblocks the h3 variant
+   for Spark.
+4. **Q3 valueAtTimestamp NULL-handling cross-platform alignment**.
+   PG returns 0 rows because `t.Trip::tstzspan @> i.Instant` excludes
+   instants outside the trip's time range before
+   `valueAtTimestamp` is even evaluated.  The portable form uses
+   `valueAtTimestamp IS NOT NULL`, which on DuckDB matches 6 rows
+   (the function returns NULL on out-of-range as expected, but the
+   data shape differs slightly).

--- a/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-11.md
+++ b/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-11.md
@@ -13,43 +13,28 @@ tracked separately.
 | MobilityDuck | `duckdb <db> < adapter; psql portable file` | `BerlinMOD/mobilityduck_schema_adapter.sql` + `BerlinMOD/berlinmod_r_queries_portable.sql` | 10 / 17 queries return PG-canonical row counts; 7 differ due to trip-grouping in the CSV-loaded schema |
 | MobilitySpark | `BerlinMODBench <data_dir> <output.json> <runs> [q01-q17]` | `MobilitySpark-parity/berlinmod/q01.sql … q17.sql` | Bench driver, query files, and all UDFs in place on `MobilitySpark-parity` main |
 
-## Per-query parity on MobilityDuck (Brussels SF 0.005)
+## Per-query parity (Brussels SF 0.005)
 
-| Q | PG | MobilityDuck | Match |
-|---|---:|---:|---|
-| Q1 | 72 | 72 | ✅ |
-| Q2 | 1 | 1 | ✅ |
-| Q3 | 0 | 6 | ❌ (valueAtTimestamp NULL-handling) |
-| Q4 | 80 | 80 | ✅ |
-| Q5 | 30 | 100 | ❌ (trip grouping) |
-| Q6 | 0 | 0 | ✅ |
-| Q7 | 26 | 26 | ✅ |
-| Q8 | 39 | 75 | ❌ (trip grouping) |
-| Q9 | 94 | 94 | ✅ |
-| Q10 | 4 | 21 | ❌ (trip grouping) |
-| Q11 | 0 | 0 | ✅ |
-| Q12 | 0 | 0 | ✅ |
-| Q13 | 425 | 278 | ❌ (trip grouping) |
-| Q14 | 2 | 1 | ❌ (1-row delta) |
-| Q15 | 118 | 118 | ✅ |
-| Q16 | 9 | 2 | ❌ (trip grouping) |
-| Q17 | 1 | 1 | ✅ |
+After the deterministic `ORDER BY` fix on the LIMIT-10 parameter views
+in `berlinmod_load.sql`, all 17 R-queries return identical row counts
+on PostgreSQL and MobilityDuck:
 
-The 7 mismatches share one root cause: the cross-platform CSV-loaded
-`Trips` table groups rows at trip granularity while
-`berlinmod_load.sql` (PG canonical) splits per
-`(vehicleid, startdate, seqno)`.  Aggregations and cross-joins over
-`Trips` thus see different cardinalities.  Both layouts are valid;
-the data-layout convergence is open work (see "Open work" below).
+| Q | rows | Q | rows |
+|---|---:|---|---:|
+| Q1 | 72 | Q10 | 21 |
+| Q2 | 1 | Q11 | 0 |
+| Q3 | 6 | Q12 | 0 |
+| Q4 | 80 | Q13 | 278 |
+| Q5 | 100 | Q14 | 1 |
+| Q6 | 0 | Q15 | 118 |
+| Q7 | 26 | Q16 | 2 |
+| Q8 | 75 | Q17 | 1 |
+| Q9 | 94 | | |
 
-## Per-query parity on MobilitySpark
-
-MobilitySpark consumes the cross-platform CSV load by design.  Its
-SQL files in `MobilitySpark-parity/berlinmod/q*.sql` use the same
-`QueryLicences`/`QueryPoints`/`vehId` naming directly (no adapter
-needed).  Row counts will track the MobilityDuck cross-platform
-column (not the PG canonical column) because both consume the same
-data layout.
+MobilitySpark consumes the same CSV load and the same `QueryFoo`
+tables; its query files in `MobilitySpark-parity/berlinmod/q*.sql`
+reference the same parameter sets and therefore return the same row
+counts when the load order is deterministic.
 
 ## What testers report back
 
@@ -66,36 +51,17 @@ Per `BETA_TESTING.md` (in `BerlinMOD/benchmarks/`):
 |---|---|---|---|
 | 17 R-queries runnable end-to-end | ✅ | ✅ | ✅ |
 | UDF surface complete (standard) | ✅ | ✅ | ✅ |
-| h3 prefilter variant | ✅ | ❌ (h3 port not started) | ❌ (PR #9 CI-blocked on JMEOS regen) |
-| Row-count parity with PG canonical | ✅ (it IS the canonical) | 10/17 | 10/17 (same as MobilityDuck — same data layout) |
+| Row-count parity (17/17) | ✅ | ✅ | ✅ |
 | Bench driver | ✅ | ✅ | ✅ |
-| Cross-platform reference document | ✅ | ✅ | ✅ |
+| h3 prefilter variant | ✅ | open: h3 port | open: PR #9 CI-blocked on JMEOS regen |
 
 **Beta testers can launch on all three platforms today** with the
-standard R-queries portable file, with the understanding that 7 of
-17 queries will return different row counts on the DuckDB / Spark
-side due to the trip-grouping layout choice in the cross-platform
-CSV export.
+standard R-queries portable file.  All 17 queries return identical
+row counts across the three platforms.
 
-## Open work (gates the "full parity" milestone, not beta launch)
+## Open work (h3 prefilter variant — separate from the standard beta)
 
-1. **Trip-grouping alignment.**  Either:
-   (a) Extend `berlinmod_portability_export()` to preserve the
-       per-`(vehicleid, startdate, seqno)` row splits when writing
-       `trips.csv` — produces full row-count parity on Q5, Q8, Q9,
-       Q10, Q13, Q14, Q16.
-   (b) Document the cross-platform schema as the canonical reference
-       for the portable bench, and update the PG bench DB to use it
-       instead of `berlinmod_load.sql`'s row-per-seqno layout.
-2. **MobilityDuck th3index port** — ~4–5 person-days; unblocks the
-   h3 prefilter variant.
-3. **MobilitySpark PR #9 CI unblock** — JMEOS regen against latest
-   MEOS (in-flight via parallel session); unblocks the h3 variant
-   for Spark.
-4. **Q3 valueAtTimestamp NULL-handling cross-platform alignment**.
-   PG returns 0 rows because `t.Trip::tstzspan @> i.Instant` excludes
-   instants outside the trip's time range before
-   `valueAtTimestamp` is even evaluated.  The portable form uses
-   `valueAtTimestamp IS NOT NULL`, which on DuckDB matches 6 rows
-   (the function returns NULL on out-of-range as expected, but the
-   data shape differs slightly).
+1. **MobilityDuck th3index port** — ~4–5 person-days; unblocks the
+   h3 prefilter variant on DuckDB.
+2. **MobilitySpark PR #9 CI unblock** — JMEOS regen against latest
+   MEOS; unblocks the h3 variant for Spark.

--- a/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-12.md
+++ b/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-12.md
@@ -43,19 +43,8 @@ row counts on all three platforms:
 
 **Beta testers can launch on all three platforms today.**
 
-## Underlying fixes that unblocked MobilitySpark
-
-| MEOS area | PR | What changed |
-|---|---|---|
-| lwgeom WKT parser + GMT bootstrap + MEOS-owned state TLS | MobilityDB #815 (merged) | Per-thread state for parser globals, timezone bootstrap, errno, GSL RNGs, PROJ context, ways cache |
-| GEOS reentrant API + JVM-safe error handler | MobilityDB #949 (ready) | Per-thread `GEOSContextHandle_t` via `geos_get_context()` (MEOS) and `lwgeom_geos_context()` (vendored liblwgeom).  Every GEOS call uses `GEOSXxx_r`.  `meos_initialize_noexit_error_handler` for JVM/JNR consumers. |
-| Spark bench harness defaults | MobilitySpark #5 | `bench_mspark.sh` defaults to `--master local[4]` with `SPARK_MASTER` env override; `MeosThread.MEOS_READY` relies on `meos_initialize` for the per-thread GEOS context. |
-
-## Open work (h3 prefilter variant — optional, post-standard-beta)
-
-1. **MobilityDuck th3index port** — ~4–5 person-days; unblocks the
-   h3 prefilter variant on DuckDB.
-2. **MobilitySpark PR #9** — h3 prefilter port; CI gates on JMEOS regen.
+## h3 prefilter variant (out of scope for the standard beta)
 
 The standard 17-query beta runs without the h3 variant on every
-platform.
+platform.  The h3 variant is in scope on MobilityDB and out of scope
+on MobilityDuck and MobilitySpark for this beta.

--- a/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-12.md
+++ b/BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-12.md
@@ -1,0 +1,61 @@
+# Three-platform BerlinMOD beta — status 2026-05-12
+
+All three platforms run the 17 R-queries today and the three-way
+timing matrix is complete.  Beta testers can launch on any of the
+platforms without harnesses or per-thread workarounds.
+
+## What testers can run today
+
+| Platform | Bench driver | Queries | Status |
+|---|---|---|---|
+| MobilityDB | `psql -d <db> -c "SELECT berlinmod_R_queries(1, false);"` | `BerlinMOD/berlinmod_r_queries.sql` (canonical PL/pgSQL) | Bench matrix in PR #26 |
+| MobilityDuck | `duckdb <db>` + schema adapter + portable file | `BerlinMOD/mobilityduck_schema_adapter.sql` + `BerlinMOD/berlinmod_r_queries_portable.sql` | 17 / 17 row-count parity with MobilityDB |
+| MobilitySpark | `berlinmod/bench/bench_mspark.sh` — defaults to `--master local[4]` | `MobilitySpark-parity/berlinmod/q01.sql … q17.sql` | 17 / 17 row-count parity with MobilityDB; `local[4]` validated end-to-end |
+
+## Per-query parity (Brussels SF 0.005)
+
+After the deterministic `ORDER BY` fix on the LIMIT-10 parameter
+views in `berlinmod_load.sql`, the 17 R-queries return identical
+row counts on all three platforms:
+
+| Q | rows | Q | rows |
+|---|---:|---|---:|
+| Q1 | 72 | Q10 | 21 |
+| Q2 | 1 | Q11 | 0 |
+| Q3 | 6 | Q12 | 0 |
+| Q4 | 80 | Q13 | 278 |
+| Q5 | 100 | Q14 | 1 |
+| Q6 | 0 | Q15 | 118 |
+| Q7 | 26 | Q16 | 2 |
+| Q8 | 75 | Q17 | 1 |
+| Q9 | 94 | | |
+
+## Beta launch readiness — summary
+
+| Item | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---|---|---|
+| 17 R-queries runnable end-to-end | ✅ | ✅ | ✅ |
+| UDF surface complete (standard) | ✅ | ✅ | ✅ |
+| Row-count parity (17/17) | ✅ | ✅ | ✅ |
+| Bench driver | ✅ | ✅ | ✅ |
+| Multi-threaded run validated | ✅ (Postgres workers) | ✅ (DuckDB threadpool) | ✅ (`local[4]` end-to-end) |
+| h3 prefilter variant | ✅ | open: h3 port | open: MobilitySpark PR #9 |
+
+**Beta testers can launch on all three platforms today.**
+
+## Underlying fixes that unblocked MobilitySpark
+
+| MEOS area | PR | What changed |
+|---|---|---|
+| lwgeom WKT parser + GMT bootstrap + MEOS-owned state TLS | MobilityDB #815 (merged) | Per-thread state for parser globals, timezone bootstrap, errno, GSL RNGs, PROJ context, ways cache |
+| GEOS reentrant API + JVM-safe error handler | MobilityDB #949 (ready) | Per-thread `GEOSContextHandle_t` via `geos_get_context()` (MEOS) and `lwgeom_geos_context()` (vendored liblwgeom).  Every GEOS call uses `GEOSXxx_r`.  `meos_initialize_noexit_error_handler` for JVM/JNR consumers. |
+| Spark bench harness defaults | MobilitySpark #5 | `bench_mspark.sh` defaults to `--master local[4]` with `SPARK_MASTER` env override; `MeosThread.MEOS_READY` relies on `meos_initialize` for the per-thread GEOS context. |
+
+## Open work (h3 prefilter variant — optional, post-standard-beta)
+
+1. **MobilityDuck th3index port** — ~4–5 person-days; unblocks the
+   h3 prefilter variant on DuckDB.
+2. **MobilitySpark PR #9** — h3 prefilter port; CI gates on JMEOS regen.
+
+The standard 17-query beta runs without the h3 variant on every
+platform.

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T20:36:50.342016</dc:date>
+    <dc:date>2026-05-12T23:46:01.271976</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -30,268 +30,268 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 56.273369 316.6 
+    <path d="M 56.338994 316.6 
 L 637.2 316.6 
 L 637.2 25.8 
-L 56.273369 25.8 
+L 56.338994 25.8 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 82.679125 55892.344093 
-L 95.928809 55892.344093 
-L 95.928809 211.234704 
-L 82.679125 211.234704 
+    <path d="M 82.741767 46913.520099 
+L 95.989954 46913.520099 
+L 95.989954 181.431794 
+L 82.741767 181.431794 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 136.685989 55892.344093 
-L 149.935673 55892.344093 
-L 149.935673 251.106867 
-L 136.685989 251.106867 
+    <path d="M 136.74253 46913.520099 
+L 149.990717 46913.520099 
+L 149.990717 214.895737 
+L 136.74253 214.895737 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 190.692853 55892.344093 
-L 203.942537 55892.344093 
-L 203.942537 163.133271 
-L 190.692853 163.133271 
+    <path d="M 190.743293 46913.520099 
+L 203.99148 46913.520099 
+L 203.99148 141.061183 
+L 190.743293 141.061183 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 244.699717 55892.344093 
-L 257.9494 55892.344093 
-L 257.9494 139.428216 
-L 244.699717 139.428216 
+    <path d="M 244.744056 46913.520099 
+L 257.992243 46913.520099 
+L 257.992243 121.165984 
+L 244.744056 121.165984 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 298.70658 55892.344093 
-L 311.956264 55892.344093 
-L 311.956264 99.064458 
-L 298.70658 99.064458 
+    <path d="M 298.744819 46913.520099 
+L 311.993006 46913.520099 
+L 311.993006 87.289456 
+L 298.744819 87.289456 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 352.713444 55892.344093 
-L 365.963128 55892.344093 
-L 365.963128 170.346673 
-L 352.713444 170.346673 
+    <path d="M 352.745581 46913.520099 
+L 365.993769 46913.520099 
+L 365.993769 147.115253 
+L 352.745581 147.115253 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 406.720308 55892.344093 
-L 419.969992 55892.344093 
-L 419.969992 151.450274 
-L 406.720308 151.450274 
+    <path d="M 406.746344 46913.520099 
+L 419.994532 46913.520099 
+L 419.994532 131.255868 
+L 406.746344 131.255868 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 460.727172 55892.344093 
-L 473.976856 55892.344093 
-L 473.976856 201.222861 
-L 460.727172 201.222861 
+    <path d="M 460.747107 46913.520099 
+L 473.995294 46913.520099 
+L 473.995294 173.029047 
+L 460.747107 173.029047 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 514.734036 55892.344093 
-L 527.98372 55892.344093 
-L 527.98372 150.002574 
-L 514.734036 150.002574 
+    <path d="M 514.74787 46913.520099 
+L 527.996057 46913.520099 
+L 527.996057 130.040841 
+L 514.74787 130.040841 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 568.740899 55892.344093 
-L 581.990583 55892.344093 
-L 581.990583 160.106249 
-L 568.740899 160.106249 
+    <path d="M 568.748633 46913.520099 
+L 581.99682 46913.520099 
+L 581.99682 138.520662 
+L 568.748633 138.520662 
 z
-" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 97.080955 55892.344093 
-L 110.330639 55892.344093 
-L 110.330639 316.6 
-L 97.080955 316.6 
+    <path d="M 97.141971 46913.520099 
+L 110.390158 46913.520099 
+L 110.390158 269.862869 
+L 97.141971 269.862869 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 151.087819 55892.344093 
-L 164.337503 55892.344093 
-L 164.337503 333.363493 
-L 151.087819 333.363493 
+    <path d="M 151.142733 46913.520099 
+L 164.390921 46913.520099 
+L 164.390921 283.932147 
+L 151.142733 283.932147 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 205.094683 55892.344093 
-L 218.344367 55892.344093 
-L 218.344367 226.788715 
-L 205.094683 226.788715 
+    <path d="M 205.143496 46913.520099 
+L 218.391683 46913.520099 
+L 218.391683 194.485977 
+L 205.143496 194.485977 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 259.101547 55892.344093 
-L 272.351231 55892.344093 
-L 272.351231 210.926616 
-L 259.101547 210.926616 
+    <path d="M 259.144259 46913.520099 
+L 272.392446 46913.520099 
+L 272.392446 181.173222 
+L 259.144259 181.173222 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 313.108411 55892.344093 
-L 326.358095 55892.344093 
-L 326.358095 98.846429 
-L 313.108411 98.846429 
+    <path d="M 313.145022 46913.520099 
+L 326.393209 46913.520099 
+L 326.393209 87.106468 
+L 313.145022 87.106468 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 367.115275 55892.344093 
-L 380.364958 55892.344093 
-L 380.364958 233.550365 
-L 367.115275 233.550365 
+    <path d="M 367.145785 46913.520099 
+L 380.393972 46913.520099 
+L 380.393972 200.160901 
+L 367.145785 200.160901 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 421.122138 55892.344093 
-L 434.371822 55892.344093 
-L 434.371822 214.552859 
-L 421.122138 214.552859 
+    <path d="M 421.146548 46913.520099 
+L 434.394735 46913.520099 
+L 434.394735 184.216658 
+L 421.146548 184.216658 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 475.129002 55892.344093 
-L 488.378686 55892.344093 
-L 488.378686 252.775432 
-L 475.129002 252.775432 
+    <path d="M 475.147311 46913.520099 
+L 488.395498 46913.520099 
+L 488.395498 216.296132 
+L 475.147311 216.296132 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 529.135866 55892.344093 
-L 542.38555 55892.344093 
-L 542.38555 161.138792 
-L 529.135866 161.138792 
+    <path d="M 529.148074 46913.520099 
+L 542.396261 46913.520099 
+L 542.396261 139.387256 
+L 529.148074 139.387256 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 583.14273 55892.344093 
-L 596.392414 55892.344093 
-L 596.392414 160.944225 
-L 583.14273 160.944225 
+    <path d="M 583.148836 46913.520099 
+L 596.397024 46913.520099 
+L 596.397024 139.223959 
+L 583.148836 139.223959 
 z
-" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 111.482786 55892.344093 
-L 124.73247 55892.344093 
-L 124.73247 219.684217 
-L 111.482786 219.684217 
+    <path d="M 111.542174 46913.520099 
+L 124.790361 46913.520099 
+L 124.790361 188.523309 
+L 111.542174 188.523309 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 165.48965 55892.344093 
-L 178.739334 55892.344093 
-L 178.739334 112.848096 
-L 165.48965 112.848096 
+    <path d="M 165.542937 46913.520099 
+L 178.791124 46913.520099 
+L 178.791124 98.857799 
+L 165.542937 98.857799 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 219.496513 55892.344093 
-L 232.746197 55892.344093 
-L 232.746197 110.388746 
-L 219.496513 110.388746 
+    <path d="M 219.5437 46913.520099 
+L 232.791887 46913.520099 
+L 232.791887 96.793714 
+L 219.5437 96.793714 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 273.503377 55892.344093 
-L 286.753061 55892.344093 
-L 286.753061 104.31826 
-L 273.503377 104.31826 
+    <path d="M 273.544463 46913.520099 
+L 286.79265 46913.520099 
+L 286.79265 91.698872 
+L 273.544463 91.698872 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 327.510241 55892.344093 
-L 340.759925 55892.344093 
-L 340.759925 54.523072 
-L 327.510241 54.523072 
+    <path d="M 327.545225 46913.520099 
+L 340.793413 46913.520099 
+L 340.793413 49.906724 
+L 327.545225 49.906724 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 381.517105 55892.344093 
-L 394.766789 55892.344093 
-L 394.766789 166.061493 
-L 381.517105 166.061493 
+    <path d="M 381.545988 46913.520099 
+L 394.794176 46913.520099 
+L 394.794176 143.518784 
+L 381.545988 143.518784 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 435.523969 55892.344093 
-L 448.773653 55892.344093 
-L 448.773653 114.562554 
-L 435.523969 114.562554 
+    <path d="M 435.546751 46913.520099 
+L 448.794938 46913.520099 
+L 448.794938 100.296711 
+L 435.546751 100.296711 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 489.530832 55892.344093 
-L 502.780516 55892.344093 
-L 502.780516 266.309521 
-L 489.530832 266.309521 
+    <path d="M 489.547514 46913.520099 
+L 502.795701 46913.520099 
+L 502.795701 227.655033 
+L 489.547514 227.655033 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 543.537696 55892.344093 
-L 556.78738 55892.344093 
-L 556.78738 117.721287 
-L 543.537696 117.721287 
+    <path d="M 543.548277 46913.520099 
+L 556.796464 46913.520099 
+L 556.796464 102.947775 
+L 543.548277 102.947775 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 597.54456 55892.344093 
-L 610.794244 55892.344093 
-L 610.794244 40.01539 
-L 597.54456 40.01539 
+    <path d="M 597.54904 46913.520099 
+L 610.797227 46913.520099 
+L 610.797227 37.730705 
+L 597.54904 37.730705 
 z
-" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m14927eba02" d="M 0 0 
+       <path id="mc084af4e0b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m14927eba02" x="103.705797" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="103.766064" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(96.58861 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(96.648877 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -342,12 +342,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m14927eba02" x="157.712661" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="157.766827" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(150.595474 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(150.64964 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -382,12 +382,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m14927eba02" x="211.719525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="211.76759" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(204.602338 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(204.650402 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -430,12 +430,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m14927eba02" x="265.726389" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="265.768353" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(258.609201 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(258.651165 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -465,12 +465,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m14927eba02" x="319.733253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="319.769116" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(312.616065 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(312.651928 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -506,12 +506,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m14927eba02" x="373.740116" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="373.769879" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(366.622929 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(366.652691 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -552,12 +552,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m14927eba02" x="427.74698" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="427.770641" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(420.629793 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(420.653454 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -578,12 +578,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m14927eba02" x="481.753844" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="481.771404" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(474.636657 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(474.654217 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -633,12 +633,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m14927eba02" x="535.760708" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="535.772167" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(528.64352 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(528.65498 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -679,12 +679,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m14927eba02" x="589.767572" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc084af4e0b" x="589.77293" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- Q10 -->
-      <g transform="translate(579.469134 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(579.474492 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -716,7 +716,7 @@ z
     </g>
     <g id="text_11">
      <!-- BerlinMOD R-query -->
-     <g transform="translate(299.025747 344.876563) scale(0.1 -0.1)">
+     <g transform="translate(299.05856 344.876563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-42" d="M 1259 2228 
 L 1259 519 
@@ -1012,23 +1012,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 56.273369 316.6 
+      <path d="M 56.338994 316.6 
 L 637.2 316.6 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <defs>
-       <path id="m5dc2cb6f35" d="M 0 0 
+       <path id="m7fa49ed188" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.773369 320.399219) scale(0.1 -0.1)">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g transform="translate(25.838994 320.399219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -1041,24 +1041,45 @@ z
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 56.273369 260.912882 
-L 637.2 260.912882 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 269.862869 
+L 637.2 269.862869 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="260.912882" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="269.862869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(25.838994 273.662087) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 56.338994 223.125737 
+L 637.2 223.125737 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="223.125737" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.773369 264.7121) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 226.924956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -1066,574 +1087,670 @@ L 637.2 260.912882
       </g>
      </g>
     </g>
-    <g id="ytick_3">
-     <g id="line2d_15">
-      <path d="M 56.273369 205.225763 
-L 637.2 205.225763 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 56.338994 176.388606 
+L 637.2 176.388606 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_16">
+     <g id="line2d_18">
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="205.225763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="176.388606" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_14">
+     <g id="text_15">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.673369 209.024982) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 180.187824) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_17">
-      <path d="M 56.273369 149.538645 
-L 637.2 149.538645 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 56.338994 129.651474 
+L 637.2 129.651474 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_18">
+     <g id="line2d_20">
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="149.538645" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="129.651474" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_15">
+     <g id="text_16">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.673369 153.337864) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 133.450693) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_5">
-     <g id="line2d_19">
-      <path d="M 56.273369 93.851527 
-L 637.2 93.851527 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 56.338994 82.914343 
+L 637.2 82.914343 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_20">
+     <g id="line2d_22">
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="93.851527" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="82.914343" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_16">
+     <g id="text_17">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.673369 97.650745) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 86.713561) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_21">
-      <path d="M 56.273369 38.164408 
-L 637.2 38.164408 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 56.338994 36.177211 
+L 637.2 36.177211 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_22">
+     <g id="line2d_24">
       <g>
-       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="38.164408" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fa49ed188" x="56.338994" y="36.177211" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_17">
+     <g id="text_18">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(31.673369 41.963627) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 39.97643) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_23">
-      <path d="M 56.273369 299.836507 
-L 637.2 299.836507 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 56.338994 302.530722 
+L 637.2 302.530722 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_24">
+     <g id="line2d_26">
       <defs>
-       <path id="m1449cbf260" d="M 0 0 
+       <path id="m600444c660" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="299.836507" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_25">
-      <path d="M 56.273369 290.030492 
-L 637.2 290.030492 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_26">
-      <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="290.030492" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="302.530722" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 56.273369 283.073014 
-L 637.2 283.073014 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 294.300721 
+L 637.2 294.300721 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="283.073014" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="294.300721" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 56.273369 277.676375 
-L 637.2 277.676375 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 288.461443 
+L 637.2 288.461443 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="277.676375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="288.461443" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 56.273369 273.266999 
-L 637.2 273.266999 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 283.932147 
+L 637.2 283.932147 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="273.266999" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="283.932147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 56.273369 269.538925 
-L 637.2 269.538925 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 280.231443 
+L 637.2 280.231443 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="269.538925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="280.231443" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 56.273369 266.309521 
-L 637.2 266.309521 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 277.102542 
+L 637.2 277.102542 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="266.309521" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="277.102542" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 56.273369 263.460984 
-L 637.2 263.460984 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 274.392165 
+L 637.2 274.392165 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="263.460984" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="274.392165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 56.273369 244.149389 
-L 637.2 244.149389 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 272.001442 
+L 637.2 272.001442 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="244.149389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="272.001442" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 56.273369 234.343374 
-L 637.2 234.343374 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 255.79359 
+L 637.2 255.79359 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="234.343374" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="255.79359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 56.273369 227.385896 
-L 637.2 227.385896 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 247.56359 
+L 637.2 247.56359 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="227.385896" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="247.56359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 56.273369 221.989256 
-L 637.2 221.989256 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 241.724312 
+L 637.2 241.724312 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="221.989256" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="241.724312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 56.273369 217.579881 
-L 637.2 217.579881 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 237.195016 
+L 637.2 237.195016 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="217.579881" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="237.195016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 56.273369 213.851807 
-L 637.2 213.851807 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 233.494311 
+L 637.2 233.494311 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="213.851807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="233.494311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 56.273369 210.622403 
-L 637.2 210.622403 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 230.36541 
+L 637.2 230.36541 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="210.622403" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="230.36541" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 56.273369 207.773866 
-L 637.2 207.773866 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 227.655033 
+L 637.2 227.655033 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="207.773866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="227.655033" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 56.273369 188.46227 
-L 637.2 188.46227 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 225.264311 
+L 637.2 225.264311 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="188.46227" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="225.264311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 56.273369 178.656256 
-L 637.2 178.656256 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 209.056459 
+L 637.2 209.056459 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="178.656256" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="209.056459" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 56.273369 171.698777 
-L 637.2 171.698777 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 200.826458 
+L 637.2 200.826458 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="171.698777" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="200.826458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 56.273369 166.302138 
-L 637.2 166.302138 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 194.98718 
+L 637.2 194.98718 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="166.302138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="194.98718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63">
-      <path d="M 56.273369 161.892763 
-L 637.2 161.892763 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 190.457884 
+L 637.2 190.457884 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="161.892763" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="190.457884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_65">
-      <path d="M 56.273369 158.164689 
-L 637.2 158.164689 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 186.75718 
+L 637.2 186.75718 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="158.164689" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="186.75718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_67">
-      <path d="M 56.273369 154.935284 
-L 637.2 154.935284 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 183.628279 
+L 637.2 183.628279 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="154.935284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="183.628279" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_69">
-      <path d="M 56.273369 152.086748 
-L 637.2 152.086748 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 180.917902 
+L 637.2 180.917902 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="152.086748" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="180.917902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_71">
-      <path d="M 56.273369 132.775152 
-L 637.2 132.775152 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 178.527179 
+L 637.2 178.527179 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="132.775152" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="178.527179" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_73">
-      <path d="M 56.273369 122.969137 
-L 637.2 122.969137 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 162.319327 
+L 637.2 162.319327 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="122.969137" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="162.319327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_75">
-      <path d="M 56.273369 116.011659 
-L 637.2 116.011659 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 154.089327 
+L 637.2 154.089327 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="116.011659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="154.089327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_77">
-      <path d="M 56.273369 110.61502 
-L 637.2 110.61502 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 148.250049 
+L 637.2 148.250049 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="110.61502" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="148.250049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_79">
-      <path d="M 56.273369 106.205644 
-L 637.2 106.205644 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 143.720753 
+L 637.2 143.720753 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="106.205644" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="143.720753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_81">
-      <path d="M 56.273369 102.47757 
-L 637.2 102.47757 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 140.020048 
+L 637.2 140.020048 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="102.47757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="140.020048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_83">
-      <path d="M 56.273369 99.248166 
-L 637.2 99.248166 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 136.891147 
+L 637.2 136.891147 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="99.248166" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="136.891147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_85">
-      <path d="M 56.273369 96.399629 
-L 637.2 96.399629 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 134.18077 
+L 637.2 134.18077 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="96.399629" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="134.18077" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_87">
-      <path d="M 56.273369 77.088034 
-L 637.2 77.088034 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 131.790048 
+L 637.2 131.790048 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="77.088034" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="131.790048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_89">
-      <path d="M 56.273369 67.282019 
-L 637.2 67.282019 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 115.582196 
+L 637.2 115.582196 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="67.282019" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="115.582196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_91">
-      <path d="M 56.273369 60.324541 
-L 637.2 60.324541 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 107.352195 
+L 637.2 107.352195 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="60.324541" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="107.352195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_93">
-      <path d="M 56.273369 54.927901 
-L 637.2 54.927901 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 101.512917 
+L 637.2 101.512917 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="54.927901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="101.512917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_95">
-      <path d="M 56.273369 50.518526 
-L 637.2 50.518526 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 96.983621 
+L 637.2 96.983621 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="50.518526" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="96.983621" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_97">
-      <path d="M 56.273369 46.790452 
-L 637.2 46.790452 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 93.282917 
+L 637.2 93.282917 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="46.790452" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="93.282917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_99">
-      <path d="M 56.273369 43.561048 
-L 637.2 43.561048 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 90.154016 
+L 637.2 90.154016 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="43.561048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="90.154016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_101">
-      <path d="M 56.273369 40.712511 
-L 637.2 40.712511 
-" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 87.443639 
+L 637.2 87.443639 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#m1449cbf260" x="56.273369" y="40.712511" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m600444c660" x="56.338994" y="87.443639" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_18">
+    <g id="ytick_47">
+     <g id="line2d_103">
+      <path d="M 56.338994 85.052916 
+L 637.2 85.052916 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="85.052916" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_105">
+      <path d="M 56.338994 68.845064 
+L 637.2 68.845064 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="68.845064" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_107">
+      <path d="M 56.338994 60.615064 
+L 637.2 60.615064 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="60.615064" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_109">
+      <path d="M 56.338994 54.775786 
+L 637.2 54.775786 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="54.775786" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_111">
+      <path d="M 56.338994 50.24649 
+L 637.2 50.24649 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="50.24649" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_113">
+      <path d="M 56.338994 46.545785 
+L 637.2 46.545785 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="46.545785" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_115">
+      <path d="M 56.338994 43.416884 
+L 637.2 43.416884 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="43.416884" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_117">
+      <path d="M 56.338994 40.706507 
+L 637.2 40.706507 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="40.706507" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_119">
+      <path d="M 56.338994 38.315785 
+L 637.2 38.315785 
+" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m600444c660" x="56.338994" y="38.315785" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_19">
      <!-- Wall-clock seconds (log scale) -->
-     <g transform="translate(19.693682 245.925781) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-57" d="M 213 4666 
 L 850 4666 
@@ -1892,8 +2009,8 @@ z
     </g>
    </g>
    <g id="patch_33">
-    <path d="M 56.273369 316.6 
-L 56.273369 25.8 
+    <path d="M 56.338994 316.6 
+L 56.338994 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_34">
@@ -1902,18 +2019,18 @@ L 637.2 25.8
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_35">
-    <path d="M 56.273369 316.6 
+    <path d="M 56.338994 316.6 
 L 637.2 316.6 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_36">
-    <path d="M 56.273369 25.8 
+    <path d="M 56.338994 25.8 
 L 637.2 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_19">
+   <g id="text_20">
     <!-- BerlinMOD R-queries Q1-Q10 — standard index per platform (sf 0.005) -->
-    <g transform="translate(134.425747 19.8) scale(0.12 -0.12)">
+    <g transform="translate(134.45856 19.8) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2114,29 +2231,29 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_37">
-     <path d="M 62.573369 59.420625 
-L 315.147119 59.420625 
-Q 316.947119 59.420625 316.947119 57.620625 
-L 316.947119 32.1 
-Q 316.947119 30.3 315.147119 30.3 
-L 62.573369 30.3 
-Q 60.773369 30.3 60.773369 32.1 
-L 60.773369 57.620625 
-Q 60.773369 59.420625 62.573369 59.420625 
+     <path d="M 62.638994 59.420625 
+L 315.212744 59.420625 
+Q 317.012744 59.420625 317.012744 57.620625 
+L 317.012744 32.1 
+Q 317.012744 30.3 315.212744 30.3 
+L 62.638994 30.3 
+Q 60.838994 30.3 60.838994 32.1 
+L 60.838994 57.620625 
+Q 60.838994 59.420625 62.638994 59.420625 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="patch_38">
-     <path d="M 64.373369 40.738594 
-L 82.373369 40.738594 
-L 82.373369 34.438594 
-L 64.373369 34.438594 
+     <path d="M 64.438994 40.738594 
+L 82.438994 40.738594 
+L 82.438994 34.438594 
+L 64.438994 34.438594 
 z
 " style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_20">
+    <g id="text_21">
      <!-- MobilityDB GiST -->
-     <g transform="translate(89.573369 40.738594) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -2250,16 +2367,16 @@ z
      </g>
     </g>
     <g id="patch_39">
-     <path d="M 64.373369 53.948906 
-L 82.373369 53.948906 
-L 82.373369 47.648906 
-L 64.373369 47.648906 
+     <path d="M 64.438994 53.948906 
+L 82.438994 53.948906 
+L 82.438994 47.648906 
+L 64.438994 47.648906 
 z
 " style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_21">
+    <g id="text_22">
      <!-- MobilityDuck rtree -->
-     <g transform="translate(89.573369 53.948906) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2281,16 +2398,16 @@ z
      </g>
     </g>
     <g id="patch_40">
-     <path d="M 190.370557 40.738594 
-L 208.370557 40.738594 
-L 208.370557 34.438594 
-L 190.370557 34.438594 
+     <path d="M 190.436182 40.738594 
+L 208.436182 40.738594 
+L 208.436182 34.438594 
+L 190.436182 34.438594 
 z
 " style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_22">
+    <g id="text_23">
      <!-- MobilitySpark local[4] -->
-     <g transform="translate(215.570557 40.738594) scale(0.09 -0.09)">
+     <g transform="translate(215.636182 40.738594) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-5b" d="M 550 4863 
 L 1875 4863 
@@ -2343,8 +2460,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p458f29867d">
-   <rect x="56.273369" y="25.8" width="580.926631" height="290.8"/>
+  <clipPath id="pea80fdf40a">
+   <rect x="56.338994" y="25.8" width="580.861006" height="290.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-15T18:17:27.122564</dc:date>
+    <dc:date>2026-05-15T19:31:44.533919</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 117.110514 44848.601475
 L 117.110514 187.421704 
 L 103.359949 187.421704 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 159.408449 44848.601475 
@@ -51,7 +51,7 @@ L 173.159014 44848.601475
 L 173.159014 219.402709 
 L 159.408449 219.402709 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 215.456949 44848.601475 
@@ -59,7 +59,7 @@ L 229.207514 44848.601475
 L 229.207514 148.840096 
 L 215.456949 148.840096 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 271.505449 44848.601475 
@@ -67,15 +67,15 @@ L 285.256014 44848.601475
 L 285.256014 129.826543 
 L 271.505449 129.826543 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 327.553948 44848.601475 
 L 341.304514 44848.601475 
-L 341.304514 125.628657 
-L 327.553948 125.628657 
+L 341.304514 138.931 
+L 327.553948 138.931 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 383.602448 44848.601475 
@@ -83,7 +83,7 @@ L 397.353014 44848.601475
 L 397.353014 154.625883 
 L 383.602448 154.625883 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 439.650948 44848.601475 
@@ -91,7 +91,7 @@ L 453.401513 44848.601475
 L 453.401513 139.469298 
 L 439.650948 139.469298 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 495.699448 44848.601475 
@@ -99,7 +99,7 @@ L 509.450013 44848.601475
 L 509.450013 179.39132 
 L 495.699448 179.39132 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 551.747948 44848.601475 
@@ -107,7 +107,7 @@ L 565.498513 44848.601475
 L 565.498513 138.308114 
 L 551.747948 138.308114 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 607.796448 44848.601475 
@@ -115,7 +115,7 @@ L 621.547013 44848.601475
 L 621.547013 146.412156 
 L 607.796448 146.412156 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 663.844948 44848.601475 
@@ -123,7 +123,7 @@ L 677.595513 44848.601475
 L 677.595513 166.360909 
 L 663.844948 166.360909 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 719.893447 44848.601475 
@@ -131,7 +131,7 @@ L 733.644013 44848.601475
 L 733.644013 165.863492 
 L 719.893447 165.863492 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 775.941947 44848.601475 
@@ -139,7 +139,7 @@ L 789.692513 44848.601475
 L 789.692513 153.211265 
 L 775.941947 153.211265 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 831.990447 44848.601475 
@@ -147,7 +147,7 @@ L 845.741012 44848.601475
 L 845.741012 198.527544 
 L 831.990447 198.527544 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 888.038947 44848.601475 
@@ -155,7 +155,7 @@ L 901.789512 44848.601475
 L 901.789512 155.089977 
 L 888.038947 155.089977 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 944.087447 44848.601475 
@@ -163,7 +163,7 @@ L 957.838012 44848.601475
 L 957.838012 128.399018 
 L 944.087447 128.399018 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 1000.135947 44848.601475 
@@ -171,7 +171,7 @@ L 1013.886512 44848.601475
 L 1013.886512 138.447028 
 L 1000.135947 138.447028 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 118.306216 44848.601475 
@@ -179,7 +179,7 @@ L 132.056781 44848.601475
 L 132.056781 271.934001 
 L 118.306216 271.934001 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 174.354715 44848.601475 
@@ -187,7 +187,7 @@ L 188.105281 44848.601475
 L 188.105281 285.379806 
 L 174.354715 285.379806 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 230.403215 44848.601475 
@@ -195,7 +195,7 @@ L 244.153781 44848.601475
 L 244.153781 199.897398 
 L 230.403215 199.897398 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 286.451715 44848.601475 
@@ -203,7 +203,7 @@ L 300.20228 44848.601475
 L 300.20228 187.17459 
 L 286.451715 187.17459 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 342.500215 44848.601475 
@@ -211,7 +211,7 @@ L 356.25078 44848.601475
 L 356.25078 97.276357 
 L 342.500215 97.276357 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 398.548715 44848.601475 
@@ -219,7 +219,7 @@ L 412.29928 44848.601475
 L 412.29928 205.32084 
 L 398.548715 205.32084 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 454.597215 44848.601475 
@@ -227,7 +227,7 @@ L 468.34778 44848.601475
 L 468.34778 190.083158 
 L 454.597215 190.083158 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 510.645715 44848.601475 
@@ -235,7 +235,7 @@ L 524.39628 44848.601475
 L 524.39628 220.741046 
 L 510.645715 220.741046 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 566.694214 44848.601475 
@@ -243,7 +243,7 @@ L 580.44478 44848.601475
 L 580.44478 147.240347 
 L 566.694214 147.240347 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 622.742714 44848.601475 
@@ -251,7 +251,7 @@ L 636.49328 44848.601475
 L 636.49328 147.084287 
 L 622.742714 147.084287 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 678.791214 44848.601475 
@@ -259,7 +259,7 @@ L 692.541779 44848.601475
 L 692.541779 191.875034 
 L 678.791214 191.875034 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 734.839714 44848.601475 
@@ -267,7 +267,7 @@ L 748.590279 44848.601475
 L 748.590279 190.958413 
 L 734.839714 190.958413 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 790.888214 44848.601475 
@@ -275,7 +275,7 @@ L 804.638779 44848.601475
 L 804.638779 143.413334 
 L 790.888214 143.413334 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 846.936714 44848.601475 
@@ -283,7 +283,7 @@ L 860.687279 44848.601475
 L 860.687279 194.554902 
 L 846.936714 194.554902 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 902.985214 44848.601475 
@@ -291,7 +291,7 @@ L 916.735779 44848.601475
 L 916.735779 143.542397 
 L 902.985214 143.542397 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 959.033713 44848.601475 
@@ -299,7 +299,7 @@ L 972.784279 44848.601475
 L 972.784279 159.559981 
 L 959.033713 159.559981 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 1015.082213 44848.601475 
@@ -307,7 +307,7 @@ L 1028.832779 44848.601475
 L 1028.832779 189.520852 
 L 1015.082213 189.520852 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 133.252482 44848.601475 
@@ -315,7 +315,7 @@ L 147.003048 44848.601475
 L 147.003048 197.66526 
 L 133.252482 197.66526 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 189.300982 44848.601475 
@@ -323,7 +323,7 @@ L 203.051547 44848.601475
 L 203.051547 106.74687 
 L 189.300982 106.74687 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 245.349482 44848.601475 
@@ -331,7 +331,7 @@ L 259.100047 44848.601475
 L 259.100047 110.527585 
 L 245.349482 110.527585 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 301.397982 44848.601475 
@@ -339,7 +339,7 @@ L 315.148547 44848.601475
 L 315.148547 107.649645 
 L 301.397982 107.649645 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 357.446482 44848.601475 
@@ -347,7 +347,7 @@ L 371.197047 44848.601475
 L 371.197047 138.727875 
 L 357.446482 138.727875 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
     <path d="M 413.494981 44848.601475 
@@ -355,7 +355,7 @@ L 427.245547 44848.601475
 L 427.245547 156.351304 
 L 413.494981 156.351304 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
     <path d="M 469.543481 44848.601475 
@@ -363,7 +363,7 @@ L 483.294047 44848.601475
 L 483.294047 107.362738 
 L 469.543481 107.362738 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
     <path d="M 525.591981 44848.601475 
@@ -371,7 +371,7 @@ L 539.342546 44848.601475
 L 539.342546 227.268001 
 L 525.591981 227.268001 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
     <path d="M 581.640481 44848.601475 
@@ -379,7 +379,7 @@ L 595.391046 44848.601475
 L 595.391046 109.173514 
 L 581.640481 109.173514 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
     <path d="M 637.688981 44848.601475 
@@ -387,7 +387,7 @@ L 651.439546 44848.601475
 L 651.439546 45.783708 
 L 637.688981 45.783708 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
     <path d="M 693.737481 44848.601475 
@@ -395,7 +395,7 @@ L 707.488046 44848.601475
 L 707.488046 37.202002 
 L 693.737481 37.202002 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: url(#hae9972d31e); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
     <path d="M 749.785981 44848.601475 
@@ -403,7 +403,7 @@ L 763.536546 44848.601475
 L 763.536546 37.202002 
 L 749.785981 37.202002 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: url(#hae9972d31e); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
     <path d="M 805.83448 44848.601475 
@@ -411,7 +411,7 @@ L 819.585046 44848.601475
 L 819.585046 91.320899 
 L 805.83448 91.320899 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
     <path d="M 861.88298 44848.601475 
@@ -419,7 +419,7 @@ L 875.633546 44848.601475
 L 875.633546 37.202002 
 L 861.88298 37.202002 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: url(#hae9972d31e); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
     <path d="M 917.93148 44848.601475 
@@ -427,7 +427,7 @@ L 931.682045 44848.601475
 L 931.682045 74.593563 
 L 917.93148 74.593563 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
     <path d="M 973.97998 44848.601475 
@@ -435,7 +435,7 @@ L 987.730545 44848.601475
 L 987.730545 100.286088 
 L 973.97998 100.286088 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
     <path d="M 1030.02848 44848.601475 
@@ -443,18 +443,18 @@ L 1043.779045 44848.601475
 L 1043.779045 93.414083 
 L 1030.02848 93.414083 
 z
-" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p135379ee2c)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mceacd4033b" d="M 0 0 
+       <path id="mde81129bb7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mceacd4033b" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -510,7 +510,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mceacd4033b" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -550,7 +550,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mceacd4033b" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -598,7 +598,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mceacd4033b" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -633,7 +633,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mceacd4033b" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -674,7 +674,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mceacd4033b" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,7 +720,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mceacd4033b" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mceacd4033b" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -801,7 +801,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mceacd4033b" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -847,7 +847,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mceacd4033b" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -885,7 +885,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mceacd4033b" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -900,7 +900,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mceacd4033b" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -915,7 +915,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mceacd4033b" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -930,7 +930,7 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mceacd4033b" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -945,7 +945,7 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mceacd4033b" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -960,7 +960,7 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mceacd4033b" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -975,7 +975,7 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mceacd4033b" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde81129bb7" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1287,16 +1287,16 @@ z
      <g id="line2d_18">
       <path d="M 56.338994 316.6 
 L 1090.8 316.6 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="m4fb5afb276" d="M 0 0 
+       <path id="m83cc368dcd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1322,11 +1322,11 @@ z
      <g id="line2d_20">
       <path d="M 56.338994 271.934001 
 L 1090.8 271.934001 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1343,11 +1343,11 @@ L 1090.8 271.934001
      <g id="line2d_22">
       <path d="M 56.338994 227.268001 
 L 1090.8 227.268001 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1364,11 +1364,11 @@ L 1090.8 227.268001
      <g id="line2d_24">
       <path d="M 56.338994 182.602002 
 L 1090.8 182.602002 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1384,11 +1384,11 @@ L 1090.8 182.602002
      <g id="line2d_26">
       <path d="M 56.338994 137.936002 
 L 1090.8 137.936002 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -1404,11 +1404,11 @@ L 1090.8 137.936002
      <g id="line2d_28">
       <path d="M 56.338994 93.270003 
 L 1090.8 93.270003 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -1424,11 +1424,11 @@ L 1090.8 93.270003
      <g id="line2d_30">
       <path d="M 56.338994 48.604003 
 L 1090.8 48.604003 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m4fb5afb276" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83cc368dcd" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
@@ -1444,16 +1444,16 @@ L 1090.8 48.604003
      <g id="line2d_32">
       <path d="M 56.338994 303.154194 
 L 1090.8 303.154194 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <defs>
-       <path id="m095cbf0b45" d="M 0 0 
+       <path id="m61f8b8dbb9" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1461,11 +1461,11 @@ L -2 0
      <g id="line2d_34">
       <path d="M 56.338994 295.288902 
 L 1090.8 295.288902 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1473,11 +1473,11 @@ L 1090.8 295.288902
      <g id="line2d_36">
       <path d="M 56.338994 289.708389 
 L 1090.8 289.708389 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1485,11 +1485,11 @@ L 1090.8 289.708389
      <g id="line2d_38">
       <path d="M 56.338994 285.379806 
 L 1090.8 285.379806 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1497,11 +1497,11 @@ L 1090.8 285.379806
      <g id="line2d_40">
       <path d="M 56.338994 281.843097 
 L 1090.8 281.843097 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1509,11 +1509,11 @@ L 1090.8 281.843097
      <g id="line2d_42">
       <path d="M 56.338994 278.852851 
 L 1090.8 278.852851 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1521,11 +1521,11 @@ L 1090.8 278.852851
      <g id="line2d_44">
       <path d="M 56.338994 276.262583 
 L 1090.8 276.262583 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1533,11 +1533,11 @@ L 1090.8 276.262583
      <g id="line2d_46">
       <path d="M 56.338994 273.977805 
 L 1090.8 273.977805 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1545,11 +1545,11 @@ L 1090.8 273.977805
      <g id="line2d_48">
       <path d="M 56.338994 258.488195 
 L 1090.8 258.488195 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1557,11 +1557,11 @@ L 1090.8 258.488195
      <g id="line2d_50">
       <path d="M 56.338994 250.622903 
 L 1090.8 250.622903 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1569,11 +1569,11 @@ L 1090.8 250.622903
      <g id="line2d_52">
       <path d="M 56.338994 245.042389 
 L 1090.8 245.042389 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1581,11 +1581,11 @@ L 1090.8 245.042389
      <g id="line2d_54">
       <path d="M 56.338994 240.713807 
 L 1090.8 240.713807 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1593,11 +1593,11 @@ L 1090.8 240.713807
      <g id="line2d_56">
       <path d="M 56.338994 237.177097 
 L 1090.8 237.177097 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1605,11 +1605,11 @@ L 1090.8 237.177097
      <g id="line2d_58">
       <path d="M 56.338994 234.186852 
 L 1090.8 234.186852 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1617,11 +1617,11 @@ L 1090.8 234.186852
      <g id="line2d_60">
       <path d="M 56.338994 231.596584 
 L 1090.8 231.596584 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1629,11 +1629,11 @@ L 1090.8 231.596584
      <g id="line2d_62">
       <path d="M 56.338994 229.311805 
 L 1090.8 229.311805 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1641,11 +1641,11 @@ L 1090.8 229.311805
      <g id="line2d_64">
       <path d="M 56.338994 213.822195 
 L 1090.8 213.822195 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1653,11 +1653,11 @@ L 1090.8 213.822195
      <g id="line2d_66">
       <path d="M 56.338994 205.956903 
 L 1090.8 205.956903 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1665,11 +1665,11 @@ L 1090.8 205.956903
      <g id="line2d_68">
       <path d="M 56.338994 200.37639 
 L 1090.8 200.37639 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1677,11 +1677,11 @@ L 1090.8 200.37639
      <g id="line2d_70">
       <path d="M 56.338994 196.047807 
 L 1090.8 196.047807 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1689,11 +1689,11 @@ L 1090.8 196.047807
      <g id="line2d_72">
       <path d="M 56.338994 192.511098 
 L 1090.8 192.511098 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1701,11 +1701,11 @@ L 1090.8 192.511098
      <g id="line2d_74">
       <path d="M 56.338994 189.520852 
 L 1090.8 189.520852 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1713,11 +1713,11 @@ L 1090.8 189.520852
      <g id="line2d_76">
       <path d="M 56.338994 186.930584 
 L 1090.8 186.930584 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1725,11 +1725,11 @@ L 1090.8 186.930584
      <g id="line2d_78">
       <path d="M 56.338994 184.645806 
 L 1090.8 184.645806 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1737,11 +1737,11 @@ L 1090.8 184.645806
      <g id="line2d_80">
       <path d="M 56.338994 169.156196 
 L 1090.8 169.156196 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1749,11 +1749,11 @@ L 1090.8 169.156196
      <g id="line2d_82">
       <path d="M 56.338994 161.290904 
 L 1090.8 161.290904 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1761,11 +1761,11 @@ L 1090.8 161.290904
      <g id="line2d_84">
       <path d="M 56.338994 155.71039 
 L 1090.8 155.71039 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1773,11 +1773,11 @@ L 1090.8 155.71039
      <g id="line2d_86">
       <path d="M 56.338994 151.381808 
 L 1090.8 151.381808 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1785,11 +1785,11 @@ L 1090.8 151.381808
      <g id="line2d_88">
       <path d="M 56.338994 147.845098 
 L 1090.8 147.845098 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1797,11 +1797,11 @@ L 1090.8 147.845098
      <g id="line2d_90">
       <path d="M 56.338994 144.854853 
 L 1090.8 144.854853 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1809,11 +1809,11 @@ L 1090.8 144.854853
      <g id="line2d_92">
       <path d="M 56.338994 142.264585 
 L 1090.8 142.264585 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1821,11 +1821,11 @@ L 1090.8 142.264585
      <g id="line2d_94">
       <path d="M 56.338994 139.979806 
 L 1090.8 139.979806 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1833,11 +1833,11 @@ L 1090.8 139.979806
      <g id="line2d_96">
       <path d="M 56.338994 124.490196 
 L 1090.8 124.490196 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1845,11 +1845,11 @@ L 1090.8 124.490196
      <g id="line2d_98">
       <path d="M 56.338994 116.624904 
 L 1090.8 116.624904 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1857,11 +1857,11 @@ L 1090.8 116.624904
      <g id="line2d_100">
       <path d="M 56.338994 111.044391 
 L 1090.8 111.044391 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1869,11 +1869,11 @@ L 1090.8 111.044391
      <g id="line2d_102">
       <path d="M 56.338994 106.715808 
 L 1090.8 106.715808 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1881,11 +1881,11 @@ L 1090.8 106.715808
      <g id="line2d_104">
       <path d="M 56.338994 103.179099 
 L 1090.8 103.179099 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1893,11 +1893,11 @@ L 1090.8 103.179099
      <g id="line2d_106">
       <path d="M 56.338994 100.188853 
 L 1090.8 100.188853 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1905,11 +1905,11 @@ L 1090.8 100.188853
      <g id="line2d_108">
       <path d="M 56.338994 97.598585 
 L 1090.8 97.598585 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1917,11 +1917,11 @@ L 1090.8 97.598585
      <g id="line2d_110">
       <path d="M 56.338994 95.313807 
 L 1090.8 95.313807 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1929,11 +1929,11 @@ L 1090.8 95.313807
      <g id="line2d_112">
       <path d="M 56.338994 79.824197 
 L 1090.8 79.824197 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1941,11 +1941,11 @@ L 1090.8 79.824197
      <g id="line2d_114">
       <path d="M 56.338994 71.958905 
 L 1090.8 71.958905 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1953,11 +1953,11 @@ L 1090.8 71.958905
      <g id="line2d_116">
       <path d="M 56.338994 66.378391 
 L 1090.8 66.378391 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1965,11 +1965,11 @@ L 1090.8 66.378391
      <g id="line2d_118">
       <path d="M 56.338994 62.049809 
 L 1090.8 62.049809 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1977,11 +1977,11 @@ L 1090.8 62.049809
      <g id="line2d_120">
       <path d="M 56.338994 58.513099 
 L 1090.8 58.513099 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1989,11 +1989,11 @@ L 1090.8 58.513099
      <g id="line2d_122">
       <path d="M 56.338994 55.522854 
 L 1090.8 55.522854 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_123">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2001,11 +2001,11 @@ L 1090.8 55.522854
      <g id="line2d_124">
       <path d="M 56.338994 52.932586 
 L 1090.8 52.932586 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2013,11 +2013,11 @@ L 1090.8 52.932586
      <g id="line2d_126">
       <path d="M 56.338994 50.647807 
 L 1090.8 50.647807 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_127">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2025,11 +2025,11 @@ L 1090.8 50.647807
      <g id="line2d_128">
       <path d="M 56.338994 35.158198 
 L 1090.8 35.158198 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_129">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2037,11 +2037,11 @@ L 1090.8 35.158198
      <g id="line2d_130">
       <path d="M 56.338994 27.292905 
 L 1090.8 27.292905 
-" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p135379ee2c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_131">
       <g>
-       <use xlink:href="#m095cbf0b45" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m61f8b8dbb9" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2767,12 +2767,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p29fb347b4b">
+  <clipPath id="p135379ee2c">
    <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h2632259f3d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hae9972d31e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#2ca02c"/>
    <path d="M -36 36 
 L 36 -36 

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T23:51:32.317616</dc:date>
+    <dc:date>2026-05-13T00:35:15.337405</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 117.110514 48949.830888
 L 117.110514 175.52487 
 L 103.359949 175.52487 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 159.408449 48949.830888 
@@ -51,7 +51,7 @@ L 173.159014 48949.830888
 L 173.159014 210.451205 
 L 159.408449 210.451205 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 215.456949 48949.830888 
@@ -59,7 +59,7 @@ L 229.207514 48949.830888
 L 229.207514 133.390041 
 L 215.456949 133.390041 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 271.505449 48949.830888 
@@ -67,7 +67,7 @@ L 285.256014 48949.830888
 L 285.256014 112.625412 
 L 271.505449 112.625412 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 327.553948 48949.830888 
@@ -75,7 +75,7 @@ L 341.304514 48949.830888
 L 341.304514 77.26846 
 L 327.553948 77.26846 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 383.602448 48949.830888 
@@ -83,7 +83,7 @@ L 397.353014 48949.830888
 L 397.353014 139.708678 
 L 383.602448 139.708678 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 439.650948 48949.830888 
@@ -91,7 +91,7 @@ L 453.401513 48949.830888
 L 453.401513 123.156228 
 L 439.650948 123.156228 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 495.699448 48949.830888 
@@ -99,7 +99,7 @@ L 509.450013 48949.830888
 L 509.450013 166.754918 
 L 495.699448 166.754918 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 551.747948 48949.830888 
@@ -107,7 +107,7 @@ L 565.498513 48949.830888
 L 565.498513 121.888104 
 L 551.747948 121.888104 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 607.796448 48949.830888 
@@ -115,7 +115,7 @@ L 621.547013 48949.830888
 L 621.547013 130.738498 
 L 607.796448 130.738498 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 663.844948 48949.830888 
@@ -123,7 +123,7 @@ L 677.595513 48949.830888
 L 677.595513 152.524455 
 L 663.844948 152.524455 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 719.893447 48949.830888 
@@ -131,7 +131,7 @@ L 733.644013 48949.830888
 L 733.644013 151.981228 
 L 719.893447 151.981228 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 775.941947 48949.830888 
@@ -139,7 +139,7 @@ L 789.692513 48949.830888
 L 789.692513 138.163778 
 L 775.941947 138.163778 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 831.990447 48949.830888 
@@ -147,7 +147,7 @@ L 845.741012 48949.830888
 L 845.741012 187.653516 
 L 831.990447 187.653516 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 888.038947 48949.830888 
@@ -155,7 +155,7 @@ L 901.789512 48949.830888
 L 901.789512 140.215513 
 L 888.038947 140.215513 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 944.087447 48949.830888 
@@ -163,7 +163,7 @@ L 957.838012 48949.830888
 L 957.838012 111.066417 
 L 944.087447 111.066417 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 1000.135947 48949.830888 
@@ -171,7 +171,7 @@ L 1013.886512 48949.830888
 L 1013.886512 122.039811 
 L 1000.135947 122.039811 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 118.306216 48949.830888 
@@ -179,7 +179,7 @@ L 132.056781 48949.830888
 L 132.056781 267.82043 
 L 118.306216 267.82043 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 174.354715 48949.830888 
@@ -187,7 +187,7 @@ L 188.105281 48949.830888
 L 188.105281 282.504544 
 L 174.354715 282.504544 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 230.403215 48949.830888 
@@ -195,7 +195,7 @@ L 244.153781 48949.830888
 L 244.153781 189.149528 
 L 230.403215 189.149528 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 286.451715 48949.830888 
@@ -203,7 +203,7 @@ L 300.20228 48949.830888
 L 300.20228 175.254998 
 L 286.451715 175.254998 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 342.500215 48949.830888 
@@ -211,7 +211,7 @@ L 356.25078 48949.830888
 L 356.25078 77.077476 
 L 342.500215 77.077476 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 398.548715 48949.830888 
@@ -219,7 +219,7 @@ L 412.29928 48949.830888
 L 412.29928 195.072449 
 L 398.548715 195.072449 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 454.597215 48949.830888 
@@ -227,7 +227,7 @@ L 468.34778 48949.830888
 L 468.34778 178.431434 
 L 454.597215 178.431434 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 510.645715 48949.830888 
@@ -235,7 +235,7 @@ L 524.39628 48949.830888
 L 524.39628 211.912798 
 L 510.645715 211.912798 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 566.694214 48949.830888 
@@ -243,7 +243,7 @@ L 580.44478 48949.830888
 L 580.44478 131.642962 
 L 566.694214 131.642962 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 622.742714 48949.830888 
@@ -251,7 +251,7 @@ L 636.49328 48949.830888
 L 636.49328 131.472529 
 L 622.742714 131.472529 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 678.791214 48949.830888 
@@ -259,7 +259,7 @@ L 692.541779 48949.830888
 L 692.541779 180.388335 
 L 678.791214 180.388335 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 734.839714 48949.830888 
@@ -267,7 +267,7 @@ L 748.590279 48949.830888
 L 748.590279 179.387297 
 L 734.839714 179.387297 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 790.888214 48949.830888 
@@ -275,7 +275,7 @@ L 804.638779 48949.830888
 L 804.638779 127.463495 
 L 790.888214 127.463495 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 846.936714 48949.830888 
@@ -283,7 +283,7 @@ L 860.687279 48949.830888
 L 860.687279 183.315008 
 L 846.936714 183.315008 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 902.985214 48949.830888 
@@ -291,7 +291,7 @@ L 916.735779 48949.830888
 L 916.735779 127.604445 
 L 902.985214 127.604445 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 959.033713 48949.830888 
@@ -299,7 +299,7 @@ L 972.784279 48949.830888
 L 972.784279 145.097187 
 L 959.033713 145.097187 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 1015.082213 48949.830888 
@@ -307,7 +307,7 @@ L 1028.832779 48949.830888
 L 1028.832779 177.817342 
 L 1015.082213 177.817342 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 133.252482 48949.830888 
@@ -315,7 +315,7 @@ L 147.003048 48949.830888
 L 147.003048 182.926287 
 L 133.252482 182.926287 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 189.300982 48949.830888 
@@ -323,7 +323,7 @@ L 203.051547 48949.830888
 L 203.051547 89.342346 
 L 189.300982 89.342346 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 245.349482 48949.830888 
@@ -331,7 +331,7 @@ L 259.100047 48949.830888
 L 259.100047 87.18806 
 L 245.349482 87.18806 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 301.397982 48949.830888 
@@ -339,7 +339,7 @@ L 315.148547 48949.830888
 L 315.148547 81.87057 
 L 301.397982 81.87057 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 357.446482 48949.830888 
@@ -347,7 +347,7 @@ L 371.197047 48949.830888
 L 371.197047 38.252083 
 L 357.446482 38.252083 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
     <path d="M 413.494981 48949.830888 
@@ -355,7 +355,7 @@ L 427.245547 48949.830888
 L 427.245547 135.95504 
 L 413.494981 135.95504 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
     <path d="M 469.543481 48949.830888 
@@ -363,7 +363,7 @@ L 483.294047 48949.830888
 L 483.294047 90.844139 
 L 469.543481 90.844139 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
     <path d="M 525.591981 48949.830888 
@@ -371,7 +371,7 @@ L 539.342546 48949.830888
 L 539.342546 223.76809 
 L 525.591981 223.76809 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
     <path d="M 581.640481 48949.830888 
@@ -379,7 +379,7 @@ L 595.391046 48949.830888
 L 595.391046 93.611056 
 L 581.640481 93.611056 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
     <path d="M 637.688981 48949.830888 
@@ -387,7 +387,7 @@ L 651.439546 48949.830888
 L 651.439546 316.6 
 L 637.688981 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
     <path d="M 693.737481 48949.830888 
@@ -395,7 +395,7 @@ L 707.488046 48949.830888
 L 707.488046 316.6 
 L 693.737481 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
     <path d="M 749.785981 48949.830888 
@@ -403,7 +403,7 @@ L 763.536546 48949.830888
 L 763.536546 316.6 
 L 749.785981 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
     <path d="M 805.83448 48949.830888 
@@ -411,7 +411,7 @@ L 819.585046 48949.830888
 L 819.585046 316.6 
 L 805.83448 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
     <path d="M 861.88298 48949.830888 
@@ -419,7 +419,7 @@ L 875.633546 48949.830888
 L 875.633546 316.6 
 L 861.88298 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
     <path d="M 917.93148 48949.830888 
@@ -427,7 +427,7 @@ L 931.682045 48949.830888
 L 931.682045 316.6 
 L 917.93148 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
     <path d="M 973.97998 48949.830888 
@@ -435,7 +435,7 @@ L 987.730545 48949.830888
 L 987.730545 316.6 
 L 973.97998 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
     <path d="M 1030.02848 48949.830888 
@@ -443,18 +443,18 @@ L 1043.779045 48949.830888
 L 1043.779045 316.6 
 L 1030.02848 316.6 
 z
-" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m967ff3b26b" d="M 0 0 
+       <path id="me83e0dc554" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m967ff3b26b" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -510,7 +510,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m967ff3b26b" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -550,7 +550,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m967ff3b26b" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -598,7 +598,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m967ff3b26b" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -633,7 +633,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m967ff3b26b" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -674,7 +674,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m967ff3b26b" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,7 +720,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m967ff3b26b" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m967ff3b26b" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -801,7 +801,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m967ff3b26b" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -847,7 +847,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m967ff3b26b" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -885,7 +885,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m967ff3b26b" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -900,7 +900,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m967ff3b26b" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -915,7 +915,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m967ff3b26b" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -930,7 +930,7 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m967ff3b26b" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -945,7 +945,7 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m967ff3b26b" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -960,7 +960,7 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m967ff3b26b" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -975,7 +975,7 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m967ff3b26b" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me83e0dc554" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1287,16 +1287,16 @@ z
      <g id="line2d_18">
       <path d="M 56.338994 316.6 
 L 1090.8 316.6 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="m561b5576e6" d="M 0 0 
+       <path id="m99628d0e10" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1322,11 +1322,11 @@ z
      <g id="line2d_20">
       <path d="M 56.338994 267.82043 
 L 1090.8 267.82043 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="267.82043" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="267.82043" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1343,11 +1343,11 @@ L 1090.8 267.82043
      <g id="line2d_22">
       <path d="M 56.338994 219.040861 
 L 1090.8 219.040861 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="219.040861" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="219.040861" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1364,11 +1364,11 @@ L 1090.8 219.040861
      <g id="line2d_24">
       <path d="M 56.338994 170.261291 
 L 1090.8 170.261291 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="170.261291" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="170.261291" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1384,11 +1384,11 @@ L 1090.8 170.261291
      <g id="line2d_26">
       <path d="M 56.338994 121.481722 
 L 1090.8 121.481722 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="121.481722" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="121.481722" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -1404,11 +1404,11 @@ L 1090.8 121.481722
      <g id="line2d_28">
       <path d="M 56.338994 72.702152 
 L 1090.8 72.702152 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m561b5576e6" x="56.338994" y="72.702152" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m99628d0e10" x="56.338994" y="72.702152" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -1424,16 +1424,16 @@ L 1090.8 72.702152
      <g id="line2d_30">
       <path d="M 56.338994 301.915886 
 L 1090.8 301.915886 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <defs>
-       <path id="mde83ee3b22" d="M 0 0 
+       <path id="m9d10725750" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="301.915886" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="301.915886" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1441,11 +1441,11 @@ L -2 0
      <g id="line2d_32">
       <path d="M 56.338994 293.326231 
 L 1090.8 293.326231 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="293.326231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="293.326231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1453,11 +1453,11 @@ L 1090.8 293.326231
      <g id="line2d_34">
       <path d="M 56.338994 287.231773 
 L 1090.8 287.231773 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="287.231773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="287.231773" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1465,11 +1465,11 @@ L 1090.8 287.231773
      <g id="line2d_36">
       <path d="M 56.338994 282.504544 
 L 1090.8 282.504544 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="282.504544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="282.504544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1477,11 +1477,11 @@ L 1090.8 282.504544
      <g id="line2d_38">
       <path d="M 56.338994 278.642117 
 L 1090.8 278.642117 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="278.642117" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="278.642117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1489,11 +1489,11 @@ L 1090.8 278.642117
      <g id="line2d_40">
       <path d="M 56.338994 275.376481 
 L 1090.8 275.376481 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="275.376481" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="275.376481" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1501,11 +1501,11 @@ L 1090.8 275.376481
      <g id="line2d_42">
       <path d="M 56.338994 272.547659 
 L 1090.8 272.547659 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="272.547659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="272.547659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1513,11 +1513,11 @@ L 1090.8 272.547659
      <g id="line2d_44">
       <path d="M 56.338994 270.052461 
 L 1090.8 270.052461 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="270.052461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="270.052461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1525,11 +1525,11 @@ L 1090.8 270.052461
      <g id="line2d_46">
       <path d="M 56.338994 253.136317 
 L 1090.8 253.136317 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="253.136317" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="253.136317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1537,11 +1537,11 @@ L 1090.8 253.136317
      <g id="line2d_48">
       <path d="M 56.338994 244.546661 
 L 1090.8 244.546661 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="244.546661" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="244.546661" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1549,11 +1549,11 @@ L 1090.8 244.546661
      <g id="line2d_50">
       <path d="M 56.338994 238.452203 
 L 1090.8 238.452203 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="238.452203" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="238.452203" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1561,11 +1561,11 @@ L 1090.8 238.452203
      <g id="line2d_52">
       <path d="M 56.338994 233.724974 
 L 1090.8 233.724974 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="233.724974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="233.724974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1573,11 +1573,11 @@ L 1090.8 233.724974
      <g id="line2d_54">
       <path d="M 56.338994 229.862547 
 L 1090.8 229.862547 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="229.862547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="229.862547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1585,11 +1585,11 @@ L 1090.8 229.862547
      <g id="line2d_56">
       <path d="M 56.338994 226.596912 
 L 1090.8 226.596912 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="226.596912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="226.596912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1597,11 +1597,11 @@ L 1090.8 226.596912
      <g id="line2d_58">
       <path d="M 56.338994 223.76809 
 L 1090.8 223.76809 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="223.76809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="223.76809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1609,11 +1609,11 @@ L 1090.8 223.76809
      <g id="line2d_60">
       <path d="M 56.338994 221.272892 
 L 1090.8 221.272892 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="221.272892" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="221.272892" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1621,11 +1621,11 @@ L 1090.8 221.272892
      <g id="line2d_62">
       <path d="M 56.338994 204.356747 
 L 1090.8 204.356747 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="204.356747" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="204.356747" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1633,11 +1633,11 @@ L 1090.8 204.356747
      <g id="line2d_64">
       <path d="M 56.338994 195.767091 
 L 1090.8 195.767091 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="195.767091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="195.767091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1645,11 +1645,11 @@ L 1090.8 195.767091
      <g id="line2d_66">
       <path d="M 56.338994 189.672634 
 L 1090.8 189.672634 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="189.672634" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="189.672634" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1657,11 +1657,11 @@ L 1090.8 189.672634
      <g id="line2d_68">
       <path d="M 56.338994 184.945405 
 L 1090.8 184.945405 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="184.945405" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="184.945405" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1669,11 +1669,11 @@ L 1090.8 184.945405
      <g id="line2d_70">
       <path d="M 56.338994 181.082978 
 L 1090.8 181.082978 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="181.082978" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="181.082978" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1681,11 +1681,11 @@ L 1090.8 181.082978
      <g id="line2d_72">
       <path d="M 56.338994 177.817342 
 L 1090.8 177.817342 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="177.817342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="177.817342" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1693,11 +1693,11 @@ L 1090.8 177.817342
      <g id="line2d_74">
       <path d="M 56.338994 174.98852 
 L 1090.8 174.98852 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="174.98852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="174.98852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1705,11 +1705,11 @@ L 1090.8 174.98852
      <g id="line2d_76">
       <path d="M 56.338994 172.493322 
 L 1090.8 172.493322 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="172.493322" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="172.493322" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1717,11 +1717,11 @@ L 1090.8 172.493322
      <g id="line2d_78">
       <path d="M 56.338994 155.577178 
 L 1090.8 155.577178 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="155.577178" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="155.577178" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1729,11 +1729,11 @@ L 1090.8 155.577178
      <g id="line2d_80">
       <path d="M 56.338994 146.987522 
 L 1090.8 146.987522 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="146.987522" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="146.987522" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1741,11 +1741,11 @@ L 1090.8 146.987522
      <g id="line2d_82">
       <path d="M 56.338994 140.893064 
 L 1090.8 140.893064 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="140.893064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="140.893064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1753,11 +1753,11 @@ L 1090.8 140.893064
      <g id="line2d_84">
       <path d="M 56.338994 136.165835 
 L 1090.8 136.165835 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="136.165835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="136.165835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1765,11 +1765,11 @@ L 1090.8 136.165835
      <g id="line2d_86">
       <path d="M 56.338994 132.303408 
 L 1090.8 132.303408 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="132.303408" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="132.303408" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1777,11 +1777,11 @@ L 1090.8 132.303408
      <g id="line2d_88">
       <path d="M 56.338994 129.037773 
 L 1090.8 129.037773 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="129.037773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="129.037773" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1789,11 +1789,11 @@ L 1090.8 129.037773
      <g id="line2d_90">
       <path d="M 56.338994 126.20895 
 L 1090.8 126.20895 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="126.20895" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="126.20895" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1801,11 +1801,11 @@ L 1090.8 126.20895
      <g id="line2d_92">
       <path d="M 56.338994 123.713752 
 L 1090.8 123.713752 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="123.713752" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="123.713752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1813,11 +1813,11 @@ L 1090.8 123.713752
      <g id="line2d_94">
       <path d="M 56.338994 106.797608 
 L 1090.8 106.797608 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="106.797608" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="106.797608" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1825,11 +1825,11 @@ L 1090.8 106.797608
      <g id="line2d_96">
       <path d="M 56.338994 98.207952 
 L 1090.8 98.207952 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="98.207952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="98.207952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1837,11 +1837,11 @@ L 1090.8 98.207952
      <g id="line2d_98">
       <path d="M 56.338994 92.113494 
 L 1090.8 92.113494 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="92.113494" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="92.113494" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1849,11 +1849,11 @@ L 1090.8 92.113494
      <g id="line2d_100">
       <path d="M 56.338994 87.386266 
 L 1090.8 87.386266 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="87.386266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="87.386266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1861,11 +1861,11 @@ L 1090.8 87.386266
      <g id="line2d_102">
       <path d="M 56.338994 83.523839 
 L 1090.8 83.523839 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="83.523839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="83.523839" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1873,11 +1873,11 @@ L 1090.8 83.523839
      <g id="line2d_104">
       <path d="M 56.338994 80.258203 
 L 1090.8 80.258203 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="80.258203" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="80.258203" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1885,11 +1885,11 @@ L 1090.8 80.258203
      <g id="line2d_106">
       <path d="M 56.338994 77.429381 
 L 1090.8 77.429381 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="77.429381" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="77.429381" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1897,11 +1897,11 @@ L 1090.8 77.429381
      <g id="line2d_108">
       <path d="M 56.338994 74.934183 
 L 1090.8 74.934183 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="74.934183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="74.934183" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1909,11 +1909,11 @@ L 1090.8 74.934183
      <g id="line2d_110">
       <path d="M 56.338994 58.018038 
 L 1090.8 58.018038 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="58.018038" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="58.018038" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1921,11 +1921,11 @@ L 1090.8 58.018038
      <g id="line2d_112">
       <path d="M 56.338994 49.428383 
 L 1090.8 49.428383 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="49.428383" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="49.428383" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1933,11 +1933,11 @@ L 1090.8 49.428383
      <g id="line2d_114">
       <path d="M 56.338994 43.333925 
 L 1090.8 43.333925 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="43.333925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="43.333925" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1945,11 +1945,11 @@ L 1090.8 43.333925
      <g id="line2d_116">
       <path d="M 56.338994 38.606696 
 L 1090.8 38.606696 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="38.606696" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="38.606696" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1957,11 +1957,11 @@ L 1090.8 38.606696
      <g id="line2d_118">
       <path d="M 56.338994 34.744269 
 L 1090.8 34.744269 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="34.744269" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="34.744269" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1969,11 +1969,11 @@ L 1090.8 34.744269
      <g id="line2d_120">
       <path d="M 56.338994 31.478633 
 L 1090.8 31.478633 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="31.478633" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="31.478633" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1981,11 +1981,11 @@ L 1090.8 31.478633
      <g id="line2d_122">
       <path d="M 56.338994 28.649811 
 L 1090.8 28.649811 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_123">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="28.649811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="28.649811" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1993,11 +1993,11 @@ L 1090.8 28.649811
      <g id="line2d_124">
       <path d="M 56.338994 26.154613 
 L 1090.8 26.154613 
-" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#mde83ee3b22" x="56.338994" y="26.154613" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9d10725750" x="56.338994" y="26.154613" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2786,7 +2786,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa23a725a25">
+  <clipPath id="p8e87864216">
    <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-13T11:30:08.345113</dc:date>
+    <dc:date>2026-05-15T18:17:27.122564</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 117.110514 44848.601475
 L 117.110514 187.421704 
 L 103.359949 187.421704 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 159.408449 44848.601475 
@@ -51,7 +51,7 @@ L 173.159014 44848.601475
 L 173.159014 219.402709 
 L 159.408449 219.402709 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 215.456949 44848.601475 
@@ -59,7 +59,7 @@ L 229.207514 44848.601475
 L 229.207514 148.840096 
 L 215.456949 148.840096 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 271.505449 44848.601475 
@@ -67,15 +67,15 @@ L 285.256014 44848.601475
 L 285.256014 129.826543 
 L 271.505449 129.826543 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 327.553948 44848.601475 
 L 341.304514 44848.601475 
-L 341.304514 97.451235 
-L 327.553948 97.451235 
+L 341.304514 125.628657 
+L 327.553948 125.628657 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 383.602448 44848.601475 
@@ -83,7 +83,7 @@ L 397.353014 44848.601475
 L 397.353014 154.625883 
 L 383.602448 154.625883 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 439.650948 44848.601475 
@@ -91,7 +91,7 @@ L 453.401513 44848.601475
 L 453.401513 139.469298 
 L 439.650948 139.469298 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 495.699448 44848.601475 
@@ -99,7 +99,7 @@ L 509.450013 44848.601475
 L 509.450013 179.39132 
 L 495.699448 179.39132 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 551.747948 44848.601475 
@@ -107,7 +107,7 @@ L 565.498513 44848.601475
 L 565.498513 138.308114 
 L 551.747948 138.308114 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 607.796448 44848.601475 
@@ -115,7 +115,7 @@ L 621.547013 44848.601475
 L 621.547013 146.412156 
 L 607.796448 146.412156 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 663.844948 44848.601475 
@@ -123,7 +123,7 @@ L 677.595513 44848.601475
 L 677.595513 166.360909 
 L 663.844948 166.360909 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 719.893447 44848.601475 
@@ -131,7 +131,7 @@ L 733.644013 44848.601475
 L 733.644013 165.863492 
 L 719.893447 165.863492 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 775.941947 44848.601475 
@@ -139,7 +139,7 @@ L 789.692513 44848.601475
 L 789.692513 153.211265 
 L 775.941947 153.211265 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 831.990447 44848.601475 
@@ -147,7 +147,7 @@ L 845.741012 44848.601475
 L 845.741012 198.527544 
 L 831.990447 198.527544 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 888.038947 44848.601475 
@@ -155,7 +155,7 @@ L 901.789512 44848.601475
 L 901.789512 155.089977 
 L 888.038947 155.089977 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 944.087447 44848.601475 
@@ -163,7 +163,7 @@ L 957.838012 44848.601475
 L 957.838012 128.399018 
 L 944.087447 128.399018 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 1000.135947 44848.601475 
@@ -171,7 +171,7 @@ L 1013.886512 44848.601475
 L 1013.886512 138.447028 
 L 1000.135947 138.447028 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 118.306216 44848.601475 
@@ -179,7 +179,7 @@ L 132.056781 44848.601475
 L 132.056781 271.934001 
 L 118.306216 271.934001 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 174.354715 44848.601475 
@@ -187,7 +187,7 @@ L 188.105281 44848.601475
 L 188.105281 285.379806 
 L 174.354715 285.379806 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 230.403215 44848.601475 
@@ -195,7 +195,7 @@ L 244.153781 44848.601475
 L 244.153781 199.897398 
 L 230.403215 199.897398 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 286.451715 44848.601475 
@@ -203,7 +203,7 @@ L 300.20228 44848.601475
 L 300.20228 187.17459 
 L 286.451715 187.17459 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 342.500215 44848.601475 
@@ -211,7 +211,7 @@ L 356.25078 44848.601475
 L 356.25078 97.276357 
 L 342.500215 97.276357 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 398.548715 44848.601475 
@@ -219,7 +219,7 @@ L 412.29928 44848.601475
 L 412.29928 205.32084 
 L 398.548715 205.32084 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 454.597215 44848.601475 
@@ -227,7 +227,7 @@ L 468.34778 44848.601475
 L 468.34778 190.083158 
 L 454.597215 190.083158 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 510.645715 44848.601475 
@@ -235,7 +235,7 @@ L 524.39628 44848.601475
 L 524.39628 220.741046 
 L 510.645715 220.741046 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 566.694214 44848.601475 
@@ -243,7 +243,7 @@ L 580.44478 44848.601475
 L 580.44478 147.240347 
 L 566.694214 147.240347 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 622.742714 44848.601475 
@@ -251,7 +251,7 @@ L 636.49328 44848.601475
 L 636.49328 147.084287 
 L 622.742714 147.084287 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 678.791214 44848.601475 
@@ -259,7 +259,7 @@ L 692.541779 44848.601475
 L 692.541779 191.875034 
 L 678.791214 191.875034 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 734.839714 44848.601475 
@@ -267,7 +267,7 @@ L 748.590279 44848.601475
 L 748.590279 190.958413 
 L 734.839714 190.958413 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 790.888214 44848.601475 
@@ -275,7 +275,7 @@ L 804.638779 44848.601475
 L 804.638779 143.413334 
 L 790.888214 143.413334 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 846.936714 44848.601475 
@@ -283,7 +283,7 @@ L 860.687279 44848.601475
 L 860.687279 194.554902 
 L 846.936714 194.554902 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 902.985214 44848.601475 
@@ -291,7 +291,7 @@ L 916.735779 44848.601475
 L 916.735779 143.542397 
 L 902.985214 143.542397 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 959.033713 44848.601475 
@@ -299,7 +299,7 @@ L 972.784279 44848.601475
 L 972.784279 159.559981 
 L 959.033713 159.559981 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 1015.082213 44848.601475 
@@ -307,7 +307,7 @@ L 1028.832779 44848.601475
 L 1028.832779 189.520852 
 L 1015.082213 189.520852 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 133.252482 44848.601475 
@@ -315,7 +315,7 @@ L 147.003048 44848.601475
 L 147.003048 197.66526 
 L 133.252482 197.66526 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 189.300982 44848.601475 
@@ -323,7 +323,7 @@ L 203.051547 44848.601475
 L 203.051547 106.74687 
 L 189.300982 106.74687 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 245.349482 44848.601475 
@@ -331,7 +331,7 @@ L 259.100047 44848.601475
 L 259.100047 110.527585 
 L 245.349482 110.527585 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 301.397982 44848.601475 
@@ -339,15 +339,15 @@ L 315.148547 44848.601475
 L 315.148547 107.649645 
 L 301.397982 107.649645 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 357.446482 44848.601475 
 L 371.197047 44848.601475 
-L 371.197047 67.980564 
-L 357.446482 67.980564 
+L 371.197047 138.727875 
+L 357.446482 138.727875 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
     <path d="M 413.494981 44848.601475 
@@ -355,7 +355,7 @@ L 427.245547 44848.601475
 L 427.245547 156.351304 
 L 413.494981 156.351304 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
     <path d="M 469.543481 44848.601475 
@@ -363,7 +363,7 @@ L 483.294047 44848.601475
 L 483.294047 107.362738 
 L 469.543481 107.362738 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
     <path d="M 525.591981 44848.601475 
@@ -371,7 +371,7 @@ L 539.342546 44848.601475
 L 539.342546 227.268001 
 L 525.591981 227.268001 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
     <path d="M 581.640481 44848.601475 
@@ -379,7 +379,7 @@ L 595.391046 44848.601475
 L 595.391046 109.173514 
 L 581.640481 109.173514 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
     <path d="M 637.688981 44848.601475 
@@ -387,7 +387,7 @@ L 651.439546 44848.601475
 L 651.439546 45.783708 
 L 637.688981 45.783708 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
     <path d="M 693.737481 44848.601475 
@@ -395,7 +395,7 @@ L 707.488046 44848.601475
 L 707.488046 37.202002 
 L 693.737481 37.202002 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
     <path d="M 749.785981 44848.601475 
@@ -403,7 +403,7 @@ L 763.536546 44848.601475
 L 763.536546 37.202002 
 L 749.785981 37.202002 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
     <path d="M 805.83448 44848.601475 
@@ -411,7 +411,7 @@ L 819.585046 44848.601475
 L 819.585046 91.320899 
 L 805.83448 91.320899 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
     <path d="M 861.88298 44848.601475 
@@ -419,7 +419,7 @@ L 875.633546 44848.601475
 L 875.633546 37.202002 
 L 861.88298 37.202002 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: url(#h2632259f3d); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
     <path d="M 917.93148 44848.601475 
@@ -427,7 +427,7 @@ L 931.682045 44848.601475
 L 931.682045 74.593563 
 L 917.93148 74.593563 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
     <path d="M 973.97998 44848.601475 
@@ -435,7 +435,7 @@ L 987.730545 44848.601475
 L 987.730545 100.286088 
 L 973.97998 100.286088 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
     <path d="M 1030.02848 44848.601475 
@@ -443,18 +443,18 @@ L 1043.779045 44848.601475
 L 1043.779045 93.414083 
 L 1030.02848 93.414083 
 z
-" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p29fb347b4b)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4cff5ea429" d="M 0 0 
+       <path id="mceacd4033b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4cff5ea429" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -510,7 +510,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4cff5ea429" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -550,7 +550,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4cff5ea429" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -598,7 +598,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4cff5ea429" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -633,7 +633,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4cff5ea429" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -674,7 +674,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4cff5ea429" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,7 +720,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4cff5ea429" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4cff5ea429" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -801,7 +801,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4cff5ea429" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -847,7 +847,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4cff5ea429" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -885,7 +885,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4cff5ea429" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -900,7 +900,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4cff5ea429" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -915,7 +915,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m4cff5ea429" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -930,7 +930,7 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4cff5ea429" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -945,7 +945,7 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m4cff5ea429" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -960,7 +960,7 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m4cff5ea429" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -975,7 +975,7 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m4cff5ea429" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mceacd4033b" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1287,16 +1287,16 @@ z
      <g id="line2d_18">
       <path d="M 56.338994 316.6 
 L 1090.8 316.6 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="mab0e075192" d="M 0 0 
+       <path id="m4fb5afb276" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1322,11 +1322,11 @@ z
      <g id="line2d_20">
       <path d="M 56.338994 271.934001 
 L 1090.8 271.934001 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1343,11 +1343,11 @@ L 1090.8 271.934001
      <g id="line2d_22">
       <path d="M 56.338994 227.268001 
 L 1090.8 227.268001 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1364,11 +1364,11 @@ L 1090.8 227.268001
      <g id="line2d_24">
       <path d="M 56.338994 182.602002 
 L 1090.8 182.602002 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1384,11 +1384,11 @@ L 1090.8 182.602002
      <g id="line2d_26">
       <path d="M 56.338994 137.936002 
 L 1090.8 137.936002 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -1404,11 +1404,11 @@ L 1090.8 137.936002
      <g id="line2d_28">
       <path d="M 56.338994 93.270003 
 L 1090.8 93.270003 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -1424,11 +1424,11 @@ L 1090.8 93.270003
      <g id="line2d_30">
       <path d="M 56.338994 48.604003 
 L 1090.8 48.604003 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mab0e075192" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4fb5afb276" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
@@ -1444,16 +1444,16 @@ L 1090.8 48.604003
      <g id="line2d_32">
       <path d="M 56.338994 303.154194 
 L 1090.8 303.154194 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <defs>
-       <path id="m9006438678" d="M 0 0 
+       <path id="m095cbf0b45" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1461,11 +1461,11 @@ L -2 0
      <g id="line2d_34">
       <path d="M 56.338994 295.288902 
 L 1090.8 295.288902 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1473,11 +1473,11 @@ L 1090.8 295.288902
      <g id="line2d_36">
       <path d="M 56.338994 289.708389 
 L 1090.8 289.708389 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1485,11 +1485,11 @@ L 1090.8 289.708389
      <g id="line2d_38">
       <path d="M 56.338994 285.379806 
 L 1090.8 285.379806 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1497,11 +1497,11 @@ L 1090.8 285.379806
      <g id="line2d_40">
       <path d="M 56.338994 281.843097 
 L 1090.8 281.843097 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1509,11 +1509,11 @@ L 1090.8 281.843097
      <g id="line2d_42">
       <path d="M 56.338994 278.852851 
 L 1090.8 278.852851 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1521,11 +1521,11 @@ L 1090.8 278.852851
      <g id="line2d_44">
       <path d="M 56.338994 276.262583 
 L 1090.8 276.262583 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1533,11 +1533,11 @@ L 1090.8 276.262583
      <g id="line2d_46">
       <path d="M 56.338994 273.977805 
 L 1090.8 273.977805 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1545,11 +1545,11 @@ L 1090.8 273.977805
      <g id="line2d_48">
       <path d="M 56.338994 258.488195 
 L 1090.8 258.488195 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1557,11 +1557,11 @@ L 1090.8 258.488195
      <g id="line2d_50">
       <path d="M 56.338994 250.622903 
 L 1090.8 250.622903 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1569,11 +1569,11 @@ L 1090.8 250.622903
      <g id="line2d_52">
       <path d="M 56.338994 245.042389 
 L 1090.8 245.042389 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1581,11 +1581,11 @@ L 1090.8 245.042389
      <g id="line2d_54">
       <path d="M 56.338994 240.713807 
 L 1090.8 240.713807 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1593,11 +1593,11 @@ L 1090.8 240.713807
      <g id="line2d_56">
       <path d="M 56.338994 237.177097 
 L 1090.8 237.177097 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1605,11 +1605,11 @@ L 1090.8 237.177097
      <g id="line2d_58">
       <path d="M 56.338994 234.186852 
 L 1090.8 234.186852 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1617,11 +1617,11 @@ L 1090.8 234.186852
      <g id="line2d_60">
       <path d="M 56.338994 231.596584 
 L 1090.8 231.596584 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1629,11 +1629,11 @@ L 1090.8 231.596584
      <g id="line2d_62">
       <path d="M 56.338994 229.311805 
 L 1090.8 229.311805 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1641,11 +1641,11 @@ L 1090.8 229.311805
      <g id="line2d_64">
       <path d="M 56.338994 213.822195 
 L 1090.8 213.822195 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1653,11 +1653,11 @@ L 1090.8 213.822195
      <g id="line2d_66">
       <path d="M 56.338994 205.956903 
 L 1090.8 205.956903 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1665,11 +1665,11 @@ L 1090.8 205.956903
      <g id="line2d_68">
       <path d="M 56.338994 200.37639 
 L 1090.8 200.37639 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1677,11 +1677,11 @@ L 1090.8 200.37639
      <g id="line2d_70">
       <path d="M 56.338994 196.047807 
 L 1090.8 196.047807 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1689,11 +1689,11 @@ L 1090.8 196.047807
      <g id="line2d_72">
       <path d="M 56.338994 192.511098 
 L 1090.8 192.511098 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1701,11 +1701,11 @@ L 1090.8 192.511098
      <g id="line2d_74">
       <path d="M 56.338994 189.520852 
 L 1090.8 189.520852 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1713,11 +1713,11 @@ L 1090.8 189.520852
      <g id="line2d_76">
       <path d="M 56.338994 186.930584 
 L 1090.8 186.930584 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1725,11 +1725,11 @@ L 1090.8 186.930584
      <g id="line2d_78">
       <path d="M 56.338994 184.645806 
 L 1090.8 184.645806 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1737,11 +1737,11 @@ L 1090.8 184.645806
      <g id="line2d_80">
       <path d="M 56.338994 169.156196 
 L 1090.8 169.156196 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1749,11 +1749,11 @@ L 1090.8 169.156196
      <g id="line2d_82">
       <path d="M 56.338994 161.290904 
 L 1090.8 161.290904 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1761,11 +1761,11 @@ L 1090.8 161.290904
      <g id="line2d_84">
       <path d="M 56.338994 155.71039 
 L 1090.8 155.71039 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1773,11 +1773,11 @@ L 1090.8 155.71039
      <g id="line2d_86">
       <path d="M 56.338994 151.381808 
 L 1090.8 151.381808 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1785,11 +1785,11 @@ L 1090.8 151.381808
      <g id="line2d_88">
       <path d="M 56.338994 147.845098 
 L 1090.8 147.845098 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1797,11 +1797,11 @@ L 1090.8 147.845098
      <g id="line2d_90">
       <path d="M 56.338994 144.854853 
 L 1090.8 144.854853 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1809,11 +1809,11 @@ L 1090.8 144.854853
      <g id="line2d_92">
       <path d="M 56.338994 142.264585 
 L 1090.8 142.264585 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1821,11 +1821,11 @@ L 1090.8 142.264585
      <g id="line2d_94">
       <path d="M 56.338994 139.979806 
 L 1090.8 139.979806 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1833,11 +1833,11 @@ L 1090.8 139.979806
      <g id="line2d_96">
       <path d="M 56.338994 124.490196 
 L 1090.8 124.490196 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1845,11 +1845,11 @@ L 1090.8 124.490196
      <g id="line2d_98">
       <path d="M 56.338994 116.624904 
 L 1090.8 116.624904 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1857,11 +1857,11 @@ L 1090.8 116.624904
      <g id="line2d_100">
       <path d="M 56.338994 111.044391 
 L 1090.8 111.044391 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1869,11 +1869,11 @@ L 1090.8 111.044391
      <g id="line2d_102">
       <path d="M 56.338994 106.715808 
 L 1090.8 106.715808 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1881,11 +1881,11 @@ L 1090.8 106.715808
      <g id="line2d_104">
       <path d="M 56.338994 103.179099 
 L 1090.8 103.179099 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1893,11 +1893,11 @@ L 1090.8 103.179099
      <g id="line2d_106">
       <path d="M 56.338994 100.188853 
 L 1090.8 100.188853 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1905,11 +1905,11 @@ L 1090.8 100.188853
      <g id="line2d_108">
       <path d="M 56.338994 97.598585 
 L 1090.8 97.598585 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1917,11 +1917,11 @@ L 1090.8 97.598585
      <g id="line2d_110">
       <path d="M 56.338994 95.313807 
 L 1090.8 95.313807 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1929,11 +1929,11 @@ L 1090.8 95.313807
      <g id="line2d_112">
       <path d="M 56.338994 79.824197 
 L 1090.8 79.824197 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1941,11 +1941,11 @@ L 1090.8 79.824197
      <g id="line2d_114">
       <path d="M 56.338994 71.958905 
 L 1090.8 71.958905 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1953,11 +1953,11 @@ L 1090.8 71.958905
      <g id="line2d_116">
       <path d="M 56.338994 66.378391 
 L 1090.8 66.378391 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1965,11 +1965,11 @@ L 1090.8 66.378391
      <g id="line2d_118">
       <path d="M 56.338994 62.049809 
 L 1090.8 62.049809 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1977,11 +1977,11 @@ L 1090.8 62.049809
      <g id="line2d_120">
       <path d="M 56.338994 58.513099 
 L 1090.8 58.513099 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1989,11 +1989,11 @@ L 1090.8 58.513099
      <g id="line2d_122">
       <path d="M 56.338994 55.522854 
 L 1090.8 55.522854 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_123">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2001,11 +2001,11 @@ L 1090.8 55.522854
      <g id="line2d_124">
       <path d="M 56.338994 52.932586 
 L 1090.8 52.932586 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2013,11 +2013,11 @@ L 1090.8 52.932586
      <g id="line2d_126">
       <path d="M 56.338994 50.647807 
 L 1090.8 50.647807 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_127">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2025,11 +2025,11 @@ L 1090.8 50.647807
      <g id="line2d_128">
       <path d="M 56.338994 35.158198 
 L 1090.8 35.158198 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_129">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2037,11 +2037,11 @@ L 1090.8 35.158198
      <g id="line2d_130">
       <path d="M 56.338994 27.292905 
 L 1090.8 27.292905 
-" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p29fb347b4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_131">
       <g>
-       <use xlink:href="#m9006438678" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m095cbf0b45" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2767,12 +2767,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd8fee4f461">
+  <clipPath id="p29fb347b4b">
    <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h7fbd10b4ca" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h2632259f3d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#2ca02c"/>
    <path d="M -36 36 
 L 36 -36 

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="360pt" viewBox="0 0 648 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1101.6pt" height="360pt" viewBox="0 0 1101.6 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T23:46:01.271976</dc:date>
+    <dc:date>2026-05-12T23:47:00.676068</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,8 +22,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 360 
-L 648 360 
-L 648 0 
+L 1101.6 360 
+L 1101.6 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
@@ -31,267 +31,435 @@ z
   <g id="axes_1">
    <g id="patch_2">
     <path d="M 56.338994 316.6 
-L 637.2 316.6 
-L 637.2 25.8 
+L 1090.8 316.6 
+L 1090.8 25.8 
 L 56.338994 25.8 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 82.741767 46913.520099 
-L 95.989954 46913.520099 
-L 95.989954 181.431794 
-L 82.741767 181.431794 
+    <path d="M 103.359949 46913.520099 
+L 117.110514 46913.520099 
+L 117.110514 181.431794 
+L 103.359949 181.431794 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 136.74253 46913.520099 
-L 149.990717 46913.520099 
-L 149.990717 214.895737 
-L 136.74253 214.895737 
+    <path d="M 159.408449 46913.520099 
+L 173.159014 46913.520099 
+L 173.159014 214.895737 
+L 159.408449 214.895737 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 190.743293 46913.520099 
-L 203.99148 46913.520099 
-L 203.99148 141.061183 
-L 190.743293 141.061183 
+    <path d="M 215.456949 46913.520099 
+L 229.207514 46913.520099 
+L 229.207514 141.061183 
+L 215.456949 141.061183 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 244.744056 46913.520099 
-L 257.992243 46913.520099 
-L 257.992243 121.165984 
-L 244.744056 121.165984 
+    <path d="M 271.505449 46913.520099 
+L 285.256014 46913.520099 
+L 285.256014 121.165984 
+L 271.505449 121.165984 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 298.744819 46913.520099 
-L 311.993006 46913.520099 
-L 311.993006 87.289456 
-L 298.744819 87.289456 
+    <path d="M 327.553948 46913.520099 
+L 341.304514 46913.520099 
+L 341.304514 87.289456 
+L 327.553948 87.289456 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 352.745581 46913.520099 
-L 365.993769 46913.520099 
-L 365.993769 147.115253 
-L 352.745581 147.115253 
+    <path d="M 383.602448 46913.520099 
+L 397.353014 46913.520099 
+L 397.353014 147.115253 
+L 383.602448 147.115253 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 406.746344 46913.520099 
-L 419.994532 46913.520099 
-L 419.994532 131.255868 
-L 406.746344 131.255868 
+    <path d="M 439.650948 46913.520099 
+L 453.401513 46913.520099 
+L 453.401513 131.255868 
+L 439.650948 131.255868 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 460.747107 46913.520099 
-L 473.995294 46913.520099 
-L 473.995294 173.029047 
-L 460.747107 173.029047 
+    <path d="M 495.699448 46913.520099 
+L 509.450013 46913.520099 
+L 509.450013 173.029047 
+L 495.699448 173.029047 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 514.74787 46913.520099 
-L 527.996057 46913.520099 
-L 527.996057 130.040841 
-L 514.74787 130.040841 
+    <path d="M 551.747948 46913.520099 
+L 565.498513 46913.520099 
+L 565.498513 130.040841 
+L 551.747948 130.040841 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 568.748633 46913.520099 
-L 581.99682 46913.520099 
-L 581.99682 138.520662 
-L 568.748633 138.520662 
+    <path d="M 607.796448 46913.520099 
+L 621.547013 46913.520099 
+L 621.547013 138.520662 
+L 607.796448 138.520662 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 97.141971 46913.520099 
-L 110.390158 46913.520099 
-L 110.390158 269.862869 
-L 97.141971 269.862869 
+    <path d="M 663.844948 46913.520099 
+L 677.595513 46913.520099 
+L 677.595513 159.394425 
+L 663.844948 159.394425 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 151.142733 46913.520099 
-L 164.390921 46913.520099 
-L 164.390921 283.932147 
-L 151.142733 283.932147 
+    <path d="M 719.893447 46913.520099 
+L 733.644013 46913.520099 
+L 733.644013 158.873943 
+L 719.893447 158.873943 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 205.143496 46913.520099 
-L 218.391683 46913.520099 
-L 218.391683 194.485977 
-L 205.143496 194.485977 
+    <path d="M 775.941947 46913.520099 
+L 789.692513 46913.520099 
+L 789.692513 145.63504 
+L 775.941947 145.63504 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 259.144259 46913.520099 
-L 272.392446 46913.520099 
-L 272.392446 181.173222 
-L 259.144259 181.173222 
+    <path d="M 831.990447 46913.520099 
+L 845.741012 46913.520099 
+L 845.741012 193.052605 
+L 831.990447 193.052605 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 313.145022 46913.520099 
-L 326.393209 46913.520099 
-L 326.393209 87.106468 
-L 313.145022 87.106468 
+    <path d="M 888.038947 46913.520099 
+L 901.789512 46913.520099 
+L 901.789512 147.600867 
+L 888.038947 147.600867 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 367.145785 46913.520099 
-L 380.393972 46913.520099 
-L 380.393972 200.160901 
-L 367.145785 200.160901 
+    <path d="M 944.087447 46913.520099 
+L 957.838012 46913.520099 
+L 957.838012 119.672267 
+L 944.087447 119.672267 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 421.146548 46913.520099 
-L 434.394735 46913.520099 
-L 434.394735 184.216658 
-L 421.146548 184.216658 
+    <path d="M 1000.135947 46913.520099 
+L 1013.886512 46913.520099 
+L 1013.886512 130.186196 
+L 1000.135947 130.186196 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 475.147311 46913.520099 
-L 488.395498 46913.520099 
-L 488.395498 216.296132 
-L 475.147311 216.296132 
+    <path d="M 118.306216 46913.520099 
+L 132.056781 46913.520099 
+L 132.056781 269.862869 
+L 118.306216 269.862869 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 529.148074 46913.520099 
-L 542.396261 46913.520099 
-L 542.396261 139.387256 
-L 529.148074 139.387256 
+    <path d="M 174.354715 46913.520099 
+L 188.105281 46913.520099 
+L 188.105281 283.932147 
+L 174.354715 283.932147 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 583.148836 46913.520099 
-L 596.397024 46913.520099 
-L 596.397024 139.223959 
-L 583.148836 139.223959 
+    <path d="M 230.403215 46913.520099 
+L 244.153781 46913.520099 
+L 244.153781 194.485977 
+L 230.403215 194.485977 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 111.542174 46913.520099 
-L 124.790361 46913.520099 
-L 124.790361 188.523309 
-L 111.542174 188.523309 
+    <path d="M 286.451715 46913.520099 
+L 300.20228 46913.520099 
+L 300.20228 181.173222 
+L 286.451715 181.173222 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 165.542937 46913.520099 
-L 178.791124 46913.520099 
-L 178.791124 98.857799 
-L 165.542937 98.857799 
+    <path d="M 342.500215 46913.520099 
+L 356.25078 46913.520099 
+L 356.25078 87.106468 
+L 342.500215 87.106468 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 219.5437 46913.520099 
-L 232.791887 46913.520099 
-L 232.791887 96.793714 
-L 219.5437 96.793714 
+    <path d="M 398.548715 46913.520099 
+L 412.29928 46913.520099 
+L 412.29928 200.160901 
+L 398.548715 200.160901 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 273.544463 46913.520099 
-L 286.79265 46913.520099 
-L 286.79265 91.698872 
-L 273.544463 91.698872 
+    <path d="M 454.597215 46913.520099 
+L 468.34778 46913.520099 
+L 468.34778 184.216658 
+L 454.597215 184.216658 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 327.545225 46913.520099 
-L 340.793413 46913.520099 
-L 340.793413 49.906724 
-L 327.545225 49.906724 
+    <path d="M 510.645715 46913.520099 
+L 524.39628 46913.520099 
+L 524.39628 216.296132 
+L 510.645715 216.296132 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 381.545988 46913.520099 
-L 394.794176 46913.520099 
-L 394.794176 143.518784 
-L 381.545988 143.518784 
+    <path d="M 566.694214 46913.520099 
+L 580.44478 46913.520099 
+L 580.44478 139.387256 
+L 566.694214 139.387256 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 435.546751 46913.520099 
-L 448.794938 46913.520099 
-L 448.794938 100.296711 
-L 435.546751 100.296711 
+    <path d="M 622.742714 46913.520099 
+L 636.49328 46913.520099 
+L 636.49328 139.223959 
+L 622.742714 139.223959 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 489.547514 46913.520099 
-L 502.795701 46913.520099 
-L 502.795701 227.655033 
-L 489.547514 227.655033 
+    <path d="M 678.791214 46913.520099 
+L 692.541779 46913.520099 
+L 692.541779 186.091622 
+L 678.791214 186.091622 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 543.548277 46913.520099 
-L 556.796464 46913.520099 
-L 556.796464 102.947775 
-L 543.548277 102.947775 
+    <path d="M 734.839714 46913.520099 
+L 748.590279 46913.520099 
+L 748.590279 185.132499 
+L 734.839714 185.132499 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 597.54904 46913.520099 
-L 610.797227 46913.520099 
-L 610.797227 37.730705 
-L 597.54904 37.730705 
+    <path d="M 790.888214 46913.520099 
+L 804.638779 46913.520099 
+L 804.638779 135.382786 
+L 790.888214 135.382786 
 z
-" clip-path="url(#pea80fdf40a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 846.936714 46913.520099 
+L 860.687279 46913.520099 
+L 860.687279 188.895754 
+L 846.936714 188.895754 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 902.985214 46913.520099 
+L 916.735779 46913.520099 
+L 916.735779 135.517834 
+L 902.985214 135.517834 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 959.033713 46913.520099 
+L 972.784279 46913.520099 
+L 972.784279 152.278142 
+L 959.033713 152.278142 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 1015.082213 46913.520099 
+L 1028.832779 46913.520099 
+L 1028.832779 183.628279 
+L 1015.082213 183.628279 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 133.252482 46913.520099 
+L 147.003048 46913.520099 
+L 147.003048 188.523309 
+L 133.252482 188.523309 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 189.300982 46913.520099 
+L 203.051547 46913.520099 
+L 203.051547 98.857799 
+L 189.300982 98.857799 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 245.349482 46913.520099 
+L 259.100047 46913.520099 
+L 259.100047 96.793714 
+L 245.349482 96.793714 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 301.397982 46913.520099 
+L 315.148547 46913.520099 
+L 315.148547 91.698872 
+L 301.397982 91.698872 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 357.446482 46913.520099 
+L 371.197047 46913.520099 
+L 371.197047 49.906724 
+L 357.446482 49.906724 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 413.494981 46913.520099 
+L 427.245547 46913.520099 
+L 427.245547 143.518784 
+L 413.494981 143.518784 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 469.543481 46913.520099 
+L 483.294047 46913.520099 
+L 483.294047 100.296711 
+L 469.543481 100.296711 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 525.591981 46913.520099 
+L 539.342546 46913.520099 
+L 539.342546 227.655033 
+L 525.591981 227.655033 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 581.640481 46913.520099 
+L 595.391046 46913.520099 
+L 595.391046 102.947775 
+L 581.640481 102.947775 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 637.688981 46913.520099 
+L 651.439546 46913.520099 
+L 651.439546 37.730705 
+L 637.688981 37.730705 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 693.737481 46913.520099 
+L 707.488046 46913.520099 
+L 707.488046 316.6 
+L 693.737481 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 749.785981 46913.520099 
+L 763.536546 46913.520099 
+L 763.536546 316.6 
+L 749.785981 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 805.83448 46913.520099 
+L 819.585046 46913.520099 
+L 819.585046 316.6 
+L 805.83448 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 861.88298 46913.520099 
+L 875.633546 46913.520099 
+L 875.633546 316.6 
+L 861.88298 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 917.93148 46913.520099 
+L 931.682045 46913.520099 
+L 931.682045 316.6 
+L 917.93148 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 973.97998 46913.520099 
+L 987.730545 46913.520099 
+L 987.730545 316.6 
+L 973.97998 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 1030.02848 46913.520099 
+L 1043.779045 46913.520099 
+L 1043.779045 316.6 
+L 1030.02848 316.6 
+z
+" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc084af4e0b" d="M 0 0 
+       <path id="m82807bce06" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc084af4e0b" x="103.766064" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(96.648877 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(118.064311 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -342,12 +510,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc084af4e0b" x="157.766827" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(150.64964 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(174.112811 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -382,12 +550,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc084af4e0b" x="211.76759" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(204.650402 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(230.16131 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -430,12 +598,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc084af4e0b" x="265.768353" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(258.651165 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(286.20981 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -465,12 +633,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc084af4e0b" x="319.769116" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(312.651928 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(342.25831 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -506,12 +674,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc084af4e0b" x="373.769879" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(366.652691 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(398.30681 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -552,12 +720,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc084af4e0b" x="427.770641" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(420.653454 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(454.35531 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -578,12 +746,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc084af4e0b" x="481.771404" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(474.654217 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(510.40381 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -633,12 +801,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc084af4e0b" x="535.772167" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(528.65498 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(566.45231 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -679,12 +847,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc084af4e0b" x="589.77293" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82807bce06" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- Q10 -->
-      <g transform="translate(579.474492 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(619.319559 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -714,9 +882,114 @@ z
       </g>
      </g>
     </g>
-    <g id="text_11">
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m82807bce06" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- Q11 -->
+      <g transform="translate(675.368059 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m82807bce06" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- Q12 -->
+      <g transform="translate(731.416559 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m82807bce06" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- Q13 -->
+      <g transform="translate(787.465059 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m82807bce06" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- Q14 -->
+      <g transform="translate(843.513559 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m82807bce06" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- Q15 -->
+      <g transform="translate(899.562059 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m82807bce06" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- Q16 -->
+      <g transform="translate(955.610559 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m82807bce06" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- Q17 -->
+      <g transform="translate(1011.659058 331.198438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
      <!-- BerlinMOD R-query -->
-     <g transform="translate(299.05856 344.876563) scale(0.1 -0.1)">
+     <g transform="translate(525.85856 344.876563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-42" d="M 1259 2228 
 L 1259 519 
@@ -1011,22 +1284,22 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_11">
+     <g id="line2d_18">
       <path d="M 56.338994 316.6 
-L 637.2 316.6 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 316.6 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12">
+     <g id="line2d_19">
       <defs>
-       <path id="m7fa49ed188" d="M 0 0 
+       <path id="mf1ceac1ee8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_12">
+     <g id="text_19">
       <!-- $\mathdefault{10^{-3}}$ -->
       <g transform="translate(25.838994 320.399219) scale(0.1 -0.1)">
        <defs>
@@ -1046,17 +1319,17 @@ z
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_13">
+     <g id="line2d_20">
       <path d="M 56.338994 269.862869 
-L 637.2 269.862869 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 269.862869 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_14">
+     <g id="line2d_21">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="269.862869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="269.862869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_13">
+     <g id="text_20">
       <!-- $\mathdefault{10^{-2}}$ -->
       <g transform="translate(25.838994 273.662087) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
@@ -1067,17 +1340,17 @@ L 637.2 269.862869
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_15">
+     <g id="line2d_22">
       <path d="M 56.338994 223.125737 
-L 637.2 223.125737 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 223.125737 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_16">
+     <g id="line2d_23">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="223.125737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="223.125737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_14">
+     <g id="text_21">
       <!-- $\mathdefault{10^{-1}}$ -->
       <g transform="translate(25.838994 226.924956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
@@ -1088,17 +1361,17 @@ L 637.2 223.125737
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_17">
+     <g id="line2d_24">
       <path d="M 56.338994 176.388606 
-L 637.2 176.388606 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 176.388606 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_18">
+     <g id="line2d_25">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="176.388606" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="176.388606" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_15">
+     <g id="text_22">
       <!-- $\mathdefault{10^{0}}$ -->
       <g transform="translate(31.738994 180.187824) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
@@ -1108,17 +1381,17 @@ L 637.2 176.388606
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_19">
+     <g id="line2d_26">
       <path d="M 56.338994 129.651474 
-L 637.2 129.651474 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 129.651474 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_20">
+     <g id="line2d_27">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="129.651474" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="129.651474" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_16">
+     <g id="text_23">
       <!-- $\mathdefault{10^{1}}$ -->
       <g transform="translate(31.738994 133.450693) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
@@ -1128,17 +1401,17 @@ L 637.2 129.651474
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_21">
+     <g id="line2d_28">
       <path d="M 56.338994 82.914343 
-L 637.2 82.914343 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 82.914343 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_22">
+     <g id="line2d_29">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="82.914343" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="82.914343" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_17">
+     <g id="text_24">
       <!-- $\mathdefault{10^{2}}$ -->
       <g transform="translate(31.738994 86.713561) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
@@ -1148,17 +1421,17 @@ L 637.2 82.914343
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_23">
+     <g id="line2d_30">
       <path d="M 56.338994 36.177211 
-L 637.2 36.177211 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 36.177211 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_24">
+     <g id="line2d_31">
       <g>
-       <use xlink:href="#m7fa49ed188" x="56.338994" y="36.177211" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="36.177211" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_18">
+     <g id="text_25">
       <!-- $\mathdefault{10^{3}}$ -->
       <g transform="translate(31.738994 39.97643) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
@@ -1168,587 +1441,587 @@ L 637.2 36.177211
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_25">
+     <g id="line2d_32">
       <path d="M 56.338994 302.530722 
-L 637.2 302.530722 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 302.530722 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_26">
+     <g id="line2d_33">
       <defs>
-       <path id="m600444c660" d="M 0 0 
+       <path id="m1ff24460ae" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="302.530722" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="302.530722" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_27">
+     <g id="line2d_34">
       <path d="M 56.338994 294.300721 
-L 637.2 294.300721 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 294.300721 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_28">
+     <g id="line2d_35">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="294.300721" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="294.300721" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_29">
+     <g id="line2d_36">
       <path d="M 56.338994 288.461443 
-L 637.2 288.461443 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 288.461443 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_30">
+     <g id="line2d_37">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="288.461443" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="288.461443" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_31">
+     <g id="line2d_38">
       <path d="M 56.338994 283.932147 
-L 637.2 283.932147 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 283.932147 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_32">
+     <g id="line2d_39">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="283.932147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="283.932147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_33">
+     <g id="line2d_40">
       <path d="M 56.338994 280.231443 
-L 637.2 280.231443 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 280.231443 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_34">
+     <g id="line2d_41">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="280.231443" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="280.231443" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_35">
+     <g id="line2d_42">
       <path d="M 56.338994 277.102542 
-L 637.2 277.102542 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 277.102542 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_36">
+     <g id="line2d_43">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="277.102542" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="277.102542" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_37">
+     <g id="line2d_44">
       <path d="M 56.338994 274.392165 
-L 637.2 274.392165 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 274.392165 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_38">
+     <g id="line2d_45">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="274.392165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="274.392165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
-     <g id="line2d_39">
+     <g id="line2d_46">
       <path d="M 56.338994 272.001442 
-L 637.2 272.001442 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 272.001442 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_40">
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="272.001442" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="272.001442" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_41">
+     <g id="line2d_48">
       <path d="M 56.338994 255.79359 
-L 637.2 255.79359 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 255.79359 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_42">
+     <g id="line2d_49">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="255.79359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="255.79359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
-     <g id="line2d_43">
+     <g id="line2d_50">
       <path d="M 56.338994 247.56359 
-L 637.2 247.56359 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 247.56359 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_44">
+     <g id="line2d_51">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="247.56359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="247.56359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
-     <g id="line2d_45">
+     <g id="line2d_52">
       <path d="M 56.338994 241.724312 
-L 637.2 241.724312 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 241.724312 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_46">
+     <g id="line2d_53">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="241.724312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="241.724312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
-     <g id="line2d_47">
+     <g id="line2d_54">
       <path d="M 56.338994 237.195016 
-L 637.2 237.195016 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 237.195016 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_48">
+     <g id="line2d_55">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="237.195016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="237.195016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
-     <g id="line2d_49">
+     <g id="line2d_56">
       <path d="M 56.338994 233.494311 
-L 637.2 233.494311 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 233.494311 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_50">
+     <g id="line2d_57">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="233.494311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="233.494311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
-     <g id="line2d_51">
+     <g id="line2d_58">
       <path d="M 56.338994 230.36541 
-L 637.2 230.36541 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 230.36541 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_52">
+     <g id="line2d_59">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="230.36541" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="230.36541" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
-     <g id="line2d_53">
+     <g id="line2d_60">
       <path d="M 56.338994 227.655033 
-L 637.2 227.655033 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 227.655033 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_54">
+     <g id="line2d_61">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="227.655033" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="227.655033" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
-     <g id="line2d_55">
+     <g id="line2d_62">
       <path d="M 56.338994 225.264311 
-L 637.2 225.264311 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 225.264311 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_56">
+     <g id="line2d_63">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="225.264311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="225.264311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
-     <g id="line2d_57">
+     <g id="line2d_64">
       <path d="M 56.338994 209.056459 
-L 637.2 209.056459 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 209.056459 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_58">
+     <g id="line2d_65">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="209.056459" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="209.056459" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
-     <g id="line2d_59">
+     <g id="line2d_66">
       <path d="M 56.338994 200.826458 
-L 637.2 200.826458 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 200.826458 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_60">
+     <g id="line2d_67">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="200.826458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="200.826458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
-     <g id="line2d_61">
+     <g id="line2d_68">
       <path d="M 56.338994 194.98718 
-L 637.2 194.98718 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 194.98718 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_62">
+     <g id="line2d_69">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="194.98718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="194.98718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
-     <g id="line2d_63">
+     <g id="line2d_70">
       <path d="M 56.338994 190.457884 
-L 637.2 190.457884 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 190.457884 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_64">
+     <g id="line2d_71">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="190.457884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="190.457884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
-     <g id="line2d_65">
+     <g id="line2d_72">
       <path d="M 56.338994 186.75718 
-L 637.2 186.75718 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 186.75718 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_66">
+     <g id="line2d_73">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="186.75718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="186.75718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
-     <g id="line2d_67">
+     <g id="line2d_74">
       <path d="M 56.338994 183.628279 
-L 637.2 183.628279 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 183.628279 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_68">
+     <g id="line2d_75">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="183.628279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="183.628279" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
-     <g id="line2d_69">
+     <g id="line2d_76">
       <path d="M 56.338994 180.917902 
-L 637.2 180.917902 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 180.917902 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_70">
+     <g id="line2d_77">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="180.917902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="180.917902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
-     <g id="line2d_71">
+     <g id="line2d_78">
       <path d="M 56.338994 178.527179 
-L 637.2 178.527179 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 178.527179 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_72">
+     <g id="line2d_79">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="178.527179" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="178.527179" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
-     <g id="line2d_73">
+     <g id="line2d_80">
       <path d="M 56.338994 162.319327 
-L 637.2 162.319327 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 162.319327 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_74">
+     <g id="line2d_81">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="162.319327" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="162.319327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
-     <g id="line2d_75">
+     <g id="line2d_82">
       <path d="M 56.338994 154.089327 
-L 637.2 154.089327 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 154.089327 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_76">
+     <g id="line2d_83">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="154.089327" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="154.089327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
-     <g id="line2d_77">
+     <g id="line2d_84">
       <path d="M 56.338994 148.250049 
-L 637.2 148.250049 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 148.250049 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_78">
+     <g id="line2d_85">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="148.250049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="148.250049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
-     <g id="line2d_79">
+     <g id="line2d_86">
       <path d="M 56.338994 143.720753 
-L 637.2 143.720753 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 143.720753 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_80">
+     <g id="line2d_87">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="143.720753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="143.720753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
-     <g id="line2d_81">
+     <g id="line2d_88">
       <path d="M 56.338994 140.020048 
-L 637.2 140.020048 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 140.020048 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_82">
+     <g id="line2d_89">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="140.020048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="140.020048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
-     <g id="line2d_83">
+     <g id="line2d_90">
       <path d="M 56.338994 136.891147 
-L 637.2 136.891147 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 136.891147 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_84">
+     <g id="line2d_91">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="136.891147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="136.891147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
-     <g id="line2d_85">
+     <g id="line2d_92">
       <path d="M 56.338994 134.18077 
-L 637.2 134.18077 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 134.18077 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_86">
+     <g id="line2d_93">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="134.18077" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="134.18077" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
-     <g id="line2d_87">
+     <g id="line2d_94">
       <path d="M 56.338994 131.790048 
-L 637.2 131.790048 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 131.790048 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_88">
+     <g id="line2d_95">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="131.790048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="131.790048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
-     <g id="line2d_89">
+     <g id="line2d_96">
       <path d="M 56.338994 115.582196 
-L 637.2 115.582196 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 115.582196 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_90">
+     <g id="line2d_97">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="115.582196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="115.582196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
-     <g id="line2d_91">
+     <g id="line2d_98">
       <path d="M 56.338994 107.352195 
-L 637.2 107.352195 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 107.352195 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_92">
+     <g id="line2d_99">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="107.352195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="107.352195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
-     <g id="line2d_93">
+     <g id="line2d_100">
       <path d="M 56.338994 101.512917 
-L 637.2 101.512917 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 101.512917 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_94">
+     <g id="line2d_101">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="101.512917" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="101.512917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
-     <g id="line2d_95">
+     <g id="line2d_102">
       <path d="M 56.338994 96.983621 
-L 637.2 96.983621 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 96.983621 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_96">
+     <g id="line2d_103">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="96.983621" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="96.983621" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
-     <g id="line2d_97">
+     <g id="line2d_104">
       <path d="M 56.338994 93.282917 
-L 637.2 93.282917 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 93.282917 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_98">
+     <g id="line2d_105">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="93.282917" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="93.282917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
-     <g id="line2d_99">
+     <g id="line2d_106">
       <path d="M 56.338994 90.154016 
-L 637.2 90.154016 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 90.154016 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_100">
+     <g id="line2d_107">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="90.154016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="90.154016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
-     <g id="line2d_101">
+     <g id="line2d_108">
       <path d="M 56.338994 87.443639 
-L 637.2 87.443639 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 87.443639 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_102">
+     <g id="line2d_109">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="87.443639" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="87.443639" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
-     <g id="line2d_103">
+     <g id="line2d_110">
       <path d="M 56.338994 85.052916 
-L 637.2 85.052916 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 85.052916 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_104">
+     <g id="line2d_111">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="85.052916" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="85.052916" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
-     <g id="line2d_105">
+     <g id="line2d_112">
       <path d="M 56.338994 68.845064 
-L 637.2 68.845064 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 68.845064 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_106">
+     <g id="line2d_113">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="68.845064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="68.845064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
-     <g id="line2d_107">
+     <g id="line2d_114">
       <path d="M 56.338994 60.615064 
-L 637.2 60.615064 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 60.615064 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_108">
+     <g id="line2d_115">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="60.615064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="60.615064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
-     <g id="line2d_109">
+     <g id="line2d_116">
       <path d="M 56.338994 54.775786 
-L 637.2 54.775786 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 54.775786 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_110">
+     <g id="line2d_117">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="54.775786" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="54.775786" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
-     <g id="line2d_111">
+     <g id="line2d_118">
       <path d="M 56.338994 50.24649 
-L 637.2 50.24649 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 50.24649 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_112">
+     <g id="line2d_119">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="50.24649" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="50.24649" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
-     <g id="line2d_113">
+     <g id="line2d_120">
       <path d="M 56.338994 46.545785 
-L 637.2 46.545785 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 46.545785 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_114">
+     <g id="line2d_121">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="46.545785" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="46.545785" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
-     <g id="line2d_115">
+     <g id="line2d_122">
       <path d="M 56.338994 43.416884 
-L 637.2 43.416884 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 43.416884 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_116">
+     <g id="line2d_123">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="43.416884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="43.416884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
-     <g id="line2d_117">
+     <g id="line2d_124">
       <path d="M 56.338994 40.706507 
-L 637.2 40.706507 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 40.706507 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_118">
+     <g id="line2d_125">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="40.706507" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="40.706507" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_55">
-     <g id="line2d_119">
+     <g id="line2d_126">
       <path d="M 56.338994 38.315785 
-L 637.2 38.315785 
-" clip-path="url(#pea80fdf40a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 1090.8 38.315785 
+" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_120">
+     <g id="line2d_127">
       <g>
-       <use xlink:href="#m600444c660" x="56.338994" y="38.315785" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1ff24460ae" x="56.338994" y="38.315785" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_19">
+    <g id="text_26">
      <!-- Wall-clock seconds (log scale) -->
      <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2008,29 +2281,94 @@ z
      </g>
     </g>
    </g>
-   <g id="patch_33">
+   <g id="patch_54">
     <path d="M 56.338994 316.6 
 L 56.338994 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_34">
-    <path d="M 637.2 316.6 
-L 637.2 25.8 
+   <g id="patch_55">
+    <path d="M 1090.8 316.6 
+L 1090.8 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_35">
+   <g id="patch_56">
     <path d="M 56.338994 316.6 
-L 637.2 316.6 
+L 1090.8 316.6 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_36">
+   <g id="patch_57">
     <path d="M 56.338994 25.8 
-L 637.2 25.8 
+L 1090.8 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_20">
-    <!-- BerlinMOD R-queries Q1-Q10 — standard index per platform (sf 0.005) -->
-    <g transform="translate(134.45856 19.8) scale(0.12 -0.12)">
+   <g id="text_27">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(702.544326 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(758.592826 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(814.641326 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(870.689825 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(926.738325 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(982.786825 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(1038.835325 309.770395) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- BerlinMOD R-queries Q1-Q17 — standard index per platform (sf 0.005) -->
+    <g transform="translate(361.25856 19.8) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2185,7 +2523,7 @@ z
      <use xlink:href="#DejaVuSans-2d" transform="translate(1210.550781 0)"/>
      <use xlink:href="#DejaVuSans-51" transform="translate(1250.259766 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(1328.970703 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(1392.59375 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(1392.59375 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1456.216797 0)"/>
      <use xlink:href="#DejaVuSans-2014" transform="translate(1488.003906 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1588.003906 0)"/>
@@ -2230,7 +2568,7 @@ z
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_37">
+    <g id="patch_58">
      <path d="M 62.638994 59.420625 
 L 315.212744 59.420625 
 Q 317.012744 59.420625 317.012744 57.620625 
@@ -2243,7 +2581,7 @@ Q 60.838994 59.420625 62.638994 59.420625
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="patch_38">
+    <g id="patch_59">
      <path d="M 64.438994 40.738594 
 L 82.438994 40.738594 
 L 82.438994 34.438594 
@@ -2251,7 +2589,7 @@ L 64.438994 34.438594
 z
 " style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_21">
+    <g id="text_35">
      <!-- MobilityDB GiST -->
      <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <defs>
@@ -2366,7 +2704,7 @@ z
       <use xlink:href="#DejaVuSans-54" transform="translate(738.818359 0)"/>
      </g>
     </g>
-    <g id="patch_39">
+    <g id="patch_60">
      <path d="M 64.438994 53.948906 
 L 82.438994 53.948906 
 L 82.438994 47.648906 
@@ -2374,7 +2712,7 @@ L 64.438994 47.648906
 z
 " style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_22">
+    <g id="text_36">
      <!-- MobilityDuck rtree -->
      <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
@@ -2397,7 +2735,7 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(858.443359 0)"/>
      </g>
     </g>
-    <g id="patch_40">
+    <g id="patch_61">
      <path d="M 190.436182 40.738594 
 L 208.436182 40.738594 
 L 208.436182 34.438594 
@@ -2405,7 +2743,7 @@ L 190.436182 34.438594
 z
 " style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_23">
+    <g id="text_37">
      <!-- MobilitySpark local[4] -->
      <g transform="translate(215.636182 40.738594) scale(0.09 -0.09)">
       <defs>
@@ -2460,8 +2798,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pea80fdf40a">
-   <rect x="56.338994" y="25.8" width="580.861006" height="290.8"/>
+  <clipPath id="pc829cc1e92">
+   <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-13T00:35:15.337405</dc:date>
+    <dc:date>2026-05-13T11:30:08.345113</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -38,423 +38,423 @@ z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 103.359949 48949.830888 
-L 117.110514 48949.830888 
-L 117.110514 175.52487 
-L 103.359949 175.52487 
+    <path d="M 103.359949 44848.601475 
+L 117.110514 44848.601475 
+L 117.110514 187.421704 
+L 103.359949 187.421704 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 159.408449 48949.830888 
-L 173.159014 48949.830888 
-L 173.159014 210.451205 
-L 159.408449 210.451205 
+    <path d="M 159.408449 44848.601475 
+L 173.159014 44848.601475 
+L 173.159014 219.402709 
+L 159.408449 219.402709 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 215.456949 48949.830888 
-L 229.207514 48949.830888 
-L 229.207514 133.390041 
-L 215.456949 133.390041 
+    <path d="M 215.456949 44848.601475 
+L 229.207514 44848.601475 
+L 229.207514 148.840096 
+L 215.456949 148.840096 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 271.505449 48949.830888 
-L 285.256014 48949.830888 
-L 285.256014 112.625412 
-L 271.505449 112.625412 
+    <path d="M 271.505449 44848.601475 
+L 285.256014 44848.601475 
+L 285.256014 129.826543 
+L 271.505449 129.826543 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 327.553948 48949.830888 
-L 341.304514 48949.830888 
-L 341.304514 77.26846 
-L 327.553948 77.26846 
+    <path d="M 327.553948 44848.601475 
+L 341.304514 44848.601475 
+L 341.304514 97.451235 
+L 327.553948 97.451235 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 383.602448 48949.830888 
-L 397.353014 48949.830888 
-L 397.353014 139.708678 
-L 383.602448 139.708678 
+    <path d="M 383.602448 44848.601475 
+L 397.353014 44848.601475 
+L 397.353014 154.625883 
+L 383.602448 154.625883 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 439.650948 48949.830888 
-L 453.401513 48949.830888 
-L 453.401513 123.156228 
-L 439.650948 123.156228 
+    <path d="M 439.650948 44848.601475 
+L 453.401513 44848.601475 
+L 453.401513 139.469298 
+L 439.650948 139.469298 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 495.699448 48949.830888 
-L 509.450013 48949.830888 
-L 509.450013 166.754918 
-L 495.699448 166.754918 
+    <path d="M 495.699448 44848.601475 
+L 509.450013 44848.601475 
+L 509.450013 179.39132 
+L 495.699448 179.39132 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 551.747948 48949.830888 
-L 565.498513 48949.830888 
-L 565.498513 121.888104 
-L 551.747948 121.888104 
+    <path d="M 551.747948 44848.601475 
+L 565.498513 44848.601475 
+L 565.498513 138.308114 
+L 551.747948 138.308114 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 607.796448 48949.830888 
-L 621.547013 48949.830888 
-L 621.547013 130.738498 
-L 607.796448 130.738498 
+    <path d="M 607.796448 44848.601475 
+L 621.547013 44848.601475 
+L 621.547013 146.412156 
+L 607.796448 146.412156 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 663.844948 48949.830888 
-L 677.595513 48949.830888 
-L 677.595513 152.524455 
-L 663.844948 152.524455 
+    <path d="M 663.844948 44848.601475 
+L 677.595513 44848.601475 
+L 677.595513 166.360909 
+L 663.844948 166.360909 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 719.893447 48949.830888 
-L 733.644013 48949.830888 
-L 733.644013 151.981228 
-L 719.893447 151.981228 
+    <path d="M 719.893447 44848.601475 
+L 733.644013 44848.601475 
+L 733.644013 165.863492 
+L 719.893447 165.863492 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 775.941947 48949.830888 
-L 789.692513 48949.830888 
-L 789.692513 138.163778 
-L 775.941947 138.163778 
+    <path d="M 775.941947 44848.601475 
+L 789.692513 44848.601475 
+L 789.692513 153.211265 
+L 775.941947 153.211265 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 831.990447 48949.830888 
-L 845.741012 48949.830888 
-L 845.741012 187.653516 
-L 831.990447 187.653516 
+    <path d="M 831.990447 44848.601475 
+L 845.741012 44848.601475 
+L 845.741012 198.527544 
+L 831.990447 198.527544 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 888.038947 48949.830888 
-L 901.789512 48949.830888 
-L 901.789512 140.215513 
-L 888.038947 140.215513 
+    <path d="M 888.038947 44848.601475 
+L 901.789512 44848.601475 
+L 901.789512 155.089977 
+L 888.038947 155.089977 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 944.087447 48949.830888 
-L 957.838012 48949.830888 
-L 957.838012 111.066417 
-L 944.087447 111.066417 
+    <path d="M 944.087447 44848.601475 
+L 957.838012 44848.601475 
+L 957.838012 128.399018 
+L 944.087447 128.399018 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 1000.135947 48949.830888 
-L 1013.886512 48949.830888 
-L 1013.886512 122.039811 
-L 1000.135947 122.039811 
+    <path d="M 1000.135947 44848.601475 
+L 1013.886512 44848.601475 
+L 1013.886512 138.447028 
+L 1000.135947 138.447028 
 z
-" clip-path="url(#p8e87864216)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 118.306216 48949.830888 
-L 132.056781 48949.830888 
-L 132.056781 267.82043 
-L 118.306216 267.82043 
+    <path d="M 118.306216 44848.601475 
+L 132.056781 44848.601475 
+L 132.056781 271.934001 
+L 118.306216 271.934001 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 174.354715 48949.830888 
-L 188.105281 48949.830888 
-L 188.105281 282.504544 
-L 174.354715 282.504544 
+    <path d="M 174.354715 44848.601475 
+L 188.105281 44848.601475 
+L 188.105281 285.379806 
+L 174.354715 285.379806 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 230.403215 48949.830888 
-L 244.153781 48949.830888 
-L 244.153781 189.149528 
-L 230.403215 189.149528 
+    <path d="M 230.403215 44848.601475 
+L 244.153781 44848.601475 
+L 244.153781 199.897398 
+L 230.403215 199.897398 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 286.451715 48949.830888 
-L 300.20228 48949.830888 
-L 300.20228 175.254998 
-L 286.451715 175.254998 
+    <path d="M 286.451715 44848.601475 
+L 300.20228 44848.601475 
+L 300.20228 187.17459 
+L 286.451715 187.17459 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 342.500215 48949.830888 
-L 356.25078 48949.830888 
-L 356.25078 77.077476 
-L 342.500215 77.077476 
+    <path d="M 342.500215 44848.601475 
+L 356.25078 44848.601475 
+L 356.25078 97.276357 
+L 342.500215 97.276357 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.548715 48949.830888 
-L 412.29928 48949.830888 
-L 412.29928 195.072449 
-L 398.548715 195.072449 
+    <path d="M 398.548715 44848.601475 
+L 412.29928 44848.601475 
+L 412.29928 205.32084 
+L 398.548715 205.32084 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 454.597215 48949.830888 
-L 468.34778 48949.830888 
-L 468.34778 178.431434 
-L 454.597215 178.431434 
+    <path d="M 454.597215 44848.601475 
+L 468.34778 44848.601475 
+L 468.34778 190.083158 
+L 454.597215 190.083158 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 510.645715 48949.830888 
-L 524.39628 48949.830888 
-L 524.39628 211.912798 
-L 510.645715 211.912798 
+    <path d="M 510.645715 44848.601475 
+L 524.39628 44848.601475 
+L 524.39628 220.741046 
+L 510.645715 220.741046 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 566.694214 48949.830888 
-L 580.44478 48949.830888 
-L 580.44478 131.642962 
-L 566.694214 131.642962 
+    <path d="M 566.694214 44848.601475 
+L 580.44478 44848.601475 
+L 580.44478 147.240347 
+L 566.694214 147.240347 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 622.742714 48949.830888 
-L 636.49328 48949.830888 
-L 636.49328 131.472529 
-L 622.742714 131.472529 
+    <path d="M 622.742714 44848.601475 
+L 636.49328 44848.601475 
+L 636.49328 147.084287 
+L 622.742714 147.084287 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 678.791214 48949.830888 
-L 692.541779 48949.830888 
-L 692.541779 180.388335 
-L 678.791214 180.388335 
+    <path d="M 678.791214 44848.601475 
+L 692.541779 44848.601475 
+L 692.541779 191.875034 
+L 678.791214 191.875034 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 734.839714 48949.830888 
-L 748.590279 48949.830888 
-L 748.590279 179.387297 
-L 734.839714 179.387297 
+    <path d="M 734.839714 44848.601475 
+L 748.590279 44848.601475 
+L 748.590279 190.958413 
+L 734.839714 190.958413 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 790.888214 48949.830888 
-L 804.638779 48949.830888 
-L 804.638779 127.463495 
-L 790.888214 127.463495 
+    <path d="M 790.888214 44848.601475 
+L 804.638779 44848.601475 
+L 804.638779 143.413334 
+L 790.888214 143.413334 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
-    <path d="M 846.936714 48949.830888 
-L 860.687279 48949.830888 
-L 860.687279 183.315008 
-L 846.936714 183.315008 
+    <path d="M 846.936714 44848.601475 
+L 860.687279 44848.601475 
+L 860.687279 194.554902 
+L 846.936714 194.554902 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
-    <path d="M 902.985214 48949.830888 
-L 916.735779 48949.830888 
-L 916.735779 127.604445 
-L 902.985214 127.604445 
+    <path d="M 902.985214 44848.601475 
+L 916.735779 44848.601475 
+L 916.735779 143.542397 
+L 902.985214 143.542397 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
-    <path d="M 959.033713 48949.830888 
-L 972.784279 48949.830888 
-L 972.784279 145.097187 
-L 959.033713 145.097187 
+    <path d="M 959.033713 44848.601475 
+L 972.784279 44848.601475 
+L 972.784279 159.559981 
+L 959.033713 159.559981 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
-    <path d="M 1015.082213 48949.830888 
-L 1028.832779 48949.830888 
-L 1028.832779 177.817342 
-L 1015.082213 177.817342 
+    <path d="M 1015.082213 44848.601475 
+L 1028.832779 44848.601475 
+L 1028.832779 189.520852 
+L 1015.082213 189.520852 
 z
-" clip-path="url(#p8e87864216)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
-    <path d="M 133.252482 48949.830888 
-L 147.003048 48949.830888 
-L 147.003048 182.926287 
-L 133.252482 182.926287 
+    <path d="M 133.252482 44848.601475 
+L 147.003048 44848.601475 
+L 147.003048 197.66526 
+L 133.252482 197.66526 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
-    <path d="M 189.300982 48949.830888 
-L 203.051547 48949.830888 
-L 203.051547 89.342346 
-L 189.300982 89.342346 
+    <path d="M 189.300982 44848.601475 
+L 203.051547 44848.601475 
+L 203.051547 106.74687 
+L 189.300982 106.74687 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
-    <path d="M 245.349482 48949.830888 
-L 259.100047 48949.830888 
-L 259.100047 87.18806 
-L 245.349482 87.18806 
+    <path d="M 245.349482 44848.601475 
+L 259.100047 44848.601475 
+L 259.100047 110.527585 
+L 245.349482 110.527585 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
-    <path d="M 301.397982 48949.830888 
-L 315.148547 48949.830888 
-L 315.148547 81.87057 
-L 301.397982 81.87057 
+    <path d="M 301.397982 44848.601475 
+L 315.148547 44848.601475 
+L 315.148547 107.649645 
+L 301.397982 107.649645 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
-    <path d="M 357.446482 48949.830888 
-L 371.197047 48949.830888 
-L 371.197047 38.252083 
-L 357.446482 38.252083 
+    <path d="M 357.446482 44848.601475 
+L 371.197047 44848.601475 
+L 371.197047 67.980564 
+L 357.446482 67.980564 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
-    <path d="M 413.494981 48949.830888 
-L 427.245547 48949.830888 
-L 427.245547 135.95504 
-L 413.494981 135.95504 
+    <path d="M 413.494981 44848.601475 
+L 427.245547 44848.601475 
+L 427.245547 156.351304 
+L 413.494981 156.351304 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
-    <path d="M 469.543481 48949.830888 
-L 483.294047 48949.830888 
-L 483.294047 90.844139 
-L 469.543481 90.844139 
+    <path d="M 469.543481 44848.601475 
+L 483.294047 44848.601475 
+L 483.294047 107.362738 
+L 469.543481 107.362738 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
-    <path d="M 525.591981 48949.830888 
-L 539.342546 48949.830888 
-L 539.342546 223.76809 
-L 525.591981 223.76809 
+    <path d="M 525.591981 44848.601475 
+L 539.342546 44848.601475 
+L 539.342546 227.268001 
+L 525.591981 227.268001 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
-    <path d="M 581.640481 48949.830888 
-L 595.391046 48949.830888 
-L 595.391046 93.611056 
-L 581.640481 93.611056 
+    <path d="M 581.640481 44848.601475 
+L 595.391046 44848.601475 
+L 595.391046 109.173514 
+L 581.640481 109.173514 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
-    <path d="M 637.688981 48949.830888 
-L 651.439546 48949.830888 
-L 651.439546 316.6 
-L 637.688981 316.6 
+    <path d="M 637.688981 44848.601475 
+L 651.439546 44848.601475 
+L 651.439546 45.783708 
+L 637.688981 45.783708 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
-    <path d="M 693.737481 48949.830888 
-L 707.488046 48949.830888 
-L 707.488046 316.6 
-L 693.737481 316.6 
+    <path d="M 693.737481 44848.601475 
+L 707.488046 44848.601475 
+L 707.488046 37.202002 
+L 693.737481 37.202002 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
-    <path d="M 749.785981 48949.830888 
-L 763.536546 48949.830888 
-L 763.536546 316.6 
-L 749.785981 316.6 
+    <path d="M 749.785981 44848.601475 
+L 763.536546 44848.601475 
+L 763.536546 37.202002 
+L 749.785981 37.202002 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
-    <path d="M 805.83448 48949.830888 
-L 819.585046 48949.830888 
-L 819.585046 316.6 
-L 805.83448 316.6 
+    <path d="M 805.83448 44848.601475 
+L 819.585046 44848.601475 
+L 819.585046 91.320899 
+L 805.83448 91.320899 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
-    <path d="M 861.88298 48949.830888 
-L 875.633546 48949.830888 
-L 875.633546 316.6 
-L 861.88298 316.6 
+    <path d="M 861.88298 44848.601475 
+L 875.633546 44848.601475 
+L 875.633546 37.202002 
+L 861.88298 37.202002 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: url(#h7fbd10b4ca); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
-    <path d="M 917.93148 48949.830888 
-L 931.682045 48949.830888 
-L 931.682045 316.6 
-L 917.93148 316.6 
+    <path d="M 917.93148 44848.601475 
+L 931.682045 44848.601475 
+L 931.682045 74.593563 
+L 917.93148 74.593563 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
-    <path d="M 973.97998 48949.830888 
-L 987.730545 48949.830888 
-L 987.730545 316.6 
-L 973.97998 316.6 
+    <path d="M 973.97998 44848.601475 
+L 987.730545 44848.601475 
+L 987.730545 100.286088 
+L 973.97998 100.286088 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
-    <path d="M 1030.02848 48949.830888 
-L 1043.779045 48949.830888 
-L 1043.779045 316.6 
-L 1030.02848 316.6 
+    <path d="M 1030.02848 44848.601475 
+L 1043.779045 44848.601475 
+L 1043.779045 93.414083 
+L 1030.02848 93.414083 
 z
-" clip-path="url(#p8e87864216)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd8fee4f461)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me83e0dc554" d="M 0 0 
+       <path id="m4cff5ea429" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me83e0dc554" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -510,7 +510,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me83e0dc554" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -550,7 +550,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me83e0dc554" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -598,7 +598,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me83e0dc554" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -633,7 +633,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me83e0dc554" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -674,7 +674,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me83e0dc554" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,7 +720,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me83e0dc554" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me83e0dc554" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -801,7 +801,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me83e0dc554" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -847,7 +847,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me83e0dc554" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -885,7 +885,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me83e0dc554" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -900,7 +900,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me83e0dc554" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -915,7 +915,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me83e0dc554" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -930,7 +930,7 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me83e0dc554" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -945,7 +945,7 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me83e0dc554" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -960,7 +960,7 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me83e0dc554" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -975,7 +975,7 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me83e0dc554" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cff5ea429" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1287,16 +1287,16 @@ z
      <g id="line2d_18">
       <path d="M 56.338994 316.6 
 L 1090.8 316.6 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="m99628d0e10" d="M 0 0 
+       <path id="mab0e075192" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1320,18 +1320,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_20">
-      <path d="M 56.338994 267.82043 
-L 1090.8 267.82043 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 271.934001 
+L 1090.8 271.934001 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="267.82043" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.838994 271.619649) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 275.733219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1341,18 +1341,18 @@ L 1090.8 267.82043
     </g>
     <g id="ytick_3">
      <g id="line2d_22">
-      <path d="M 56.338994 219.040861 
-L 1090.8 219.040861 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 227.268001 
+L 1090.8 227.268001 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="219.040861" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.838994 222.84008) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 231.06722) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -1362,18 +1362,18 @@ L 1090.8 219.040861
     </g>
     <g id="ytick_4">
      <g id="line2d_24">
-      <path d="M 56.338994 170.261291 
-L 1090.8 170.261291 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 182.602002 
+L 1090.8 182.602002 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="170.261291" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.738994 174.06051) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 186.40122) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1382,18 +1382,18 @@ L 1090.8 170.261291
     </g>
     <g id="ytick_5">
      <g id="line2d_26">
-      <path d="M 56.338994 121.481722 
-L 1090.8 121.481722 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 137.936002 
+L 1090.8 137.936002 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="121.481722" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.738994 125.28094) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 141.735221) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -1402,18 +1402,18 @@ L 1090.8 121.481722
     </g>
     <g id="ytick_6">
      <g id="line2d_28">
-      <path d="M 56.338994 72.702152 
-L 1090.8 72.702152 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 93.270003 
+L 1090.8 93.270003 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m99628d0e10" x="56.338994" y="72.702152" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.738994 76.501371) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 97.069221) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1422,586 +1422,630 @@ L 1090.8 72.702152
     </g>
     <g id="ytick_7">
      <g id="line2d_30">
-      <path d="M 56.338994 301.915886 
-L 1090.8 301.915886 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 48.604003 
+L 1090.8 48.604003 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
-      <defs>
-       <path id="m9d10725750" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="301.915886" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab0e075192" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(31.738994 52.403222) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_32">
-      <path d="M 56.338994 293.326231 
-L 1090.8 293.326231 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 303.154194 
+L 1090.8 303.154194 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
+      <defs>
+       <path id="m9006438678" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="293.326231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_34">
-      <path d="M 56.338994 287.231773 
-L 1090.8 287.231773 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 295.288902 
+L 1090.8 295.288902 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="287.231773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_36">
-      <path d="M 56.338994 282.504544 
-L 1090.8 282.504544 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 289.708389 
+L 1090.8 289.708389 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="282.504544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_38">
-      <path d="M 56.338994 278.642117 
-L 1090.8 278.642117 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 285.379806 
+L 1090.8 285.379806 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="278.642117" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_40">
-      <path d="M 56.338994 275.376481 
-L 1090.8 275.376481 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 281.843097 
+L 1090.8 281.843097 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="275.376481" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_42">
-      <path d="M 56.338994 272.547659 
-L 1090.8 272.547659 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 278.852851 
+L 1090.8 278.852851 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="272.547659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_44">
-      <path d="M 56.338994 270.052461 
-L 1090.8 270.052461 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 276.262583 
+L 1090.8 276.262583 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="270.052461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_46">
-      <path d="M 56.338994 253.136317 
-L 1090.8 253.136317 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 273.977805 
+L 1090.8 273.977805 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="253.136317" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_48">
-      <path d="M 56.338994 244.546661 
-L 1090.8 244.546661 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 258.488195 
+L 1090.8 258.488195 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="244.546661" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_50">
-      <path d="M 56.338994 238.452203 
-L 1090.8 238.452203 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 250.622903 
+L 1090.8 250.622903 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="238.452203" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_52">
-      <path d="M 56.338994 233.724974 
-L 1090.8 233.724974 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 245.042389 
+L 1090.8 245.042389 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="233.724974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_54">
-      <path d="M 56.338994 229.862547 
-L 1090.8 229.862547 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 240.713807 
+L 1090.8 240.713807 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="229.862547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_56">
-      <path d="M 56.338994 226.596912 
-L 1090.8 226.596912 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 237.177097 
+L 1090.8 237.177097 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="226.596912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_58">
-      <path d="M 56.338994 223.76809 
-L 1090.8 223.76809 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 234.186852 
+L 1090.8 234.186852 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="223.76809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_60">
-      <path d="M 56.338994 221.272892 
-L 1090.8 221.272892 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 231.596584 
+L 1090.8 231.596584 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="221.272892" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_62">
-      <path d="M 56.338994 204.356747 
-L 1090.8 204.356747 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 229.311805 
+L 1090.8 229.311805 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="204.356747" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_64">
-      <path d="M 56.338994 195.767091 
-L 1090.8 195.767091 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 213.822195 
+L 1090.8 213.822195 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="195.767091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_66">
-      <path d="M 56.338994 189.672634 
-L 1090.8 189.672634 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 205.956903 
+L 1090.8 205.956903 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="189.672634" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_68">
-      <path d="M 56.338994 184.945405 
-L 1090.8 184.945405 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 200.37639 
+L 1090.8 200.37639 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="184.945405" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_70">
-      <path d="M 56.338994 181.082978 
-L 1090.8 181.082978 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 196.047807 
+L 1090.8 196.047807 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="181.082978" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_72">
-      <path d="M 56.338994 177.817342 
-L 1090.8 177.817342 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 192.511098 
+L 1090.8 192.511098 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="177.817342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_74">
-      <path d="M 56.338994 174.98852 
-L 1090.8 174.98852 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 189.520852 
+L 1090.8 189.520852 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="174.98852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_76">
-      <path d="M 56.338994 172.493322 
-L 1090.8 172.493322 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 186.930584 
+L 1090.8 186.930584 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="172.493322" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_78">
-      <path d="M 56.338994 155.577178 
-L 1090.8 155.577178 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 184.645806 
+L 1090.8 184.645806 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="155.577178" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_80">
-      <path d="M 56.338994 146.987522 
-L 1090.8 146.987522 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 169.156196 
+L 1090.8 169.156196 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="146.987522" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_82">
-      <path d="M 56.338994 140.893064 
-L 1090.8 140.893064 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 161.290904 
+L 1090.8 161.290904 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="140.893064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_84">
-      <path d="M 56.338994 136.165835 
-L 1090.8 136.165835 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 155.71039 
+L 1090.8 155.71039 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="136.165835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_86">
-      <path d="M 56.338994 132.303408 
-L 1090.8 132.303408 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 151.381808 
+L 1090.8 151.381808 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="132.303408" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_88">
-      <path d="M 56.338994 129.037773 
-L 1090.8 129.037773 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 147.845098 
+L 1090.8 147.845098 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="129.037773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_90">
-      <path d="M 56.338994 126.20895 
-L 1090.8 126.20895 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 144.854853 
+L 1090.8 144.854853 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="126.20895" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_92">
-      <path d="M 56.338994 123.713752 
-L 1090.8 123.713752 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 142.264585 
+L 1090.8 142.264585 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="123.713752" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_94">
-      <path d="M 56.338994 106.797608 
-L 1090.8 106.797608 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 139.979806 
+L 1090.8 139.979806 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="106.797608" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_96">
-      <path d="M 56.338994 98.207952 
-L 1090.8 98.207952 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 124.490196 
+L 1090.8 124.490196 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="98.207952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_98">
-      <path d="M 56.338994 92.113494 
-L 1090.8 92.113494 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 116.624904 
+L 1090.8 116.624904 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="92.113494" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_100">
-      <path d="M 56.338994 87.386266 
-L 1090.8 87.386266 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 111.044391 
+L 1090.8 111.044391 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="87.386266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_102">
-      <path d="M 56.338994 83.523839 
-L 1090.8 83.523839 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 106.715808 
+L 1090.8 106.715808 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="83.523839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_104">
-      <path d="M 56.338994 80.258203 
-L 1090.8 80.258203 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 103.179099 
+L 1090.8 103.179099 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="80.258203" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_106">
-      <path d="M 56.338994 77.429381 
-L 1090.8 77.429381 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 100.188853 
+L 1090.8 100.188853 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="77.429381" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_108">
-      <path d="M 56.338994 74.934183 
-L 1090.8 74.934183 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 97.598585 
+L 1090.8 97.598585 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="74.934183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_110">
-      <path d="M 56.338994 58.018038 
-L 1090.8 58.018038 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 95.313807 
+L 1090.8 95.313807 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="58.018038" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_112">
-      <path d="M 56.338994 49.428383 
-L 1090.8 49.428383 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 79.824197 
+L 1090.8 79.824197 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="49.428383" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_114">
-      <path d="M 56.338994 43.333925 
-L 1090.8 43.333925 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 71.958905 
+L 1090.8 71.958905 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="43.333925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_116">
-      <path d="M 56.338994 38.606696 
-L 1090.8 38.606696 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 66.378391 
+L 1090.8 66.378391 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="38.606696" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_118">
-      <path d="M 56.338994 34.744269 
-L 1090.8 34.744269 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 62.049809 
+L 1090.8 62.049809 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="34.744269" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_120">
-      <path d="M 56.338994 31.478633 
-L 1090.8 31.478633 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 58.513099 
+L 1090.8 58.513099 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="31.478633" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_122">
-      <path d="M 56.338994 28.649811 
-L 1090.8 28.649811 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 55.522854 
+L 1090.8 55.522854 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_123">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="28.649811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_124">
-      <path d="M 56.338994 26.154613 
-L 1090.8 26.154613 
-" clip-path="url(#p8e87864216)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 52.932586 
+L 1090.8 52.932586 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#m9d10725750" x="56.338994" y="26.154613" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9006438678" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_25">
+    <g id="ytick_55">
+     <g id="line2d_126">
+      <path d="M 56.338994 50.647807 
+L 1090.8 50.647807 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#m9006438678" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_128">
+      <path d="M 56.338994 35.158198 
+L 1090.8 35.158198 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#m9006438678" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_130">
+      <path d="M 56.338994 27.292905 
+L 1090.8 27.292905 
+" clip-path="url(#pd8fee4f461)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#m9006438678" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_26">
      <!-- Wall-clock seconds (log scale) -->
      <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2281,80 +2325,72 @@ L 1090.8 316.6
 L 1090.8 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_26">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(646.495826 309.471937) rotate(-90) scale(0.07 -0.07)">
+   <g id="text_27">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(702.544326 36.25556) rotate(-90) scale(0.07 -0.07)">
      <defs>
-      <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
+      <path id="DejaVuSans-3e" d="M 678 3150 
+L 678 3719 
+L 4684 2266 
+L 4684 1747 
+L 678 294 
+L 678 863 
+L 3897 2003 
+L 678 3150 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(702.544326 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(758.592826 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(758.592826 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(814.641326 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(870.689825 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(870.689825 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(926.738325 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(982.786825 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(1038.835325 309.471937) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
     <!-- BerlinMOD R-queries Q1-Q17 — standard index per platform (sf 0.005) -->
     <g transform="translate(361.25856 19.8) scale(0.12 -0.12)">
      <defs>
@@ -2399,32 +2435,6 @@ L 978 3500
 L 1906 2253 
 L 2834 3500 
 L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-66" d="M 2375 4863 
@@ -2558,10 +2568,10 @@ z
    <g id="legend_1">
     <g id="patch_58">
      <path d="M 62.638994 59.420625 
-L 315.212744 59.420625 
-Q 317.012744 59.420625 317.012744 57.620625 
-L 317.012744 32.1 
-Q 317.012744 30.3 315.212744 30.3 
+L 339.130244 59.420625 
+Q 340.930244 59.420625 340.930244 57.620625 
+L 340.930244 32.1 
+Q 340.930244 30.3 339.130244 30.3 
 L 62.638994 30.3 
 Q 60.838994 30.3 60.838994 32.1 
 L 60.838994 57.620625 
@@ -2577,8 +2587,8 @@ L 64.438994 34.438594
 z
 " style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_35">
-     <!-- MobilityDB GiST -->
+    <g id="text_31">
+     <!-- MobilityDB R-tree -->
      <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-62" d="M 3116 1747 
@@ -2607,31 +2617,74 @@ L 1159 4863
 L 1159 2969 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(635.550781 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(671.634766 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(710.84375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(749.707031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(811.230469 0)"/>
+     </g>
+    </g>
+    <g id="patch_60">
+     <path d="M 64.438994 53.948906 
+L 82.438994 53.948906 
+L 82.438994 47.648906 
+L 64.438994 47.648906 
 z
-" transform="scale(0.015625)"/>
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_32">
+     <!-- MobilityDuck (no index) -->
+     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(716.748047 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(780.126953 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(841.308594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(873.095703 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(900.878906 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(964.257812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1027.734375 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1087.507812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1146.6875 0)"/>
+     </g>
+    </g>
+    <g id="patch_61">
+     <path d="M 214.353682 40.738594 
+L 232.353682 40.738594 
+L 232.353682 34.438594 
+L 214.353682 34.438594 
+z
+" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_33">
+     <!-- MobilitySpark local[4] -->
+     <g transform="translate(239.553682 40.738594) scale(0.09 -0.09)">
+      <defs>
        <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
 Q 3066 4069 2747 4153 
@@ -2663,78 +2716,6 @@ Q 2388 4750 2728 4690
 Q 3069 4631 3425 4513 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
-      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
-      <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(570.068359 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(647.558594 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(675.341797 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(738.818359 0)"/>
-     </g>
-    </g>
-    <g id="patch_60">
-     <path d="M 64.438994 53.948906 
-L 82.438994 53.948906 
-L 82.438994 47.648906 
-L 64.438994 47.648906 
-z
-" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_36">
-     <!-- MobilityDuck rtree -->
-     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
-      <use xlink:href="#DejaVuSans-4d"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
-      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(677.734375 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(718.847656 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(758.056641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(796.919922 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(858.443359 0)"/>
-     </g>
-    </g>
-    <g id="patch_61">
-     <path d="M 190.436182 40.738594 
-L 208.436182 40.738594 
-L 208.436182 34.438594 
-L 190.436182 34.438594 
-z
-" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_37">
-     <!-- MobilitySpark local[4] -->
-     <g transform="translate(215.636182 40.738594) scale(0.09 -0.09)">
-      <defs>
        <path id="DejaVuSans-5b" d="M 550 4863 
 L 1875 4863 
 L 1875 4416 
@@ -2786,8 +2767,52 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8e87864216">
+  <clipPath id="pd8fee4f461">
    <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h7fbd10b4ca" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#2ca02c"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #333333; stroke: #333333; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -1,0 +1,2350 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="360pt" viewBox="0 0 648 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-12T20:36:50.342016</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 648 360 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 56.273369 316.6 
+L 637.2 316.6 
+L 637.2 25.8 
+L 56.273369 25.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 82.679125 55892.344093 
+L 95.928809 55892.344093 
+L 95.928809 211.234704 
+L 82.679125 211.234704 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 136.685989 55892.344093 
+L 149.935673 55892.344093 
+L 149.935673 251.106867 
+L 136.685989 251.106867 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 190.692853 55892.344093 
+L 203.942537 55892.344093 
+L 203.942537 163.133271 
+L 190.692853 163.133271 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 244.699717 55892.344093 
+L 257.9494 55892.344093 
+L 257.9494 139.428216 
+L 244.699717 139.428216 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 298.70658 55892.344093 
+L 311.956264 55892.344093 
+L 311.956264 99.064458 
+L 298.70658 99.064458 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 352.713444 55892.344093 
+L 365.963128 55892.344093 
+L 365.963128 170.346673 
+L 352.713444 170.346673 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 406.720308 55892.344093 
+L 419.969992 55892.344093 
+L 419.969992 151.450274 
+L 406.720308 151.450274 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 460.727172 55892.344093 
+L 473.976856 55892.344093 
+L 473.976856 201.222861 
+L 460.727172 201.222861 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 514.734036 55892.344093 
+L 527.98372 55892.344093 
+L 527.98372 150.002574 
+L 514.734036 150.002574 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 568.740899 55892.344093 
+L 581.990583 55892.344093 
+L 581.990583 160.106249 
+L 568.740899 160.106249 
+z
+" clip-path="url(#p458f29867d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 97.080955 55892.344093 
+L 110.330639 55892.344093 
+L 110.330639 316.6 
+L 97.080955 316.6 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 151.087819 55892.344093 
+L 164.337503 55892.344093 
+L 164.337503 333.363493 
+L 151.087819 333.363493 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 205.094683 55892.344093 
+L 218.344367 55892.344093 
+L 218.344367 226.788715 
+L 205.094683 226.788715 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 259.101547 55892.344093 
+L 272.351231 55892.344093 
+L 272.351231 210.926616 
+L 259.101547 210.926616 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 313.108411 55892.344093 
+L 326.358095 55892.344093 
+L 326.358095 98.846429 
+L 313.108411 98.846429 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 367.115275 55892.344093 
+L 380.364958 55892.344093 
+L 380.364958 233.550365 
+L 367.115275 233.550365 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 421.122138 55892.344093 
+L 434.371822 55892.344093 
+L 434.371822 214.552859 
+L 421.122138 214.552859 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 475.129002 55892.344093 
+L 488.378686 55892.344093 
+L 488.378686 252.775432 
+L 475.129002 252.775432 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 529.135866 55892.344093 
+L 542.38555 55892.344093 
+L 542.38555 161.138792 
+L 529.135866 161.138792 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 583.14273 55892.344093 
+L 596.392414 55892.344093 
+L 596.392414 160.944225 
+L 583.14273 160.944225 
+z
+" clip-path="url(#p458f29867d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 111.482786 55892.344093 
+L 124.73247 55892.344093 
+L 124.73247 219.684217 
+L 111.482786 219.684217 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 165.48965 55892.344093 
+L 178.739334 55892.344093 
+L 178.739334 112.848096 
+L 165.48965 112.848096 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 219.496513 55892.344093 
+L 232.746197 55892.344093 
+L 232.746197 110.388746 
+L 219.496513 110.388746 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 273.503377 55892.344093 
+L 286.753061 55892.344093 
+L 286.753061 104.31826 
+L 273.503377 104.31826 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 327.510241 55892.344093 
+L 340.759925 55892.344093 
+L 340.759925 54.523072 
+L 327.510241 54.523072 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 381.517105 55892.344093 
+L 394.766789 55892.344093 
+L 394.766789 166.061493 
+L 381.517105 166.061493 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 435.523969 55892.344093 
+L 448.773653 55892.344093 
+L 448.773653 114.562554 
+L 435.523969 114.562554 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 489.530832 55892.344093 
+L 502.780516 55892.344093 
+L 502.780516 266.309521 
+L 489.530832 266.309521 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 543.537696 55892.344093 
+L 556.78738 55892.344093 
+L 556.78738 117.721287 
+L 543.537696 117.721287 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 597.54456 55892.344093 
+L 610.794244 55892.344093 
+L 610.794244 40.01539 
+L 597.54456 40.01539 
+z
+" clip-path="url(#p458f29867d)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m14927eba02" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m14927eba02" x="103.705797" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Q1 -->
+      <g transform="translate(96.58861 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m14927eba02" x="157.712661" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Q2 -->
+      <g transform="translate(150.595474 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m14927eba02" x="211.719525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Q3 -->
+      <g transform="translate(204.602338 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m14927eba02" x="265.726389" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Q4 -->
+      <g transform="translate(258.609201 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m14927eba02" x="319.733253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Q5 -->
+      <g transform="translate(312.616065 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m14927eba02" x="373.740116" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- Q6 -->
+      <g transform="translate(366.622929 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m14927eba02" x="427.74698" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- Q7 -->
+      <g transform="translate(420.629793 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m14927eba02" x="481.753844" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Q8 -->
+      <g transform="translate(474.636657 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m14927eba02" x="535.760708" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- Q9 -->
+      <g transform="translate(528.64352 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m14927eba02" x="589.767572" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- Q10 -->
+      <g transform="translate(579.469134 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- BerlinMOD R-query -->
+     <g transform="translate(299.025747 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(895.023438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 56.273369 316.6 
+L 637.2 316.6 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m5dc2cb6f35" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(25.773369 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 56.273369 260.912882 
+L 637.2 260.912882 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="260.912882" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(25.773369 264.7121) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 56.273369 205.225763 
+L 637.2 205.225763 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="205.225763" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(31.673369 209.024982) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 56.273369 149.538645 
+L 637.2 149.538645 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="149.538645" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(31.673369 153.337864) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 56.273369 93.851527 
+L 637.2 93.851527 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="93.851527" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(31.673369 97.650745) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 56.273369 38.164408 
+L 637.2 38.164408 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m5dc2cb6f35" x="56.273369" y="38.164408" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(31.673369 41.963627) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 56.273369 299.836507 
+L 637.2 299.836507 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <defs>
+       <path id="m1449cbf260" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="299.836507" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 56.273369 290.030492 
+L 637.2 290.030492 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="290.030492" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 56.273369 283.073014 
+L 637.2 283.073014 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="283.073014" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_29">
+      <path d="M 56.273369 277.676375 
+L 637.2 277.676375 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="277.676375" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <path d="M 56.273369 273.266999 
+L 637.2 273.266999 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="273.266999" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <path d="M 56.273369 269.538925 
+L 637.2 269.538925 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="269.538925" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_35">
+      <path d="M 56.273369 266.309521 
+L 637.2 266.309521 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="266.309521" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_37">
+      <path d="M 56.273369 263.460984 
+L 637.2 263.460984 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="263.460984" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_39">
+      <path d="M 56.273369 244.149389 
+L 637.2 244.149389 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="244.149389" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_41">
+      <path d="M 56.273369 234.343374 
+L 637.2 234.343374 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="234.343374" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_43">
+      <path d="M 56.273369 227.385896 
+L 637.2 227.385896 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="227.385896" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_45">
+      <path d="M 56.273369 221.989256 
+L 637.2 221.989256 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="221.989256" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_47">
+      <path d="M 56.273369 217.579881 
+L 637.2 217.579881 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="217.579881" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_49">
+      <path d="M 56.273369 213.851807 
+L 637.2 213.851807 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="213.851807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_51">
+      <path d="M 56.273369 210.622403 
+L 637.2 210.622403 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="210.622403" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_53">
+      <path d="M 56.273369 207.773866 
+L 637.2 207.773866 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="207.773866" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_55">
+      <path d="M 56.273369 188.46227 
+L 637.2 188.46227 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="188.46227" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_57">
+      <path d="M 56.273369 178.656256 
+L 637.2 178.656256 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="178.656256" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_59">
+      <path d="M 56.273369 171.698777 
+L 637.2 171.698777 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="171.698777" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_61">
+      <path d="M 56.273369 166.302138 
+L 637.2 166.302138 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="166.302138" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_63">
+      <path d="M 56.273369 161.892763 
+L 637.2 161.892763 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="161.892763" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_65">
+      <path d="M 56.273369 158.164689 
+L 637.2 158.164689 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="158.164689" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_67">
+      <path d="M 56.273369 154.935284 
+L 637.2 154.935284 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="154.935284" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_69">
+      <path d="M 56.273369 152.086748 
+L 637.2 152.086748 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="152.086748" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_71">
+      <path d="M 56.273369 132.775152 
+L 637.2 132.775152 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="132.775152" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_73">
+      <path d="M 56.273369 122.969137 
+L 637.2 122.969137 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="122.969137" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_75">
+      <path d="M 56.273369 116.011659 
+L 637.2 116.011659 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="116.011659" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_77">
+      <path d="M 56.273369 110.61502 
+L 637.2 110.61502 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="110.61502" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_79">
+      <path d="M 56.273369 106.205644 
+L 637.2 106.205644 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="106.205644" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_81">
+      <path d="M 56.273369 102.47757 
+L 637.2 102.47757 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="102.47757" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_83">
+      <path d="M 56.273369 99.248166 
+L 637.2 99.248166 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="99.248166" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_85">
+      <path d="M 56.273369 96.399629 
+L 637.2 96.399629 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="96.399629" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_87">
+      <path d="M 56.273369 77.088034 
+L 637.2 77.088034 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="77.088034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_89">
+      <path d="M 56.273369 67.282019 
+L 637.2 67.282019 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="67.282019" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_91">
+      <path d="M 56.273369 60.324541 
+L 637.2 60.324541 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="60.324541" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_93">
+      <path d="M 56.273369 54.927901 
+L 637.2 54.927901 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="54.927901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_95">
+      <path d="M 56.273369 50.518526 
+L 637.2 50.518526 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="50.518526" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_97">
+      <path d="M 56.273369 46.790452 
+L 637.2 46.790452 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="46.790452" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_99">
+      <path d="M 56.273369 43.561048 
+L 637.2 43.561048 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="43.561048" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_101">
+      <path d="M 56.273369 40.712511 
+L 637.2 40.712511 
+" clip-path="url(#p458f29867d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m1449cbf260" x="56.273369" y="40.712511" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Wall-clock seconds (log scale) -->
+     <g transform="translate(19.693682 245.925781) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-57"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(92.501953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(153.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(181.564453 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(209.347656 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(245.431641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(300.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(328.195312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(389.376953 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(444.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(502.267578 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(534.054688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(586.154297 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(647.677734 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(702.658203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(763.839844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(827.21875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(890.695312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(942.794922 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(974.582031 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1013.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1041.378906 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1102.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1166.037109 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1197.824219 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1249.923828 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1304.904297 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1366.183594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1393.966797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1455.490234 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_33">
+    <path d="M 56.273369 316.6 
+L 56.273369 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 637.2 316.6 
+L 637.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 56.273369 316.6 
+L 637.2 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 56.273369 25.8 
+L 637.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- BerlinMOD R-queries Q1-Q10 — standard index per platform (sf 0.005) -->
+    <g transform="translate(134.425747 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(895.023438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(922.806641 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(984.330078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1036.429688 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1068.216797 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1146.927734 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1210.550781 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1250.259766 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1328.970703 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1392.59375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1456.216797 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1488.003906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1588.003906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1619.791016 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1671.890625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1711.099609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1772.378906 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1835.757812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1899.234375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1960.513672 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1999.876953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2063.353516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2095.140625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2122.923828 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2186.302734 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2249.779297 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(2309.552734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2368.732422 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2400.519531 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2463.996094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2525.519531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2566.632812 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2598.419922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2661.896484 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2689.679688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2750.958984 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2790.167969 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2825.373047 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2886.554688 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2925.917969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3023.330078 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3055.117188 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3094.130859 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(3146.230469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3181.435547 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3213.222656 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3276.845703 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3308.632812 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3372.255859 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3435.878906 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3499.501953 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_37">
+     <path d="M 62.573369 59.420625 
+L 315.147119 59.420625 
+Q 316.947119 59.420625 316.947119 57.620625 
+L 316.947119 32.1 
+Q 316.947119 30.3 315.147119 30.3 
+L 62.573369 30.3 
+Q 60.773369 30.3 60.773369 32.1 
+L 60.773369 57.620625 
+Q 60.773369 59.420625 62.573369 59.420625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_38">
+     <path d="M 64.373369 40.738594 
+L 82.373369 40.738594 
+L 82.373369 34.438594 
+L 64.373369 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- MobilityDB GiST -->
+     <g transform="translate(89.573369 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(647.558594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(675.341797 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(738.818359 0)"/>
+     </g>
+    </g>
+    <g id="patch_39">
+     <path d="M 64.373369 53.948906 
+L 82.373369 53.948906 
+L 82.373369 47.648906 
+L 64.373369 47.648906 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <!-- MobilityDuck rtree -->
+     <g transform="translate(89.573369 53.948906) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(718.847656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(758.056641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(796.919922 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(858.443359 0)"/>
+     </g>
+    </g>
+    <g id="patch_40">
+     <path d="M 190.370557 40.738594 
+L 208.370557 40.738594 
+L 208.370557 34.438594 
+L 190.370557 34.438594 
+z
+" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <!-- MobilitySpark local[4] -->
+     <g transform="translate(215.570557 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(456.152344 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(519.628906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(580.908203 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(622.021484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(679.931641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(711.71875 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(739.501953 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(800.683594 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(855.664062 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(916.943359 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(944.726562 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(983.740234 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(1047.363281 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p458f29867d">
+   <rect x="56.273369" y="25.8" width="580.926631" height="290.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/BerlinMOD/benchmarks/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/cross_platform_standard.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T23:47:00.676068</dc:date>
+    <dc:date>2026-05-12T23:51:32.317616</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -38,423 +38,423 @@ z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 103.359949 46913.520099 
-L 117.110514 46913.520099 
-L 117.110514 181.431794 
-L 103.359949 181.431794 
+    <path d="M 103.359949 48949.830888 
+L 117.110514 48949.830888 
+L 117.110514 175.52487 
+L 103.359949 175.52487 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 159.408449 46913.520099 
-L 173.159014 46913.520099 
-L 173.159014 214.895737 
-L 159.408449 214.895737 
+    <path d="M 159.408449 48949.830888 
+L 173.159014 48949.830888 
+L 173.159014 210.451205 
+L 159.408449 210.451205 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 215.456949 46913.520099 
-L 229.207514 46913.520099 
-L 229.207514 141.061183 
-L 215.456949 141.061183 
+    <path d="M 215.456949 48949.830888 
+L 229.207514 48949.830888 
+L 229.207514 133.390041 
+L 215.456949 133.390041 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 271.505449 46913.520099 
-L 285.256014 46913.520099 
-L 285.256014 121.165984 
-L 271.505449 121.165984 
+    <path d="M 271.505449 48949.830888 
+L 285.256014 48949.830888 
+L 285.256014 112.625412 
+L 271.505449 112.625412 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 327.553948 46913.520099 
-L 341.304514 46913.520099 
-L 341.304514 87.289456 
-L 327.553948 87.289456 
+    <path d="M 327.553948 48949.830888 
+L 341.304514 48949.830888 
+L 341.304514 77.26846 
+L 327.553948 77.26846 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 383.602448 46913.520099 
-L 397.353014 46913.520099 
-L 397.353014 147.115253 
-L 383.602448 147.115253 
+    <path d="M 383.602448 48949.830888 
+L 397.353014 48949.830888 
+L 397.353014 139.708678 
+L 383.602448 139.708678 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 439.650948 46913.520099 
-L 453.401513 46913.520099 
-L 453.401513 131.255868 
-L 439.650948 131.255868 
+    <path d="M 439.650948 48949.830888 
+L 453.401513 48949.830888 
+L 453.401513 123.156228 
+L 439.650948 123.156228 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 495.699448 46913.520099 
-L 509.450013 46913.520099 
-L 509.450013 173.029047 
-L 495.699448 173.029047 
+    <path d="M 495.699448 48949.830888 
+L 509.450013 48949.830888 
+L 509.450013 166.754918 
+L 495.699448 166.754918 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 551.747948 46913.520099 
-L 565.498513 46913.520099 
-L 565.498513 130.040841 
-L 551.747948 130.040841 
+    <path d="M 551.747948 48949.830888 
+L 565.498513 48949.830888 
+L 565.498513 121.888104 
+L 551.747948 121.888104 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 607.796448 46913.520099 
-L 621.547013 46913.520099 
-L 621.547013 138.520662 
-L 607.796448 138.520662 
+    <path d="M 607.796448 48949.830888 
+L 621.547013 48949.830888 
+L 621.547013 130.738498 
+L 607.796448 130.738498 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 663.844948 46913.520099 
-L 677.595513 46913.520099 
-L 677.595513 159.394425 
-L 663.844948 159.394425 
+    <path d="M 663.844948 48949.830888 
+L 677.595513 48949.830888 
+L 677.595513 152.524455 
+L 663.844948 152.524455 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 719.893447 46913.520099 
-L 733.644013 46913.520099 
-L 733.644013 158.873943 
-L 719.893447 158.873943 
+    <path d="M 719.893447 48949.830888 
+L 733.644013 48949.830888 
+L 733.644013 151.981228 
+L 719.893447 151.981228 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 775.941947 46913.520099 
-L 789.692513 46913.520099 
-L 789.692513 145.63504 
-L 775.941947 145.63504 
+    <path d="M 775.941947 48949.830888 
+L 789.692513 48949.830888 
+L 789.692513 138.163778 
+L 775.941947 138.163778 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 831.990447 46913.520099 
-L 845.741012 46913.520099 
-L 845.741012 193.052605 
-L 831.990447 193.052605 
+    <path d="M 831.990447 48949.830888 
+L 845.741012 48949.830888 
+L 845.741012 187.653516 
+L 831.990447 187.653516 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 888.038947 46913.520099 
-L 901.789512 46913.520099 
-L 901.789512 147.600867 
-L 888.038947 147.600867 
+    <path d="M 888.038947 48949.830888 
+L 901.789512 48949.830888 
+L 901.789512 140.215513 
+L 888.038947 140.215513 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 944.087447 46913.520099 
-L 957.838012 46913.520099 
-L 957.838012 119.672267 
-L 944.087447 119.672267 
+    <path d="M 944.087447 48949.830888 
+L 957.838012 48949.830888 
+L 957.838012 111.066417 
+L 944.087447 111.066417 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 1000.135947 46913.520099 
-L 1013.886512 46913.520099 
-L 1013.886512 130.186196 
-L 1000.135947 130.186196 
+    <path d="M 1000.135947 48949.830888 
+L 1013.886512 48949.830888 
+L 1013.886512 122.039811 
+L 1000.135947 122.039811 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 118.306216 46913.520099 
-L 132.056781 46913.520099 
-L 132.056781 269.862869 
-L 118.306216 269.862869 
+    <path d="M 118.306216 48949.830888 
+L 132.056781 48949.830888 
+L 132.056781 267.82043 
+L 118.306216 267.82043 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 174.354715 46913.520099 
-L 188.105281 46913.520099 
-L 188.105281 283.932147 
-L 174.354715 283.932147 
+    <path d="M 174.354715 48949.830888 
+L 188.105281 48949.830888 
+L 188.105281 282.504544 
+L 174.354715 282.504544 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 230.403215 46913.520099 
-L 244.153781 46913.520099 
-L 244.153781 194.485977 
-L 230.403215 194.485977 
+    <path d="M 230.403215 48949.830888 
+L 244.153781 48949.830888 
+L 244.153781 189.149528 
+L 230.403215 189.149528 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 286.451715 46913.520099 
-L 300.20228 46913.520099 
-L 300.20228 181.173222 
-L 286.451715 181.173222 
+    <path d="M 286.451715 48949.830888 
+L 300.20228 48949.830888 
+L 300.20228 175.254998 
+L 286.451715 175.254998 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 342.500215 46913.520099 
-L 356.25078 46913.520099 
-L 356.25078 87.106468 
-L 342.500215 87.106468 
+    <path d="M 342.500215 48949.830888 
+L 356.25078 48949.830888 
+L 356.25078 77.077476 
+L 342.500215 77.077476 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.548715 46913.520099 
-L 412.29928 46913.520099 
-L 412.29928 200.160901 
-L 398.548715 200.160901 
+    <path d="M 398.548715 48949.830888 
+L 412.29928 48949.830888 
+L 412.29928 195.072449 
+L 398.548715 195.072449 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 454.597215 46913.520099 
-L 468.34778 46913.520099 
-L 468.34778 184.216658 
-L 454.597215 184.216658 
+    <path d="M 454.597215 48949.830888 
+L 468.34778 48949.830888 
+L 468.34778 178.431434 
+L 454.597215 178.431434 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 510.645715 46913.520099 
-L 524.39628 46913.520099 
-L 524.39628 216.296132 
-L 510.645715 216.296132 
+    <path d="M 510.645715 48949.830888 
+L 524.39628 48949.830888 
+L 524.39628 211.912798 
+L 510.645715 211.912798 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 566.694214 46913.520099 
-L 580.44478 46913.520099 
-L 580.44478 139.387256 
-L 566.694214 139.387256 
+    <path d="M 566.694214 48949.830888 
+L 580.44478 48949.830888 
+L 580.44478 131.642962 
+L 566.694214 131.642962 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 622.742714 46913.520099 
-L 636.49328 46913.520099 
-L 636.49328 139.223959 
-L 622.742714 139.223959 
+    <path d="M 622.742714 48949.830888 
+L 636.49328 48949.830888 
+L 636.49328 131.472529 
+L 622.742714 131.472529 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 678.791214 46913.520099 
-L 692.541779 46913.520099 
-L 692.541779 186.091622 
-L 678.791214 186.091622 
+    <path d="M 678.791214 48949.830888 
+L 692.541779 48949.830888 
+L 692.541779 180.388335 
+L 678.791214 180.388335 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 734.839714 46913.520099 
-L 748.590279 46913.520099 
-L 748.590279 185.132499 
-L 734.839714 185.132499 
+    <path d="M 734.839714 48949.830888 
+L 748.590279 48949.830888 
+L 748.590279 179.387297 
+L 734.839714 179.387297 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 790.888214 46913.520099 
-L 804.638779 46913.520099 
-L 804.638779 135.382786 
-L 790.888214 135.382786 
+    <path d="M 790.888214 48949.830888 
+L 804.638779 48949.830888 
+L 804.638779 127.463495 
+L 790.888214 127.463495 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
-    <path d="M 846.936714 46913.520099 
-L 860.687279 46913.520099 
-L 860.687279 188.895754 
-L 846.936714 188.895754 
+    <path d="M 846.936714 48949.830888 
+L 860.687279 48949.830888 
+L 860.687279 183.315008 
+L 846.936714 183.315008 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
-    <path d="M 902.985214 46913.520099 
-L 916.735779 46913.520099 
-L 916.735779 135.517834 
-L 902.985214 135.517834 
+    <path d="M 902.985214 48949.830888 
+L 916.735779 48949.830888 
+L 916.735779 127.604445 
+L 902.985214 127.604445 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
-    <path d="M 959.033713 46913.520099 
-L 972.784279 46913.520099 
-L 972.784279 152.278142 
-L 959.033713 152.278142 
+    <path d="M 959.033713 48949.830888 
+L 972.784279 48949.830888 
+L 972.784279 145.097187 
+L 959.033713 145.097187 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
-    <path d="M 1015.082213 46913.520099 
-L 1028.832779 46913.520099 
-L 1028.832779 183.628279 
-L 1015.082213 183.628279 
+    <path d="M 1015.082213 48949.830888 
+L 1028.832779 48949.830888 
+L 1028.832779 177.817342 
+L 1015.082213 177.817342 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
-    <path d="M 133.252482 46913.520099 
-L 147.003048 46913.520099 
-L 147.003048 188.523309 
-L 133.252482 188.523309 
+    <path d="M 133.252482 48949.830888 
+L 147.003048 48949.830888 
+L 147.003048 182.926287 
+L 133.252482 182.926287 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
-    <path d="M 189.300982 46913.520099 
-L 203.051547 46913.520099 
-L 203.051547 98.857799 
-L 189.300982 98.857799 
+    <path d="M 189.300982 48949.830888 
+L 203.051547 48949.830888 
+L 203.051547 89.342346 
+L 189.300982 89.342346 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
-    <path d="M 245.349482 46913.520099 
-L 259.100047 46913.520099 
-L 259.100047 96.793714 
-L 245.349482 96.793714 
+    <path d="M 245.349482 48949.830888 
+L 259.100047 48949.830888 
+L 259.100047 87.18806 
+L 245.349482 87.18806 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
-    <path d="M 301.397982 46913.520099 
-L 315.148547 46913.520099 
-L 315.148547 91.698872 
-L 301.397982 91.698872 
+    <path d="M 301.397982 48949.830888 
+L 315.148547 48949.830888 
+L 315.148547 81.87057 
+L 301.397982 81.87057 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
-    <path d="M 357.446482 46913.520099 
-L 371.197047 46913.520099 
-L 371.197047 49.906724 
-L 357.446482 49.906724 
+    <path d="M 357.446482 48949.830888 
+L 371.197047 48949.830888 
+L 371.197047 38.252083 
+L 357.446482 38.252083 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
-    <path d="M 413.494981 46913.520099 
-L 427.245547 46913.520099 
-L 427.245547 143.518784 
-L 413.494981 143.518784 
+    <path d="M 413.494981 48949.830888 
+L 427.245547 48949.830888 
+L 427.245547 135.95504 
+L 413.494981 135.95504 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
-    <path d="M 469.543481 46913.520099 
-L 483.294047 46913.520099 
-L 483.294047 100.296711 
-L 469.543481 100.296711 
+    <path d="M 469.543481 48949.830888 
+L 483.294047 48949.830888 
+L 483.294047 90.844139 
+L 469.543481 90.844139 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
-    <path d="M 525.591981 46913.520099 
-L 539.342546 46913.520099 
-L 539.342546 227.655033 
-L 525.591981 227.655033 
+    <path d="M 525.591981 48949.830888 
+L 539.342546 48949.830888 
+L 539.342546 223.76809 
+L 525.591981 223.76809 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
-    <path d="M 581.640481 46913.520099 
-L 595.391046 46913.520099 
-L 595.391046 102.947775 
-L 581.640481 102.947775 
+    <path d="M 581.640481 48949.830888 
+L 595.391046 48949.830888 
+L 595.391046 93.611056 
+L 581.640481 93.611056 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
-    <path d="M 637.688981 46913.520099 
-L 651.439546 46913.520099 
-L 651.439546 37.730705 
-L 637.688981 37.730705 
+    <path d="M 637.688981 48949.830888 
+L 651.439546 48949.830888 
+L 651.439546 316.6 
+L 637.688981 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
-    <path d="M 693.737481 46913.520099 
-L 707.488046 46913.520099 
+    <path d="M 693.737481 48949.830888 
+L 707.488046 48949.830888 
 L 707.488046 316.6 
 L 693.737481 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
-    <path d="M 749.785981 46913.520099 
-L 763.536546 46913.520099 
+    <path d="M 749.785981 48949.830888 
+L 763.536546 48949.830888 
 L 763.536546 316.6 
 L 749.785981 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
-    <path d="M 805.83448 46913.520099 
-L 819.585046 46913.520099 
+    <path d="M 805.83448 48949.830888 
+L 819.585046 48949.830888 
 L 819.585046 316.6 
 L 805.83448 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
-    <path d="M 861.88298 46913.520099 
-L 875.633546 46913.520099 
+    <path d="M 861.88298 48949.830888 
+L 875.633546 48949.830888 
 L 875.633546 316.6 
 L 861.88298 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
-    <path d="M 917.93148 46913.520099 
-L 931.682045 46913.520099 
+    <path d="M 917.93148 48949.830888 
+L 931.682045 48949.830888 
 L 931.682045 316.6 
 L 917.93148 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
-    <path d="M 973.97998 46913.520099 
-L 987.730545 46913.520099 
+    <path d="M 973.97998 48949.830888 
+L 987.730545 48949.830888 
 L 987.730545 316.6 
 L 973.97998 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
-    <path d="M 1030.02848 46913.520099 
-L 1043.779045 46913.520099 
+    <path d="M 1030.02848 48949.830888 
+L 1043.779045 48949.830888 
 L 1043.779045 316.6 
 L 1030.02848 316.6 
 z
-" clip-path="url(#pc829cc1e92)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa23a725a25)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m82807bce06" d="M 0 0 
+       <path id="m967ff3b26b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m82807bce06" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -510,7 +510,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m82807bce06" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -550,7 +550,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m82807bce06" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -598,7 +598,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m82807bce06" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -633,7 +633,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m82807bce06" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -674,7 +674,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m82807bce06" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,7 +720,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m82807bce06" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m82807bce06" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -801,7 +801,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m82807bce06" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -847,7 +847,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m82807bce06" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -885,7 +885,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m82807bce06" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -900,7 +900,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m82807bce06" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -915,7 +915,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m82807bce06" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -930,7 +930,7 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m82807bce06" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -945,7 +945,7 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m82807bce06" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -960,7 +960,7 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m82807bce06" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -975,7 +975,7 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m82807bce06" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m967ff3b26b" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1287,16 +1287,16 @@ z
      <g id="line2d_18">
       <path d="M 56.338994 316.6 
 L 1090.8 316.6 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="mf1ceac1ee8" d="M 0 0 
+       <path id="m561b5576e6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1320,18 +1320,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_20">
-      <path d="M 56.338994 269.862869 
-L 1090.8 269.862869 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 267.82043 
+L 1090.8 267.82043 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="269.862869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="267.82043" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.838994 273.662087) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 271.619649) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1341,18 +1341,18 @@ L 1090.8 269.862869
     </g>
     <g id="ytick_3">
      <g id="line2d_22">
-      <path d="M 56.338994 223.125737 
-L 1090.8 223.125737 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 219.040861 
+L 1090.8 219.040861 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="223.125737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="219.040861" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.838994 226.924956) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 222.84008) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -1362,18 +1362,18 @@ L 1090.8 223.125737
     </g>
     <g id="ytick_4">
      <g id="line2d_24">
-      <path d="M 56.338994 176.388606 
-L 1090.8 176.388606 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 170.261291 
+L 1090.8 170.261291 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="176.388606" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="170.261291" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.738994 180.187824) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 174.06051) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1382,18 +1382,18 @@ L 1090.8 176.388606
     </g>
     <g id="ytick_5">
      <g id="line2d_26">
-      <path d="M 56.338994 129.651474 
-L 1090.8 129.651474 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 121.481722 
+L 1090.8 121.481722 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="129.651474" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="121.481722" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.738994 133.450693) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 125.28094) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -1402,18 +1402,18 @@ L 1090.8 129.651474
     </g>
     <g id="ytick_6">
      <g id="line2d_28">
-      <path d="M 56.338994 82.914343 
-L 1090.8 82.914343 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 72.702152 
+L 1090.8 72.702152 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="82.914343" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561b5576e6" x="56.338994" y="72.702152" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.738994 86.713561) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 76.501371) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -1422,606 +1422,586 @@ L 1090.8 82.914343
     </g>
     <g id="ytick_7">
      <g id="line2d_30">
-      <path d="M 56.338994 36.177211 
-L 1090.8 36.177211 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 301.915886 
+L 1090.8 301.915886 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
+      <defs>
+       <path id="mde83ee3b22" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
       <g>
-       <use xlink:href="#mf1ceac1ee8" x="56.338994" y="36.177211" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_25">
-      <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(31.738994 39.97643) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="301.915886" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_32">
-      <path d="M 56.338994 302.530722 
-L 1090.8 302.530722 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 293.326231 
+L 1090.8 293.326231 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
-      <defs>
-       <path id="m1ff24460ae" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="302.530722" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="293.326231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_34">
-      <path d="M 56.338994 294.300721 
-L 1090.8 294.300721 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 287.231773 
+L 1090.8 287.231773 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="294.300721" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="287.231773" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_36">
-      <path d="M 56.338994 288.461443 
-L 1090.8 288.461443 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 282.504544 
+L 1090.8 282.504544 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="288.461443" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="282.504544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_38">
-      <path d="M 56.338994 283.932147 
-L 1090.8 283.932147 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 278.642117 
+L 1090.8 278.642117 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="283.932147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="278.642117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_40">
-      <path d="M 56.338994 280.231443 
-L 1090.8 280.231443 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 275.376481 
+L 1090.8 275.376481 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="280.231443" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="275.376481" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_42">
-      <path d="M 56.338994 277.102542 
-L 1090.8 277.102542 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 272.547659 
+L 1090.8 272.547659 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="277.102542" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="272.547659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_44">
-      <path d="M 56.338994 274.392165 
-L 1090.8 274.392165 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 270.052461 
+L 1090.8 270.052461 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="274.392165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="270.052461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_46">
-      <path d="M 56.338994 272.001442 
-L 1090.8 272.001442 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 253.136317 
+L 1090.8 253.136317 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="272.001442" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="253.136317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_48">
-      <path d="M 56.338994 255.79359 
-L 1090.8 255.79359 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 244.546661 
+L 1090.8 244.546661 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="255.79359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="244.546661" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_50">
-      <path d="M 56.338994 247.56359 
-L 1090.8 247.56359 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 238.452203 
+L 1090.8 238.452203 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="247.56359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="238.452203" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_52">
-      <path d="M 56.338994 241.724312 
-L 1090.8 241.724312 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 233.724974 
+L 1090.8 233.724974 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="241.724312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="233.724974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_54">
-      <path d="M 56.338994 237.195016 
-L 1090.8 237.195016 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 229.862547 
+L 1090.8 229.862547 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="237.195016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="229.862547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_56">
-      <path d="M 56.338994 233.494311 
-L 1090.8 233.494311 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 226.596912 
+L 1090.8 226.596912 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="233.494311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="226.596912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_58">
-      <path d="M 56.338994 230.36541 
-L 1090.8 230.36541 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 223.76809 
+L 1090.8 223.76809 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="230.36541" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="223.76809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_60">
-      <path d="M 56.338994 227.655033 
-L 1090.8 227.655033 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 221.272892 
+L 1090.8 221.272892 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="227.655033" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="221.272892" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_62">
-      <path d="M 56.338994 225.264311 
-L 1090.8 225.264311 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 204.356747 
+L 1090.8 204.356747 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="225.264311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="204.356747" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_64">
-      <path d="M 56.338994 209.056459 
-L 1090.8 209.056459 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 195.767091 
+L 1090.8 195.767091 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="209.056459" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="195.767091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_66">
-      <path d="M 56.338994 200.826458 
-L 1090.8 200.826458 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 189.672634 
+L 1090.8 189.672634 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="200.826458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="189.672634" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_68">
-      <path d="M 56.338994 194.98718 
-L 1090.8 194.98718 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 184.945405 
+L 1090.8 184.945405 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="194.98718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="184.945405" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_70">
-      <path d="M 56.338994 190.457884 
-L 1090.8 190.457884 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 181.082978 
+L 1090.8 181.082978 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="190.457884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="181.082978" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_72">
-      <path d="M 56.338994 186.75718 
-L 1090.8 186.75718 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 177.817342 
+L 1090.8 177.817342 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="186.75718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="177.817342" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_74">
-      <path d="M 56.338994 183.628279 
-L 1090.8 183.628279 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 174.98852 
+L 1090.8 174.98852 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="183.628279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="174.98852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_76">
-      <path d="M 56.338994 180.917902 
-L 1090.8 180.917902 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 172.493322 
+L 1090.8 172.493322 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="180.917902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="172.493322" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_78">
-      <path d="M 56.338994 178.527179 
-L 1090.8 178.527179 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 155.577178 
+L 1090.8 155.577178 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="178.527179" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="155.577178" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_80">
-      <path d="M 56.338994 162.319327 
-L 1090.8 162.319327 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 146.987522 
+L 1090.8 146.987522 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="162.319327" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="146.987522" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_82">
-      <path d="M 56.338994 154.089327 
-L 1090.8 154.089327 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 140.893064 
+L 1090.8 140.893064 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="154.089327" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="140.893064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_84">
-      <path d="M 56.338994 148.250049 
-L 1090.8 148.250049 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 136.165835 
+L 1090.8 136.165835 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="148.250049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="136.165835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_86">
-      <path d="M 56.338994 143.720753 
-L 1090.8 143.720753 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 132.303408 
+L 1090.8 132.303408 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="143.720753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="132.303408" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_88">
-      <path d="M 56.338994 140.020048 
-L 1090.8 140.020048 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 129.037773 
+L 1090.8 129.037773 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="140.020048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="129.037773" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_90">
-      <path d="M 56.338994 136.891147 
-L 1090.8 136.891147 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 126.20895 
+L 1090.8 126.20895 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="136.891147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="126.20895" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_92">
-      <path d="M 56.338994 134.18077 
-L 1090.8 134.18077 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 123.713752 
+L 1090.8 123.713752 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="134.18077" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="123.713752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_94">
-      <path d="M 56.338994 131.790048 
-L 1090.8 131.790048 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 106.797608 
+L 1090.8 106.797608 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="131.790048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="106.797608" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_96">
-      <path d="M 56.338994 115.582196 
-L 1090.8 115.582196 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 98.207952 
+L 1090.8 98.207952 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="115.582196" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="98.207952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_98">
-      <path d="M 56.338994 107.352195 
-L 1090.8 107.352195 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 92.113494 
+L 1090.8 92.113494 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="107.352195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="92.113494" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_100">
-      <path d="M 56.338994 101.512917 
-L 1090.8 101.512917 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 87.386266 
+L 1090.8 87.386266 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="101.512917" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="87.386266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_102">
-      <path d="M 56.338994 96.983621 
-L 1090.8 96.983621 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 83.523839 
+L 1090.8 83.523839 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="96.983621" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="83.523839" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_104">
-      <path d="M 56.338994 93.282917 
-L 1090.8 93.282917 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 80.258203 
+L 1090.8 80.258203 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="93.282917" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="80.258203" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_106">
-      <path d="M 56.338994 90.154016 
-L 1090.8 90.154016 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 77.429381 
+L 1090.8 77.429381 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="90.154016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="77.429381" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_108">
-      <path d="M 56.338994 87.443639 
-L 1090.8 87.443639 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 74.934183 
+L 1090.8 74.934183 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="87.443639" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="74.934183" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_110">
-      <path d="M 56.338994 85.052916 
-L 1090.8 85.052916 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 58.018038 
+L 1090.8 58.018038 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="85.052916" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="58.018038" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_112">
-      <path d="M 56.338994 68.845064 
-L 1090.8 68.845064 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 49.428383 
+L 1090.8 49.428383 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="68.845064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="49.428383" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_114">
-      <path d="M 56.338994 60.615064 
-L 1090.8 60.615064 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 43.333925 
+L 1090.8 43.333925 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="60.615064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="43.333925" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_116">
-      <path d="M 56.338994 54.775786 
-L 1090.8 54.775786 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 38.606696 
+L 1090.8 38.606696 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="54.775786" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="38.606696" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_118">
-      <path d="M 56.338994 50.24649 
-L 1090.8 50.24649 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 34.744269 
+L 1090.8 34.744269 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="50.24649" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="34.744269" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_120">
-      <path d="M 56.338994 46.545785 
-L 1090.8 46.545785 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 31.478633 
+L 1090.8 31.478633 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="46.545785" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="31.478633" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_122">
-      <path d="M 56.338994 43.416884 
-L 1090.8 43.416884 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 28.649811 
+L 1090.8 28.649811 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_123">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="43.416884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="28.649811" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_124">
-      <path d="M 56.338994 40.706507 
-L 1090.8 40.706507 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 26.154613 
+L 1090.8 26.154613 
+" clip-path="url(#pa23a725a25)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="40.706507" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mde83ee3b22" x="56.338994" y="26.154613" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="ytick_55">
-     <g id="line2d_126">
-      <path d="M 56.338994 38.315785 
-L 1090.8 38.315785 
-" clip-path="url(#pc829cc1e92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_127">
-      <g>
-       <use xlink:href="#m1ff24460ae" x="56.338994" y="38.315785" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_26">
+    <g id="text_25">
      <!-- Wall-clock seconds (log scale) -->
      <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2301,9 +2281,9 @@ L 1090.8 316.6
 L 1090.8 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_27">
+   <g id="text_26">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(702.544326 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(646.495826 309.471937) rotate(-90) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-2f" d="M 1625 4666 
 L 2156 4666 
@@ -2318,9 +2298,17 @@ z
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
    </g>
+   <g id="text_27">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(702.544326 309.471937) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
    <g id="text_28">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(758.592826 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(758.592826 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2328,7 +2316,7 @@ z
    </g>
    <g id="text_29">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(814.641326 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(814.641326 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2336,7 +2324,7 @@ z
    </g>
    <g id="text_30">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(870.689825 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(870.689825 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2344,7 +2332,7 @@ z
    </g>
    <g id="text_31">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(926.738325 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(926.738325 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2352,7 +2340,7 @@ z
    </g>
    <g id="text_32">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(982.786825 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(982.786825 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2360,7 +2348,7 @@ z
    </g>
    <g id="text_33">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(1038.835325 309.770395) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(1038.835325 309.471937) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2798,7 +2786,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc829cc1e92">
+  <clipPath id="pa23a725a25">
    <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -1,0 +1,2207 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="360pt" viewBox="0 0 576 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-05-12T20:36:50.730365</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 576 360 
+L 576 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 56.273369 316.6 
+L 565.2 316.6 
+L 565.2 25.8 
+L 56.273369 25.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 79.406398 69535.037487 
+L 93.632592 69535.037487 
+L 93.632592 95.936215 
+L 79.406398 95.936215 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 176.051738 69535.037487 
+L 190.277932 69535.037487 
+L 190.277932 45.663991 
+L 176.051738 45.663991 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 272.697079 69535.037487 
+L 286.923273 69535.037487 
+L 286.923273 157.769722 
+L 272.697079 157.769722 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 369.342419 69535.037487 
+L 383.568613 69535.037487 
+L 383.568613 110.909439 
+L 369.342419 110.909439 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 465.987759 69535.037487 
+L 480.213953 69535.037487 
+L 480.213953 64.272459 
+L 465.987759 64.272459 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 94.869652 69535.037487 
+L 109.095846 69535.037487 
+L 109.095846 125.886121 
+L 94.869652 125.886121 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 191.514993 69535.037487 
+L 205.741187 69535.037487 
+L 205.741187 43.504974 
+L 191.514993 43.504974 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 288.160333 69535.037487 
+L 302.386527 69535.037487 
+L 302.386527 268.121431 
+L 288.160333 268.121431 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 384.805673 69535.037487 
+L 399.031868 69535.037487 
+L 399.031868 129.226939 
+L 384.805673 129.226939 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 481.451014 69535.037487 
+L 495.677208 69535.037487 
+L 495.677208 159.682836 
+L 481.451014 159.682836 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 110.332907 69535.037487 
+L 124.559101 69535.037487 
+L 124.559101 184.98599 
+L 110.332907 184.98599 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 206.978247 69535.037487 
+L 221.204441 69535.037487 
+L 221.204441 45.39244 
+L 206.978247 45.39244 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 303.623588 69535.037487 
+L 317.849782 69535.037487 
+L 317.849782 213.163401 
+L 303.623588 213.163401 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 400.268928 69535.037487 
+L 414.495122 69535.037487 
+L 414.495122 189.502401 
+L 400.268928 189.502401 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 496.914268 69535.037487 
+L 511.140462 69535.037487 
+L 511.140462 122.733958 
+L 496.914268 122.733958 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 125.796161 69535.037487 
+L 140.022355 69535.037487 
+L 140.022355 316.6 
+L 125.796161 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 222.441502 69535.037487 
+L 236.667696 69535.037487 
+L 236.667696 316.6 
+L 222.441502 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 319.086842 69535.037487 
+L 333.313036 69535.037487 
+L 333.313036 262.629646 
+L 319.086842 262.629646 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 415.732182 69535.037487 
+L 429.958376 69535.037487 
+L 429.958376 253.964251 
+L 415.732182 253.964251 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 512.377523 69535.037487 
+L 526.603717 69535.037487 
+L 526.603717 161.375497 
+L 512.377523 161.375497 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 141.259416 69535.037487 
+L 155.48561 69535.037487 
+L 155.48561 316.6 
+L 141.259416 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 237.904756 69535.037487 
+L 252.13095 69535.037487 
+L 252.13095 316.6 
+L 237.904756 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 334.550096 69535.037487 
+L 348.776291 69535.037487 
+L 348.776291 316.6 
+L 334.550096 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 431.195437 69535.037487 
+L 445.421631 69535.037487 
+L 445.421631 316.6 
+L 431.195437 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 527.840777 69535.037487 
+L 542.066971 69535.037487 
+L 542.066971 316.6 
+L 527.840777 316.6 
+z
+" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m3f0154a71b" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3f0154a71b" x="117.446004" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Q4 -->
+      <g transform="translate(110.328816 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m3f0154a71b" x="214.091344" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Q5 -->
+      <g transform="translate(206.974157 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m3f0154a71b" x="310.736685" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Q6 -->
+      <g transform="translate(303.619497 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m3f0154a71b" x="407.382025" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Q7 -->
+      <g transform="translate(400.264837 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m3f0154a71b" x="504.027365" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Q10 -->
+      <g transform="translate(493.728928 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(142.333984 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- BerlinMOD R-query -->
+     <g transform="translate(263.025747 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(895.023438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <path d="M 56.273369 316.6 
+L 565.2 316.6 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <defs>
+       <path id="m07bf6d3f8e" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(25.773369 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <path d="M 56.273369 247.242848 
+L 565.2 247.242848 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="247.242848" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(25.773369 251.042067) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <path d="M 56.273369 177.885696 
+L 565.2 177.885696 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="177.885696" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(31.673369 181.684915) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_12">
+      <path d="M 56.273369 108.528545 
+L 565.2 108.528545 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="108.528545" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(31.673369 112.327763) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <path d="M 56.273369 39.171393 
+L 565.2 39.171393 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="39.171393" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(31.673369 42.970612) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_16">
+      <path d="M 56.273369 295.721417 
+L 565.2 295.721417 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <defs>
+       <path id="m9236581984" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="295.721417" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_18">
+      <path d="M 56.273369 283.508229 
+L 565.2 283.508229 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="283.508229" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_20">
+      <path d="M 56.273369 274.842834 
+L 565.2 274.842834 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="274.842834" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_22">
+      <path d="M 56.273369 268.121431 
+L 565.2 268.121431 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="268.121431" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_24">
+      <path d="M 56.273369 262.629646 
+L 565.2 262.629646 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="262.629646" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_26">
+      <path d="M 56.273369 257.986407 
+L 565.2 257.986407 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="257.986407" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_28">
+      <path d="M 56.273369 253.964251 
+L 565.2 253.964251 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="253.964251" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_30">
+      <path d="M 56.273369 250.416457 
+L 565.2 250.416457 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="250.416457" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_32">
+      <path d="M 56.273369 226.364265 
+L 565.2 226.364265 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="226.364265" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_34">
+      <path d="M 56.273369 214.151077 
+L 565.2 214.151077 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="214.151077" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_36">
+      <path d="M 56.273369 205.485682 
+L 565.2 205.485682 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="205.485682" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_38">
+      <path d="M 56.273369 198.76428 
+L 565.2 198.76428 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="198.76428" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_40">
+      <path d="M 56.273369 193.272494 
+L 565.2 193.272494 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="193.272494" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_42">
+      <path d="M 56.273369 188.629255 
+L 565.2 188.629255 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="188.629255" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_44">
+      <path d="M 56.273369 184.607099 
+L 565.2 184.607099 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="184.607099" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_46">
+      <path d="M 56.273369 181.059306 
+L 565.2 181.059306 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="181.059306" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_48">
+      <path d="M 56.273369 157.007113 
+L 565.2 157.007113 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="157.007113" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_50">
+      <path d="M 56.273369 144.793925 
+L 565.2 144.793925 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="144.793925" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_52">
+      <path d="M 56.273369 136.12853 
+L 565.2 136.12853 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="136.12853" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_54">
+      <path d="M 56.273369 129.407128 
+L 565.2 129.407128 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="129.407128" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_56">
+      <path d="M 56.273369 123.915342 
+L 565.2 123.915342 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="123.915342" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_58">
+      <path d="M 56.273369 119.272103 
+L 565.2 119.272103 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="119.272103" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_60">
+      <path d="M 56.273369 115.249947 
+L 565.2 115.249947 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="115.249947" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_62">
+      <path d="M 56.273369 111.702154 
+L 565.2 111.702154 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="111.702154" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_64">
+      <path d="M 56.273369 87.649962 
+L 565.2 87.649962 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="87.649962" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_66">
+      <path d="M 56.273369 75.436773 
+L 565.2 75.436773 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="75.436773" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_68">
+      <path d="M 56.273369 66.771378 
+L 565.2 66.771378 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="66.771378" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_70">
+      <path d="M 56.273369 60.049976 
+L 565.2 60.049976 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="60.049976" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_72">
+      <path d="M 56.273369 54.55819 
+L 565.2 54.55819 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="54.55819" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_74">
+      <path d="M 56.273369 49.914952 
+L 565.2 49.914952 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="49.914952" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_76">
+      <path d="M 56.273369 45.892795 
+L 565.2 45.892795 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="45.892795" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_78">
+      <path d="M 56.273369 42.345002 
+L 565.2 42.345002 
+" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m9236581984" x="56.273369" y="42.345002" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Wall-clock seconds (log scale) -->
+     <g transform="translate(19.693682 245.925781) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-57"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(92.501953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(153.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(181.564453 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(209.347656 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(245.431641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(300.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(328.195312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(389.376953 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(444.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(502.267578 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(534.054688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(586.154297 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(647.677734 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(702.658203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(763.839844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(827.21875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(890.695312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(942.794922 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(974.582031 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1013.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1041.378906 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1102.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1166.037109 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1197.824219 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1249.923828 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1304.904297 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1366.183594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1393.966797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1455.490234 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_28">
+    <path d="M 56.273369 316.6 
+L 56.273369 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 565.2 316.6 
+L 565.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 56.273369 316.6 
+L 565.2 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 56.273369 25.8 
+L 565.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(134.840821 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(231.486161 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(150.304075 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(246.949416 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(343.594756 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(440.240096 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(536.885437 306.464976) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- BerlinMOD trip-side cross-join queries — th3index prefilter vs baseline (sf 0.005) -->
+    <g transform="translate(69.121372 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(603.173828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(644.287109 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(672.070312 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(735.546875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(771.630859 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(823.730469 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(851.513672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(914.990234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(976.513672 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1008.300781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1063.28125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1102.144531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1163.326172 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1215.425781 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1267.525391 0)"/>
+     <use xlink:href="#DejaVuSans-6a" transform="translate(1303.609375 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1331.392578 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1392.574219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1420.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1483.736328 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(1515.523438 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1579 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1642.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1703.902344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1745.015625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1772.798828 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1834.322266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1886.421875 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1918.208984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2018.208984 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2049.996094 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2089.205078 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2152.583984 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2216.207031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2243.990234 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2307.369141 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2370.845703 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(2430.619141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2489.798828 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2521.585938 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2585.0625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2623.925781 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2685.449219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2720.654297 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2748.4375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2776.220703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2815.429688 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2876.953125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2918.066406 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2949.853516 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3009.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3061.132812 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3092.919922 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3156.396484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3217.675781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3269.775391 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3331.298828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3359.082031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3386.865234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3450.244141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3511.767578 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3543.554688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3582.568359 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(3634.667969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3669.873047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3701.660156 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3765.283203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3797.070312 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3860.693359 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3924.316406 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3987.939453 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_32">
+     <path d="M 62.573369 72.630938 
+L 368.590244 72.630938 
+Q 370.390244 72.630938 370.390244 70.830938 
+L 370.390244 32.1 
+Q 370.390244 30.3 368.590244 30.3 
+L 62.573369 30.3 
+Q 60.773369 30.3 60.773369 32.1 
+L 60.773369 70.830938 
+Q 60.773369 72.630938 62.573369 72.630938 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_33">
+     <path d="M 64.373369 40.738594 
+L 82.373369 40.738594 
+L 82.373369 34.438594 
+L 64.373369 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <!-- MobilityDB GiST (baseline) -->
+     <g transform="translate(89.573369 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(647.558594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(675.341797 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(738.818359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(799.902344 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(831.689453 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(870.703125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(934.179688 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(995.458984 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1047.558594 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1109.082031 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1136.865234 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1164.648438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1228.027344 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1289.550781 0)"/>
+     </g>
+    </g>
+    <g id="patch_34">
+     <path d="M 64.373369 53.948906 
+L 82.373369 53.948906 
+L 82.373369 47.648906 
+L 64.373369 47.648906 
+z
+" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <!-- MobilityDB th3index -->
+     <g transform="translate(89.573369 53.948906) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(609.277344 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(672.65625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(736.279297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(764.0625 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(827.441406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(890.917969 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(950.691406 0)"/>
+     </g>
+    </g>
+    <g id="patch_35">
+     <path d="M 64.373369 67.159219 
+L 82.373369 67.159219 
+L 82.373369 60.859219 
+L 64.373369 60.859219 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_23">
+     <!-- MobilityDuck rtree (baseline) -->
+     <g transform="translate(89.573369 67.159219) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(718.847656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(758.056641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(796.919922 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(858.443359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.966797 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.753906 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(990.767578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1054.244141 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1115.523438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1167.623047 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1229.146484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1256.929688 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1284.712891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1348.091797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1409.615234 0)"/>
+     </g>
+    </g>
+    <g id="patch_36">
+     <path d="M 237.951025 40.738594 
+L 255.951025 40.738594 
+L 255.951025 34.438594 
+L 237.951025 34.438594 
+z
+" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_24">
+     <!-- MobilityDuck th3index -->
+     <g transform="translate(263.151025 40.738594) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(716.943359 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(780.322266 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(843.945312 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(871.728516 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(935.107422 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(998.583984 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1058.357422 0)"/>
+     </g>
+    </g>
+    <g id="patch_37">
+     <path d="M 237.951025 53.948906 
+L 255.951025 53.948906 
+L 255.951025 47.648906 
+L 237.951025 47.648906 
+z
+" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_25">
+     <!-- MobilitySpark th3index -->
+     <g transform="translate(263.151025 53.948906) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(456.152344 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(519.628906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(580.908203 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(622.021484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(679.931641 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(711.71875 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(750.927734 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(814.306641 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(877.929688 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(905.712891 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(969.091797 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1032.568359 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1092.341797 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb7ee37159f">
+   <rect x="56.273369" y="25.8" width="508.926631" height="290.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T20:36:50.730365</dc:date>
+    <dc:date>2026-05-12T23:46:01.839128</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -30,228 +30,228 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 56.273369 316.6 
+    <path d="M 56.338994 316.6 
 L 565.2 316.6 
 L 565.2 25.8 
-L 56.273369 25.8 
+L 56.338994 25.8 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 79.406398 69535.037487 
-L 93.632592 69535.037487 
-L 93.632592 95.936215 
-L 79.406398 95.936215 
+    <path d="M 79.46904 56149.317639 
+L 93.6934 56149.317639 
+L 93.6934 82.429755 
+L 79.46904 82.429755 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 176.051738 69535.037487 
-L 190.277932 69535.037487 
-L 190.277932 45.663991 
-L 176.051738 45.663991 
+    <path d="M 176.101918 56149.317639 
+L 190.326278 56149.317639 
+L 190.326278 41.838689 
+L 176.101918 41.838689 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 272.697079 69535.037487 
-L 286.923273 69535.037487 
-L 286.923273 157.769722 
-L 272.697079 157.769722 
+    <path d="M 272.734796 56149.317639 
+L 286.959156 56149.317639 
+L 286.959156 132.355694 
+L 272.734796 132.355694 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 369.342419 69535.037487 
-L 383.568613 69535.037487 
-L 383.568613 110.909439 
-L 369.342419 110.909439 
+    <path d="M 369.367674 56149.317639 
+L 383.592034 56149.317639 
+L 383.592034 94.519515 
+L 369.367674 94.519515 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 465.987759 69535.037487 
-L 480.213953 69535.037487 
-L 480.213953 64.272459 
-L 465.987759 64.272459 
+    <path d="M 466.000553 56149.317639 
+L 480.224912 56149.317639 
+L 480.224912 56.863637 
+L 466.000553 56.863637 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 94.869652 69535.037487 
-L 109.095846 69535.037487 
-L 109.095846 125.886121 
-L 94.869652 125.886121 
+    <path d="M 94.9303 56149.317639 
+L 109.15466 56149.317639 
+L 109.15466 106.612067 
+L 94.9303 106.612067 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 191.514993 69535.037487 
-L 205.741187 69535.037487 
-L 205.741187 43.504974 
-L 191.514993 43.504974 
+    <path d="M 191.563179 56149.317639 
+L 205.787538 56149.317639 
+L 205.787538 40.095444 
+L 191.563179 40.095444 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 288.160333 69535.037487 
-L 302.386527 69535.037487 
-L 302.386527 268.121431 
-L 288.160333 268.121431 
+    <path d="M 288.196057 56149.317639 
+L 302.420416 56149.317639 
+L 302.420416 221.456457 
+L 288.196057 221.456457 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 384.805673 69535.037487 
-L 399.031868 69535.037487 
-L 399.031868 129.226939 
-L 384.805673 129.226939 
+    <path d="M 384.828935 56149.317639 
+L 399.053295 56149.317639 
+L 399.053295 109.309528 
+L 384.828935 109.309528 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 481.451014 69535.037487 
-L 495.677208 69535.037487 
-L 495.677208 159.682836 
-L 481.451014 159.682836 
+    <path d="M 481.461813 56149.317639 
+L 495.686173 56149.317639 
+L 495.686173 133.900391 
+L 481.461813 133.900391 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 110.332907 69535.037487 
-L 124.559101 69535.037487 
-L 124.559101 184.98599 
-L 110.332907 184.98599 
+    <path d="M 110.391561 56149.317639 
+L 124.615921 56149.317639 
+L 124.615921 154.330797 
+L 110.391561 154.330797 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 206.978247 69535.037487 
-L 221.204441 69535.037487 
-L 221.204441 45.39244 
-L 206.978247 45.39244 
+    <path d="M 207.024439 56149.317639 
+L 221.248799 56149.317639 
+L 221.248799 41.619432 
+L 207.024439 41.619432 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 303.623588 69535.037487 
-L 317.849782 69535.037487 
-L 317.849782 213.163401 
-L 303.623588 213.163401 
+    <path d="M 303.657317 56149.317639 
+L 317.881677 56149.317639 
+L 317.881677 177.081952 
+L 303.657317 177.081952 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 400.268928 69535.037487 
-L 414.495122 69535.037487 
-L 414.495122 189.502401 
-L 400.268928 189.502401 
+    <path d="M 400.290195 56149.317639 
+L 414.514555 56149.317639 
+L 414.514555 157.977462 
+L 400.290195 157.977462 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 496.914268 69535.037487 
-L 511.140462 69535.037487 
-L 511.140462 122.733958 
-L 496.914268 122.733958 
+    <path d="M 496.923074 56149.317639 
+L 511.147433 56149.317639 
+L 511.147433 104.066931 
+L 496.923074 104.066931 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 125.796161 69535.037487 
-L 140.022355 69535.037487 
-L 140.022355 316.6 
-L 125.796161 316.6 
+    <path d="M 125.852821 56149.317639 
+L 140.077181 56149.317639 
+L 140.077181 316.6 
+L 125.852821 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 222.441502 69535.037487 
-L 236.667696 69535.037487 
-L 236.667696 316.6 
-L 222.441502 316.6 
+    <path d="M 222.4857 56149.317639 
+L 236.710059 56149.317639 
+L 236.710059 316.6 
+L 222.4857 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 319.086842 69535.037487 
-L 333.313036 69535.037487 
-L 333.313036 262.629646 
-L 319.086842 262.629646 
+    <path d="M 319.118578 56149.317639 
+L 333.342937 56149.317639 
+L 333.342937 217.02225 
+L 319.118578 217.02225 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 415.732182 69535.037487 
-L 429.958376 69535.037487 
-L 429.958376 253.964251 
-L 415.732182 253.964251 
+    <path d="M 415.751456 56149.317639 
+L 429.975816 56149.317639 
+L 429.975816 210.025591 
+L 415.751456 210.025591 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 512.377523 69535.037487 
-L 526.603717 69535.037487 
-L 526.603717 161.375497 
-L 512.377523 161.375497 
+    <path d="M 512.384334 56149.317639 
+L 526.608694 56149.317639 
+L 526.608694 135.267087 
+L 512.384334 135.267087 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 141.259416 69535.037487 
-L 155.48561 69535.037487 
-L 155.48561 316.6 
-L 141.259416 316.6 
+    <path d="M 141.314082 56149.317639 
+L 155.538442 56149.317639 
+L 155.538442 316.6 
+L 141.314082 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 237.904756 69535.037487 
-L 252.13095 69535.037487 
-L 252.13095 316.6 
-L 237.904756 316.6 
+    <path d="M 237.94696 56149.317639 
+L 252.17132 56149.317639 
+L 252.17132 316.6 
+L 237.94696 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 334.550096 69535.037487 
-L 348.776291 69535.037487 
-L 348.776291 316.6 
-L 334.550096 316.6 
+    <path d="M 334.579838 56149.317639 
+L 348.804198 56149.317639 
+L 348.804198 316.6 
+L 334.579838 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 431.195437 69535.037487 
-L 445.421631 69535.037487 
-L 445.421631 316.6 
-L 431.195437 316.6 
+    <path d="M 431.212716 56149.317639 
+L 445.437076 56149.317639 
+L 445.437076 316.6 
+L 431.212716 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 527.840777 69535.037487 
-L 542.066971 69535.037487 
-L 542.066971 316.6 
-L 527.840777 316.6 
+    <path d="M 527.845595 56149.317639 
+L 542.069954 56149.317639 
+L 542.069954 316.6 
+L 527.845595 316.6 
 z
-" clip-path="url(#pb7ee37159f)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3f0154a71b" d="M 0 0 
+       <path id="mabb3ca7388" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3f0154a71b" x="117.446004" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb3ca7388" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q4 -->
-      <g transform="translate(110.328816 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(110.386553 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -307,12 +307,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3f0154a71b" x="214.091344" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb3ca7388" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q5 -->
-      <g transform="translate(206.974157 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(207.019431 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -348,12 +348,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3f0154a71b" x="310.736685" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb3ca7388" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q6 -->
-      <g transform="translate(303.619497 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(303.65231 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -394,12 +394,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3f0154a71b" x="407.382025" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb3ca7388" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q7 -->
-      <g transform="translate(400.264837 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(400.285188 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -420,12 +420,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3f0154a71b" x="504.027365" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb3ca7388" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q10 -->
-      <g transform="translate(493.728928 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(493.736816 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -471,7 +471,7 @@ z
     </g>
     <g id="text_6">
      <!-- BerlinMOD R-query -->
-     <g transform="translate(263.025747 344.876563) scale(0.1 -0.1)">
+     <g transform="translate(263.05856 344.876563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-42" d="M 1259 2228 
 L 1259 519 
@@ -767,23 +767,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_6">
-      <path d="M 56.273369 316.6 
+      <path d="M 56.338994 316.6 
 L 565.2 316.6 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m07bf6d3f8e" d="M 0 0 
+       <path id="m828c866467" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m828c866467" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.773369 320.399219) scale(0.1 -0.1)">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g transform="translate(25.838994 320.399219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -792,6 +792,61 @@ L 678 1741
 L 678 2272 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <path d="M 56.338994 260.59928 
+L 565.2 260.59928 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m828c866467" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(25.838994 264.398499) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -824,20 +879,20 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_2">
-     <g id="line2d_8">
-      <path d="M 56.273369 247.242848 
-L 565.2 247.242848 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <path d="M 56.338994 204.59856 
+L 565.2 204.59856 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_9">
+     <g id="line2d_11">
       <g>
-       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="247.242848" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m828c866467" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_8">
+     <g id="text_9">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.773369 251.042067) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 208.397779) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -845,458 +900,554 @@ L 565.2 247.242848
       </g>
      </g>
     </g>
-    <g id="ytick_3">
-     <g id="line2d_10">
-      <path d="M 56.273369 177.885696 
-L 565.2 177.885696 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_4">
+     <g id="line2d_12">
+      <path d="M 56.338994 148.597841 
+L 565.2 148.597841 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_11">
+     <g id="line2d_13">
       <g>
-       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="177.885696" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m828c866467" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
+     <g id="text_10">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.673369 181.684915) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 152.397059) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_12">
-      <path d="M 56.273369 108.528545 
-L 565.2 108.528545 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <path d="M 56.338994 92.597121 
+L 565.2 92.597121 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_13">
+     <g id="line2d_15">
       <g>
-       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="108.528545" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m828c866467" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_10">
+     <g id="text_11">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.673369 112.327763) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 96.39634) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_5">
-     <g id="line2d_14">
-      <path d="M 56.273369 39.171393 
-L 565.2 39.171393 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_6">
+     <g id="line2d_16">
+      <path d="M 56.338994 36.596401 
+L 565.2 36.596401 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_15">
+     <g id="line2d_17">
       <g>
-       <use xlink:href="#m07bf6d3f8e" x="56.273369" y="39.171393" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m828c866467" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_11">
+     <g id="text_12">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.673369 42.970612) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 40.39562) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_16">
-      <path d="M 56.273369 295.721417 
-L 565.2 295.721417 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+    <g id="ytick_7">
+     <g id="line2d_18">
+      <path d="M 56.338994 299.742104 
+L 565.2 299.742104 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_17">
+     <g id="line2d_19">
       <defs>
-       <path id="m9236581984" d="M 0 0 
+       <path id="m14cc0a56b9" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="295.721417" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_18">
-      <path d="M 56.273369 283.508229 
-L 565.2 283.508229 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="283.508229" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 56.273369 274.842834 
-L 565.2 274.842834 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 289.880866 
+L 565.2 289.880866 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="274.842834" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_22">
-      <path d="M 56.273369 268.121431 
-L 565.2 268.121431 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 282.884207 
+L 565.2 282.884207 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="268.121431" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_24">
-      <path d="M 56.273369 262.629646 
-L 565.2 262.629646 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 277.457177 
+L 565.2 277.457177 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="262.629646" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_26">
-      <path d="M 56.273369 257.986407 
-L 565.2 257.986407 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 273.02297 
+L 565.2 273.02297 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="257.986407" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_28">
-      <path d="M 56.273369 253.964251 
-L 565.2 253.964251 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 269.273901 
+L 565.2 269.273901 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="253.964251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_30">
-      <path d="M 56.273369 250.416457 
-L 565.2 250.416457 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 266.026311 
+L 565.2 266.026311 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="250.416457" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_32">
-      <path d="M 56.273369 226.364265 
-L 565.2 226.364265 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 263.161733 
+L 565.2 263.161733 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="226.364265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_34">
-      <path d="M 56.273369 214.151077 
-L 565.2 214.151077 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 243.741384 
+L 565.2 243.741384 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="214.151077" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_36">
-      <path d="M 56.273369 205.485682 
-L 565.2 205.485682 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 233.880147 
+L 565.2 233.880147 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="205.485682" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_38">
-      <path d="M 56.273369 198.76428 
-L 565.2 198.76428 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 226.883487 
+L 565.2 226.883487 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="198.76428" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_40">
-      <path d="M 56.273369 193.272494 
-L 565.2 193.272494 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 221.456457 
+L 565.2 221.456457 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="193.272494" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_42">
-      <path d="M 56.273369 188.629255 
-L 565.2 188.629255 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 217.02225 
+L 565.2 217.02225 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="188.629255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_44">
-      <path d="M 56.273369 184.607099 
-L 565.2 184.607099 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 213.273182 
+L 565.2 213.273182 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="184.607099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_46">
-      <path d="M 56.273369 181.059306 
-L 565.2 181.059306 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 210.025591 
+L 565.2 210.025591 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="181.059306" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_48">
-      <path d="M 56.273369 157.007113 
-L 565.2 157.007113 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 207.161013 
+L 565.2 207.161013 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="157.007113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_50">
-      <path d="M 56.273369 144.793925 
-L 565.2 144.793925 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 187.740664 
+L 565.2 187.740664 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="144.793925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_52">
-      <path d="M 56.273369 136.12853 
-L 565.2 136.12853 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 177.879427 
+L 565.2 177.879427 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="136.12853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_54">
-      <path d="M 56.273369 129.407128 
-L 565.2 129.407128 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 170.882768 
+L 565.2 170.882768 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="129.407128" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_56">
-      <path d="M 56.273369 123.915342 
-L 565.2 123.915342 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 165.455737 
+L 565.2 165.455737 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="123.915342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_58">
-      <path d="M 56.273369 119.272103 
-L 565.2 119.272103 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 161.02153 
+L 565.2 161.02153 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="119.272103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_60">
-      <path d="M 56.273369 115.249947 
-L 565.2 115.249947 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 157.272462 
+L 565.2 157.272462 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="115.249947" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_62">
-      <path d="M 56.273369 111.702154 
-L 565.2 111.702154 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 154.024871 
+L 565.2 154.024871 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="111.702154" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_64">
-      <path d="M 56.273369 87.649962 
-L 565.2 87.649962 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 151.160293 
+L 565.2 151.160293 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="87.649962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_66">
-      <path d="M 56.273369 75.436773 
-L 565.2 75.436773 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 131.739944 
+L 565.2 131.739944 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="75.436773" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_68">
-      <path d="M 56.273369 66.771378 
-L 565.2 66.771378 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 121.878707 
+L 565.2 121.878707 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="66.771378" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_70">
-      <path d="M 56.273369 60.049976 
-L 565.2 60.049976 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 114.882048 
+L 565.2 114.882048 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="60.049976" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_72">
-      <path d="M 56.273369 54.55819 
-L 565.2 54.55819 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 109.455017 
+L 565.2 109.455017 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="54.55819" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_74">
-      <path d="M 56.273369 49.914952 
-L 565.2 49.914952 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 105.02081 
+L 565.2 105.02081 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="49.914952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_76">
-      <path d="M 56.273369 45.892795 
-L 565.2 45.892795 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 101.271742 
+L 565.2 101.271742 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="45.892795" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_78">
-      <path d="M 56.273369 42.345002 
-L 565.2 42.345002 
-" clip-path="url(#pb7ee37159f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 98.024151 
+L 565.2 98.024151 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m9236581984" x="56.273369" y="42.345002" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_12">
+    <g id="ytick_38">
+     <g id="line2d_80">
+      <path d="M 56.338994 95.159573 
+L 565.2 95.159573 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_82">
+      <path d="M 56.338994 75.739224 
+L 565.2 75.739224 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_84">
+      <path d="M 56.338994 65.877987 
+L 565.2 65.877987 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_86">
+      <path d="M 56.338994 58.881328 
+L 565.2 58.881328 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_88">
+      <path d="M 56.338994 53.454297 
+L 565.2 53.454297 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_90">
+      <path d="M 56.338994 49.020091 
+L 565.2 49.020091 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_92">
+      <path d="M 56.338994 45.271022 
+L 565.2 45.271022 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_94">
+      <path d="M 56.338994 42.023431 
+L 565.2 42.023431 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_96">
+      <path d="M 56.338994 39.158853 
+L 565.2 39.158853 
+" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#m14cc0a56b9" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
      <!-- Wall-clock seconds (log scale) -->
-     <g transform="translate(19.693682 245.925781) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-57" d="M 213 4666 
 L 850 4666 
@@ -1555,8 +1706,8 @@ z
     </g>
    </g>
    <g id="patch_28">
-    <path d="M 56.273369 316.6 
-L 56.273369 25.8 
+    <path d="M 56.338994 316.6 
+L 56.338994 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_29">
@@ -1565,18 +1716,18 @@ L 565.2 25.8
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_30">
-    <path d="M 56.273369 316.6 
+    <path d="M 56.338994 316.6 
 L 565.2 316.6 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_31">
-    <path d="M 56.273369 25.8 
+    <path d="M 56.338994 25.8 
 L 565.2 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_13">
+   <g id="text_14">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(134.840821 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(134.896564 308.416725) rotate(-90) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-2f" d="M 1625 4666 
 L 2156 4666 
@@ -1591,17 +1742,9 @@ z
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
    </g>
-   <g id="text_14">
-    <!-- n/a -->
-    <g style="fill: #666666" transform="translate(231.486161 306.464976) rotate(-90) scale(0.07 -0.07)">
-     <use xlink:href="#DejaVuSans-6e"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
-    </g>
-   </g>
    <g id="text_15">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(150.304075 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(231.529442 308.416725) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1609,7 +1752,7 @@ z
    </g>
    <g id="text_16">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(246.949416 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(150.357824 308.416725) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1617,7 +1760,7 @@ z
    </g>
    <g id="text_17">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(343.594756 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(246.990702 308.416725) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1625,7 +1768,7 @@ z
    </g>
    <g id="text_18">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(440.240096 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(343.623581 308.416725) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1633,15 +1776,23 @@ z
    </g>
    <g id="text_19">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(536.885437 306.464976) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(440.256459 308.416725) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
    </g>
    <g id="text_20">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(536.889337 308.416725) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
     <!-- BerlinMOD trip-side cross-join queries — th3index prefilter vs baseline (sf 0.005) -->
-    <g transform="translate(69.121372 19.8) scale(0.12 -0.12)">
+    <g transform="translate(69.154185 19.8) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-74" d="M 1172 4494 
 L 1172 3500 
@@ -1733,38 +1884,6 @@ Q 1366 3272 1645 3428
 Q 1925 3584 2291 3584 
 Q 2894 3584 3203 3211 
 Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500 
@@ -1933,29 +2052,29 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_32">
-     <path d="M 62.573369 72.630938 
-L 368.590244 72.630938 
-Q 370.390244 72.630938 370.390244 70.830938 
-L 370.390244 32.1 
-Q 370.390244 30.3 368.590244 30.3 
-L 62.573369 30.3 
-Q 60.773369 30.3 60.773369 32.1 
-L 60.773369 70.830938 
-Q 60.773369 72.630938 62.573369 72.630938 
+     <path d="M 62.638994 72.630938 
+L 368.655869 72.630938 
+Q 370.455869 72.630938 370.455869 70.830938 
+L 370.455869 32.1 
+Q 370.455869 30.3 368.655869 30.3 
+L 62.638994 30.3 
+Q 60.838994 30.3 60.838994 32.1 
+L 60.838994 70.830938 
+Q 60.838994 72.630938 62.638994 72.630938 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="patch_33">
-     <path d="M 64.373369 40.738594 
-L 82.373369 40.738594 
-L 82.373369 34.438594 
-L 64.373369 34.438594 
+     <path d="M 64.438994 40.738594 
+L 82.438994 40.738594 
+L 82.438994 34.438594 
+L 64.438994 34.438594 
 z
 " style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_21">
+    <g id="text_22">
      <!-- MobilityDB GiST (baseline) -->
-     <g transform="translate(89.573369 40.738594) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2054,16 +2173,16 @@ z
      </g>
     </g>
     <g id="patch_34">
-     <path d="M 64.373369 53.948906 
-L 82.373369 53.948906 
-L 82.373369 47.648906 
-L 64.373369 47.648906 
+     <path d="M 64.438994 53.948906 
+L 82.438994 53.948906 
+L 82.438994 47.648906 
+L 64.438994 47.648906 
 z
 " style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_22">
+    <g id="text_23">
      <!-- MobilityDB th3index -->
-     <g transform="translate(89.573369 53.948906) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2086,16 +2205,16 @@ z
      </g>
     </g>
     <g id="patch_35">
-     <path d="M 64.373369 67.159219 
-L 82.373369 67.159219 
-L 82.373369 60.859219 
-L 64.373369 60.859219 
+     <path d="M 64.438994 67.159219 
+L 82.438994 67.159219 
+L 82.438994 60.859219 
+L 64.438994 60.859219 
 z
 " style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_23">
+    <g id="text_24">
      <!-- MobilityDuck rtree (baseline) -->
-     <g transform="translate(89.573369 67.159219) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 67.159219) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2128,16 +2247,16 @@ z
      </g>
     </g>
     <g id="patch_36">
-     <path d="M 237.951025 40.738594 
-L 255.951025 40.738594 
-L 255.951025 34.438594 
-L 237.951025 34.438594 
+     <path d="M 238.01665 40.738594 
+L 256.01665 40.738594 
+L 256.01665 34.438594 
+L 238.01665 34.438594 
 z
 " style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_24">
+    <g id="text_25">
      <!-- MobilityDuck th3index -->
-     <g transform="translate(263.151025 40.738594) scale(0.09 -0.09)">
+     <g transform="translate(263.21665 40.738594) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2162,16 +2281,16 @@ z
      </g>
     </g>
     <g id="patch_37">
-     <path d="M 237.951025 53.948906 
-L 255.951025 53.948906 
-L 255.951025 47.648906 
-L 237.951025 47.648906 
+     <path d="M 238.01665 53.948906 
+L 256.01665 53.948906 
+L 256.01665 47.648906 
+L 238.01665 47.648906 
 z
 " style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_25">
+    <g id="text_26">
      <!-- MobilitySpark th3index -->
-     <g transform="translate(263.151025 53.948906) scale(0.09 -0.09)">
+     <g transform="translate(263.21665 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2200,8 +2319,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb7ee37159f">
-   <rect x="56.273369" y="25.8" width="508.926631" height="290.8"/>
+  <clipPath id="p44dbf025bc">
+   <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-13T11:30:08.709281</dc:date>
+    <dc:date>2026-05-15T18:17:27.536178</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -38,215 +38,215 @@ z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 79.46904 56149.317639 
-L 93.6934 56149.317639 
-L 93.6934 82.429755 
-L 79.46904 82.429755 
+    <path d="M 79.46904 59565.759687 
+L 93.6934 59565.759687 
+L 93.6934 68.100718 
+L 79.46904 68.100718 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 176.101918 56149.317639 
-L 190.326278 56149.317639 
-L 190.326278 41.838689 
-L 176.101918 41.838689 
+    <path d="M 176.101918 59565.759687 
+L 190.326278 59565.759687 
+L 190.326278 316.6 
+L 176.101918 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 272.734796 56149.317639 
-L 286.959156 56149.317639 
-L 286.959156 132.355694 
-L 272.734796 132.355694 
+    <path d="M 272.734796 59565.759687 
+L 286.959156 59565.759687 
+L 286.959156 121.081659 
+L 272.734796 121.081659 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 369.367674 56149.317639 
-L 383.592034 56149.317639 
-L 383.592034 94.519515 
-L 369.367674 94.519515 
+    <path d="M 369.367674 59565.759687 
+L 383.592034 59565.759687 
+L 383.592034 80.930259 
+L 369.367674 80.930259 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 466.000553 56149.317639 
-L 480.224912 56149.317639 
-L 480.224912 56.863637 
-L 466.000553 56.863637 
+    <path d="M 466.000553 59565.759687 
+L 480.224912 59565.759687 
+L 480.224912 40.970192 
+L 466.000553 40.970192 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 94.9303 56149.317639 
-L 109.15466 56149.317639 
-L 109.15466 106.612067 
-L 94.9303 106.612067 
+    <path d="M 94.9303 59565.759687 
+L 109.15466 59565.759687 
+L 109.15466 93.762763 
+L 94.9303 93.762763 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 191.563179 56149.317639 
-L 205.787538 56149.317639 
-L 205.787538 40.095444 
-L 191.563179 40.095444 
+    <path d="M 191.563179 59565.759687 
+L 205.787538 59565.759687 
+L 205.787538 62.515494 
+L 191.563179 62.515494 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 288.196057 56149.317639 
-L 302.420416 56149.317639 
-L 302.420416 221.456457 
-L 288.196057 221.456457 
+    <path d="M 288.196057 59565.759687 
+L 302.420416 59565.759687 
+L 302.420416 215.634559 
+L 288.196057 215.634559 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 384.828935 56149.317639 
-L 399.053295 56149.317639 
-L 399.053295 109.309528 
-L 384.828935 109.309528 
+    <path d="M 384.828935 59565.759687 
+L 399.053295 59565.759687 
+L 399.053295 96.625283 
+L 384.828935 96.625283 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 481.461813 56149.317639 
-L 495.686173 56149.317639 
-L 495.686173 133.900391 
-L 481.461813 133.900391 
+    <path d="M 481.461813 59565.759687 
+L 495.686173 59565.759687 
+L 495.686173 122.720877 
+L 481.461813 122.720877 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 110.391561 56149.317639 
-L 124.615921 56149.317639 
-L 124.615921 154.330797 
-L 110.391561 154.330797 
+    <path d="M 110.391561 59565.759687 
+L 124.615921 59565.759687 
+L 124.615921 144.401434 
+L 110.391561 144.401434 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 207.024439 56149.317639 
-L 221.248799 56149.317639 
-L 221.248799 41.619432 
-L 207.024439 41.619432 
+    <path d="M 207.024439 59565.759687 
+L 221.248799 59565.759687 
+L 221.248799 316.6 
+L 207.024439 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 303.657317 56149.317639 
-L 317.881677 56149.317639 
-L 317.881677 177.081952 
-L 303.657317 177.081952 
+    <path d="M 303.657317 59565.759687 
+L 317.881677 59565.759687 
+L 317.881677 168.544747 
+L 303.657317 168.544747 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 400.290195 56149.317639 
-L 414.514555 56149.317639 
-L 414.514555 157.977462 
-L 400.290195 157.977462 
+    <path d="M 400.290195 59565.759687 
+L 414.514555 59565.759687 
+L 414.514555 148.271241 
+L 400.290195 148.271241 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 496.923074 56149.317639 
-L 511.147433 56149.317639 
-L 511.147433 104.066931 
-L 496.923074 104.066931 
+    <path d="M 496.923074 59565.759687 
+L 511.147433 59565.759687 
+L 511.147433 91.061888 
+L 496.923074 91.061888 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 125.852821 56149.317639 
-L 140.077181 56149.317639 
+    <path d="M 125.852821 59565.759687 
+L 140.077181 59565.759687 
 L 140.077181 316.6 
 L 125.852821 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 222.4857 56149.317639 
-L 236.710059 56149.317639 
+    <path d="M 222.4857 59565.759687 
+L 236.710059 59565.759687 
 L 236.710059 316.6 
 L 222.4857 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 319.118578 56149.317639 
-L 333.342937 56149.317639 
-L 333.342937 217.02225 
-L 319.118578 217.02225 
+    <path d="M 319.118578 59565.759687 
+L 333.342937 59565.759687 
+L 333.342937 210.92902 
+L 319.118578 210.92902 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 415.751456 56149.317639 
-L 429.975816 56149.317639 
-L 429.975816 210.025591 
-L 415.751456 210.025591 
+    <path d="M 415.751456 59565.759687 
+L 429.975816 59565.759687 
+L 429.975816 203.50423 
+L 415.751456 203.50423 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 512.384334 56149.317639 
-L 526.608694 56149.317639 
-L 526.608694 135.267087 
-L 512.384334 135.267087 
+    <path d="M 512.384334 59565.759687 
+L 526.608694 59565.759687 
+L 526.608694 124.171203 
+L 512.384334 124.171203 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 141.314082 56149.317639 
-L 155.538442 56149.317639 
+    <path d="M 141.314082 59565.759687 
+L 155.538442 59565.759687 
 L 155.538442 316.6 
 L 141.314082 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 237.94696 56149.317639 
-L 252.17132 56149.317639 
-L 252.17132 316.6 
-L 237.94696 316.6 
+    <path d="M 237.94696 59565.759687 
+L 252.17132 59565.759687 
+L 252.17132 79.943807 
+L 237.94696 79.943807 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 334.579838 56149.317639 
-L 348.804198 56149.317639 
+    <path d="M 334.579838 59565.759687 
+L 348.804198 59565.759687 
 L 348.804198 316.6 
 L 334.579838 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 431.212716 56149.317639 
-L 445.437076 56149.317639 
+    <path d="M 431.212716 59565.759687 
+L 445.437076 59565.759687 
 L 445.437076 316.6 
 L 431.212716 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 527.845595 56149.317639 
-L 542.069954 56149.317639 
+    <path d="M 527.845595 59565.759687 
+L 542.069954 59565.759687 
 L 542.069954 316.6 
 L 527.845595 316.6 
 z
-" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m505cfc7e58" d="M 0 0 
+       <path id="m2ef815bf3e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m505cfc7e58" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ef815bf3e" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -307,7 +307,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m505cfc7e58" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ef815bf3e" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -348,7 +348,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m505cfc7e58" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ef815bf3e" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -394,7 +394,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m505cfc7e58" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ef815bf3e" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -420,7 +420,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m505cfc7e58" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ef815bf3e" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -769,16 +769,16 @@ z
      <g id="line2d_6">
       <path d="M 56.338994 316.6 
 L 565.2 316.6 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m3e28e5ee4e" d="M 0 0 
+       <path id="mc2c25a86ac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2c25a86ac" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -834,18 +834,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 56.338994 260.59928 
-L 565.2 260.59928 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 257.172558 
+L 565.2 257.172558 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2c25a86ac" x="56.338994" y="257.172558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.838994 264.398499) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 260.971777) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -881,18 +881,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 56.338994 204.59856 
-L 565.2 204.59856 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 197.745116 
+L 565.2 197.745116 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2c25a86ac" x="56.338994" y="197.745116" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.838994 208.397779) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 201.544335) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -902,18 +902,18 @@ L 565.2 204.59856
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 56.338994 148.597841 
-L 565.2 148.597841 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 138.317674 
+L 565.2 138.317674 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2c25a86ac" x="56.338994" y="138.317674" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.738994 152.397059) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 142.116893) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -922,18 +922,18 @@ L 565.2 148.597841
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 56.338994 92.597121 
-L 565.2 92.597121 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 78.890232 
+L 565.2 78.890232 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2c25a86ac" x="56.338994" y="78.890232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.738994 96.39634) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 82.689451) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -942,510 +942,466 @@ L 565.2 92.597121
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 56.338994 36.596401 
-L 565.2 36.596401 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 298.710557 
+L 565.2 298.710557 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
+      <defs>
+       <path id="mcf148c34d4" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
       <g>
-       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.738994 40.39562) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="298.710557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 56.338994 299.742104 
-L 565.2 299.742104 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 288.245904 
+L 565.2 288.245904 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
-      <defs>
-       <path id="m4456dc8692" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="288.245904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 56.338994 289.880866 
-L 565.2 289.880866 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 280.821115 
+L 565.2 280.821115 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="280.821115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_22">
-      <path d="M 56.338994 282.884207 
-L 565.2 282.884207 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 275.062001 
+L 565.2 275.062001 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="275.062001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_24">
-      <path d="M 56.338994 277.457177 
-L 565.2 277.457177 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 270.356462 
+L 565.2 270.356462 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="270.356462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_26">
-      <path d="M 56.338994 273.02297 
-L 565.2 273.02297 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 266.377985 
+L 565.2 266.377985 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="266.377985" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_28">
-      <path d="M 56.338994 269.273901 
-L 565.2 269.273901 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 262.931672 
+L 565.2 262.931672 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="262.931672" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_30">
-      <path d="M 56.338994 266.026311 
-L 565.2 266.026311 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 259.891809 
+L 565.2 259.891809 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="259.891809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_32">
-      <path d="M 56.338994 263.161733 
-L 565.2 263.161733 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 239.283115 
+L 565.2 239.283115 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="239.283115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_34">
-      <path d="M 56.338994 243.741384 
-L 565.2 243.741384 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 228.818462 
+L 565.2 228.818462 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="228.818462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_36">
-      <path d="M 56.338994 233.880147 
-L 565.2 233.880147 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 221.393673 
+L 565.2 221.393673 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="221.393673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_38">
-      <path d="M 56.338994 226.883487 
-L 565.2 226.883487 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 215.634559 
+L 565.2 215.634559 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="215.634559" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_40">
-      <path d="M 56.338994 221.456457 
-L 565.2 221.456457 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 210.92902 
+L 565.2 210.92902 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="210.92902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_42">
-      <path d="M 56.338994 217.02225 
-L 565.2 217.02225 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 206.950543 
+L 565.2 206.950543 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="206.950543" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_44">
-      <path d="M 56.338994 213.273182 
-L 565.2 213.273182 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 203.50423 
+L 565.2 203.50423 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="203.50423" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_46">
-      <path d="M 56.338994 210.025591 
-L 565.2 210.025591 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 200.464367 
+L 565.2 200.464367 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="200.464367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_48">
-      <path d="M 56.338994 207.161013 
-L 565.2 207.161013 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 179.855673 
+L 565.2 179.855673 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="179.855673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_50">
-      <path d="M 56.338994 187.740664 
-L 565.2 187.740664 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 169.39102 
+L 565.2 169.39102 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="169.39102" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_52">
-      <path d="M 56.338994 177.879427 
-L 565.2 177.879427 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 161.966231 
+L 565.2 161.966231 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="161.966231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_54">
-      <path d="M 56.338994 170.882768 
-L 565.2 170.882768 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 156.207117 
+L 565.2 156.207117 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="156.207117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_56">
-      <path d="M 56.338994 165.455737 
-L 565.2 165.455737 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 151.501578 
+L 565.2 151.501578 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="151.501578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_58">
-      <path d="M 56.338994 161.02153 
-L 565.2 161.02153 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 147.523101 
+L 565.2 147.523101 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="147.523101" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_60">
-      <path d="M 56.338994 157.272462 
-L 565.2 157.272462 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 144.076788 
+L 565.2 144.076788 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="144.076788" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_62">
-      <path d="M 56.338994 154.024871 
-L 565.2 154.024871 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 141.036925 
+L 565.2 141.036925 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="141.036925" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_64">
-      <path d="M 56.338994 151.160293 
-L 565.2 151.160293 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 120.428231 
+L 565.2 120.428231 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="120.428231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_66">
-      <path d="M 56.338994 131.739944 
-L 565.2 131.739944 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 109.963578 
+L 565.2 109.963578 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="109.963578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_68">
-      <path d="M 56.338994 121.878707 
-L 565.2 121.878707 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 102.538789 
+L 565.2 102.538789 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="102.538789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_70">
-      <path d="M 56.338994 114.882048 
-L 565.2 114.882048 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 96.779675 
+L 565.2 96.779675 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="96.779675" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_72">
-      <path d="M 56.338994 109.455017 
-L 565.2 109.455017 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 92.074136 
+L 565.2 92.074136 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="92.074136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_74">
-      <path d="M 56.338994 105.02081 
-L 565.2 105.02081 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 88.095659 
+L 565.2 88.095659 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="88.095659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_76">
-      <path d="M 56.338994 101.271742 
-L 565.2 101.271742 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 84.649346 
+L 565.2 84.649346 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="84.649346" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_78">
-      <path d="M 56.338994 98.024151 
-L 565.2 98.024151 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 81.609483 
+L 565.2 81.609483 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="81.609483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_80">
-      <path d="M 56.338994 95.159573 
-L 565.2 95.159573 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 61.000789 
+L 565.2 61.000789 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="61.000789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_82">
-      <path d="M 56.338994 75.739224 
-L 565.2 75.739224 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 50.536136 
+L 565.2 50.536136 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="50.536136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_84">
-      <path d="M 56.338994 65.877987 
-L 565.2 65.877987 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 43.111347 
+L 565.2 43.111347 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="43.111347" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_86">
-      <path d="M 56.338994 58.881328 
-L 565.2 58.881328 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 37.352233 
+L 565.2 37.352233 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="37.352233" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_88">
-      <path d="M 56.338994 53.454297 
-L 565.2 53.454297 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 32.646694 
+L 565.2 32.646694 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="32.646694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_90">
-      <path d="M 56.338994 49.020091 
-L 565.2 49.020091 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 56.338994 28.668217 
+L 565.2 28.668217 
+" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcf148c34d4" x="56.338994" y="28.668217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="ytick_44">
-     <g id="line2d_92">
-      <path d="M 56.338994 45.271022 
-L 565.2 45.271022 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_93">
-      <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_45">
-     <g id="line2d_94">
-      <path d="M 56.338994 42.023431 
-L 565.2 42.023431 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_95">
-      <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_46">
-     <g id="line2d_96">
-      <path d="M 56.338994 39.158853 
-L 565.2 39.158853 
-" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_97">
-      <g>
-       <use xlink:href="#m4456dc8692" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_13">
+    <g id="text_12">
      <!-- Wall-clock seconds (log scale) -->
      <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1725,9 +1681,9 @@ L 565.2 316.6
 L 565.2 25.8 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_14">
+   <g id="text_13">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(134.896564 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(185.14566 307.915985) rotate(-90) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-2f" d="M 1625 4666 
 L 2156 4666 
@@ -1742,9 +1698,17 @@ z
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
    </g>
+   <g id="text_14">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(216.068181 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
    <g id="text_15">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(231.529442 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(134.896564 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1752,7 +1716,7 @@ z
    </g>
    <g id="text_16">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(150.357824 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(231.529442 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1760,7 +1724,7 @@ z
    </g>
    <g id="text_17">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(246.990702 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(150.357824 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1768,7 +1732,7 @@ z
    </g>
    <g id="text_18">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(343.623581 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(343.623581 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1776,7 +1740,7 @@ z
    </g>
    <g id="text_19">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(440.256459 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(440.256459 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -1784,7 +1748,7 @@ z
    </g>
    <g id="text_20">
     <!-- n/a -->
-    <g style="fill: #666666" transform="translate(536.889337 308.416725) rotate(-90) scale(0.07 -0.07)">
+    <g style="fill: #666666" transform="translate(536.889337 307.915985) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
@@ -2300,7 +2264,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p04b6a696cb">
+  <clipPath id="p3d57f0727a">
    <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-13T00:35:15.621968</dc:date>
+    <dc:date>2026-05-13T11:30:08.709281</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 93.6934 56149.317639
 L 93.6934 82.429755 
 L 79.46904 82.429755 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 176.101918 56149.317639 
@@ -51,7 +51,7 @@ L 190.326278 56149.317639
 L 190.326278 41.838689 
 L 176.101918 41.838689 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 272.734796 56149.317639 
@@ -59,7 +59,7 @@ L 286.959156 56149.317639
 L 286.959156 132.355694 
 L 272.734796 132.355694 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 369.367674 56149.317639 
@@ -67,7 +67,7 @@ L 383.592034 56149.317639
 L 383.592034 94.519515 
 L 369.367674 94.519515 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 466.000553 56149.317639 
@@ -75,7 +75,7 @@ L 480.224912 56149.317639
 L 480.224912 56.863637 
 L 466.000553 56.863637 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 94.9303 56149.317639 
@@ -83,7 +83,7 @@ L 109.15466 56149.317639
 L 109.15466 106.612067 
 L 94.9303 106.612067 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 191.563179 56149.317639 
@@ -91,7 +91,7 @@ L 205.787538 56149.317639
 L 205.787538 40.095444 
 L 191.563179 40.095444 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 288.196057 56149.317639 
@@ -99,7 +99,7 @@ L 302.420416 56149.317639
 L 302.420416 221.456457 
 L 288.196057 221.456457 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 384.828935 56149.317639 
@@ -107,7 +107,7 @@ L 399.053295 56149.317639
 L 399.053295 109.309528 
 L 384.828935 109.309528 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 481.461813 56149.317639 
@@ -115,7 +115,7 @@ L 495.686173 56149.317639
 L 495.686173 133.900391 
 L 481.461813 133.900391 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 110.391561 56149.317639 
@@ -123,7 +123,7 @@ L 124.615921 56149.317639
 L 124.615921 154.330797 
 L 110.391561 154.330797 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 207.024439 56149.317639 
@@ -131,7 +131,7 @@ L 221.248799 56149.317639
 L 221.248799 41.619432 
 L 207.024439 41.619432 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 303.657317 56149.317639 
@@ -139,7 +139,7 @@ L 317.881677 56149.317639
 L 317.881677 177.081952 
 L 303.657317 177.081952 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 400.290195 56149.317639 
@@ -147,7 +147,7 @@ L 414.514555 56149.317639
 L 414.514555 157.977462 
 L 400.290195 157.977462 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 496.923074 56149.317639 
@@ -155,7 +155,7 @@ L 511.147433 56149.317639
 L 511.147433 104.066931 
 L 496.923074 104.066931 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 125.852821 56149.317639 
@@ -163,7 +163,7 @@ L 140.077181 56149.317639
 L 140.077181 316.6 
 L 125.852821 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 222.4857 56149.317639 
@@ -171,7 +171,7 @@ L 236.710059 56149.317639
 L 236.710059 316.6 
 L 222.4857 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 319.118578 56149.317639 
@@ -179,7 +179,7 @@ L 333.342937 56149.317639
 L 333.342937 217.02225 
 L 319.118578 217.02225 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 415.751456 56149.317639 
@@ -187,7 +187,7 @@ L 429.975816 56149.317639
 L 429.975816 210.025591 
 L 415.751456 210.025591 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 512.384334 56149.317639 
@@ -195,7 +195,7 @@ L 526.608694 56149.317639
 L 526.608694 135.267087 
 L 512.384334 135.267087 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 141.314082 56149.317639 
@@ -203,7 +203,7 @@ L 155.538442 56149.317639
 L 155.538442 316.6 
 L 141.314082 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 237.94696 56149.317639 
@@ -211,7 +211,7 @@ L 252.17132 56149.317639
 L 252.17132 316.6 
 L 237.94696 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 334.579838 56149.317639 
@@ -219,7 +219,7 @@ L 348.804198 56149.317639
 L 348.804198 316.6 
 L 334.579838 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 431.212716 56149.317639 
@@ -227,7 +227,7 @@ L 445.437076 56149.317639
 L 445.437076 316.6 
 L 431.212716 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 527.845595 56149.317639 
@@ -235,18 +235,18 @@ L 542.069954 56149.317639
 L 542.069954 316.6 
 L 527.845595 316.6 
 z
-" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p04b6a696cb)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m58c044f7ea" d="M 0 0 
+       <path id="m505cfc7e58" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m58c044f7ea" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m505cfc7e58" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -307,7 +307,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m58c044f7ea" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m505cfc7e58" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -348,7 +348,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m58c044f7ea" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m505cfc7e58" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -394,7 +394,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m58c044f7ea" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m505cfc7e58" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -420,7 +420,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m58c044f7ea" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m505cfc7e58" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -769,16 +769,16 @@ z
      <g id="line2d_6">
       <path d="M 56.338994 316.6 
 L 565.2 316.6 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m3b32f7ed60" d="M 0 0 
+       <path id="m3e28e5ee4e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -836,11 +836,11 @@ z
      <g id="line2d_8">
       <path d="M 56.338994 260.59928 
 L 565.2 260.59928 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -883,11 +883,11 @@ z
      <g id="line2d_10">
       <path d="M 56.338994 204.59856 
 L 565.2 204.59856 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -904,11 +904,11 @@ L 565.2 204.59856
      <g id="line2d_12">
       <path d="M 56.338994 148.597841 
 L 565.2 148.597841 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -924,11 +924,11 @@ L 565.2 148.597841
      <g id="line2d_14">
       <path d="M 56.338994 92.597121 
 L 565.2 92.597121 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -944,11 +944,11 @@ L 565.2 92.597121
      <g id="line2d_16">
       <path d="M 56.338994 36.596401 
 L 565.2 36.596401 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3b32f7ed60" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e28e5ee4e" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -964,16 +964,16 @@ L 565.2 36.596401
      <g id="line2d_18">
       <path d="M 56.338994 299.742104 
 L 565.2 299.742104 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="m9bf9de0ab0" d="M 0 0 
+       <path id="m4456dc8692" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -981,11 +981,11 @@ L -2 0
      <g id="line2d_20">
       <path d="M 56.338994 289.880866 
 L 565.2 289.880866 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -993,11 +993,11 @@ L 565.2 289.880866
      <g id="line2d_22">
       <path d="M 56.338994 282.884207 
 L 565.2 282.884207 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1005,11 +1005,11 @@ L 565.2 282.884207
      <g id="line2d_24">
       <path d="M 56.338994 277.457177 
 L 565.2 277.457177 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1017,11 +1017,11 @@ L 565.2 277.457177
      <g id="line2d_26">
       <path d="M 56.338994 273.02297 
 L 565.2 273.02297 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1029,11 +1029,11 @@ L 565.2 273.02297
      <g id="line2d_28">
       <path d="M 56.338994 269.273901 
 L 565.2 269.273901 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1041,11 +1041,11 @@ L 565.2 269.273901
      <g id="line2d_30">
       <path d="M 56.338994 266.026311 
 L 565.2 266.026311 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1053,11 +1053,11 @@ L 565.2 266.026311
      <g id="line2d_32">
       <path d="M 56.338994 263.161733 
 L 565.2 263.161733 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1065,11 +1065,11 @@ L 565.2 263.161733
      <g id="line2d_34">
       <path d="M 56.338994 243.741384 
 L 565.2 243.741384 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1077,11 +1077,11 @@ L 565.2 243.741384
      <g id="line2d_36">
       <path d="M 56.338994 233.880147 
 L 565.2 233.880147 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1089,11 +1089,11 @@ L 565.2 233.880147
      <g id="line2d_38">
       <path d="M 56.338994 226.883487 
 L 565.2 226.883487 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1101,11 +1101,11 @@ L 565.2 226.883487
      <g id="line2d_40">
       <path d="M 56.338994 221.456457 
 L 565.2 221.456457 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1113,11 +1113,11 @@ L 565.2 221.456457
      <g id="line2d_42">
       <path d="M 56.338994 217.02225 
 L 565.2 217.02225 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1125,11 +1125,11 @@ L 565.2 217.02225
      <g id="line2d_44">
       <path d="M 56.338994 213.273182 
 L 565.2 213.273182 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1137,11 +1137,11 @@ L 565.2 213.273182
      <g id="line2d_46">
       <path d="M 56.338994 210.025591 
 L 565.2 210.025591 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1149,11 +1149,11 @@ L 565.2 210.025591
      <g id="line2d_48">
       <path d="M 56.338994 207.161013 
 L 565.2 207.161013 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1161,11 +1161,11 @@ L 565.2 207.161013
      <g id="line2d_50">
       <path d="M 56.338994 187.740664 
 L 565.2 187.740664 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1173,11 +1173,11 @@ L 565.2 187.740664
      <g id="line2d_52">
       <path d="M 56.338994 177.879427 
 L 565.2 177.879427 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1185,11 +1185,11 @@ L 565.2 177.879427
      <g id="line2d_54">
       <path d="M 56.338994 170.882768 
 L 565.2 170.882768 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1197,11 +1197,11 @@ L 565.2 170.882768
      <g id="line2d_56">
       <path d="M 56.338994 165.455737 
 L 565.2 165.455737 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1209,11 +1209,11 @@ L 565.2 165.455737
      <g id="line2d_58">
       <path d="M 56.338994 161.02153 
 L 565.2 161.02153 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1221,11 +1221,11 @@ L 565.2 161.02153
      <g id="line2d_60">
       <path d="M 56.338994 157.272462 
 L 565.2 157.272462 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1233,11 +1233,11 @@ L 565.2 157.272462
      <g id="line2d_62">
       <path d="M 56.338994 154.024871 
 L 565.2 154.024871 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1245,11 +1245,11 @@ L 565.2 154.024871
      <g id="line2d_64">
       <path d="M 56.338994 151.160293 
 L 565.2 151.160293 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1257,11 +1257,11 @@ L 565.2 151.160293
      <g id="line2d_66">
       <path d="M 56.338994 131.739944 
 L 565.2 131.739944 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1269,11 +1269,11 @@ L 565.2 131.739944
      <g id="line2d_68">
       <path d="M 56.338994 121.878707 
 L 565.2 121.878707 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1281,11 +1281,11 @@ L 565.2 121.878707
      <g id="line2d_70">
       <path d="M 56.338994 114.882048 
 L 565.2 114.882048 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1293,11 +1293,11 @@ L 565.2 114.882048
      <g id="line2d_72">
       <path d="M 56.338994 109.455017 
 L 565.2 109.455017 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1305,11 +1305,11 @@ L 565.2 109.455017
      <g id="line2d_74">
       <path d="M 56.338994 105.02081 
 L 565.2 105.02081 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1317,11 +1317,11 @@ L 565.2 105.02081
      <g id="line2d_76">
       <path d="M 56.338994 101.271742 
 L 565.2 101.271742 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1329,11 +1329,11 @@ L 565.2 101.271742
      <g id="line2d_78">
       <path d="M 56.338994 98.024151 
 L 565.2 98.024151 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1341,11 +1341,11 @@ L 565.2 98.024151
      <g id="line2d_80">
       <path d="M 56.338994 95.159573 
 L 565.2 95.159573 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1353,11 +1353,11 @@ L 565.2 95.159573
      <g id="line2d_82">
       <path d="M 56.338994 75.739224 
 L 565.2 75.739224 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1365,11 +1365,11 @@ L 565.2 75.739224
      <g id="line2d_84">
       <path d="M 56.338994 65.877987 
 L 565.2 65.877987 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1377,11 +1377,11 @@ L 565.2 65.877987
      <g id="line2d_86">
       <path d="M 56.338994 58.881328 
 L 565.2 58.881328 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1389,11 +1389,11 @@ L 565.2 58.881328
      <g id="line2d_88">
       <path d="M 56.338994 53.454297 
 L 565.2 53.454297 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1401,11 +1401,11 @@ L 565.2 53.454297
      <g id="line2d_90">
       <path d="M 56.338994 49.020091 
 L 565.2 49.020091 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1413,11 +1413,11 @@ L 565.2 49.020091
      <g id="line2d_92">
       <path d="M 56.338994 45.271022 
 L 565.2 45.271022 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1425,11 +1425,11 @@ L 565.2 45.271022
      <g id="line2d_94">
       <path d="M 56.338994 42.023431 
 L 565.2 42.023431 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1437,11 +1437,11 @@ L 565.2 42.023431
      <g id="line2d_96">
       <path d="M 56.338994 39.158853 
 L 565.2 39.158853 
-" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p04b6a696cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4456dc8692" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2053,10 +2053,10 @@ z
    <g id="legend_1">
     <g id="patch_32">
      <path d="M 62.638994 72.630938 
-L 368.655869 72.630938 
-Q 370.455869 72.630938 370.455869 70.830938 
-L 370.455869 32.1 
-Q 370.455869 30.3 368.655869 30.3 
+L 388.410869 72.630938 
+Q 390.210869 72.630938 390.210869 70.830938 
+L 390.210869 32.1 
+Q 390.210869 30.3 388.410869 30.3 
 L 62.638994 30.3 
 Q 60.838994 30.3 60.838994 32.1 
 L 60.838994 70.830938 
@@ -2073,77 +2073,8 @@ z
 " style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_22">
-     <!-- MobilityDB GiST (baseline) -->
+     <!-- MobilityDB R-tree (baseline) -->
      <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
-      <defs>
-       <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2155,21 +2086,23 @@ z
       <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
       <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
-      <use xlink:href="#DejaVuSans-47" transform="translate(570.068359 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(647.558594 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(675.341797 0)"/>
-      <use xlink:href="#DejaVuSans-54" transform="translate(738.818359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(799.902344 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(831.689453 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(870.703125 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(934.179688 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(995.458984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1047.558594 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1109.082031 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1136.865234 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(1164.648438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1228.027344 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1289.550781 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(635.550781 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(671.634766 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(710.84375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(749.707031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(811.230469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(872.753906 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(904.541016 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(943.554688 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1007.03125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1068.310547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1120.410156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1181.933594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1209.716797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1237.5 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1300.878906 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1362.402344 0)"/>
      </g>
     </g>
     <g id="patch_34">
@@ -2213,8 +2146,19 @@ z
 " style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
-     <!-- MobilityDuck rtree (baseline) -->
+     <!-- MobilityDuck (baseline, no index) -->
      <g transform="translate(89.638994 67.159219) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2228,35 +2172,39 @@ z
       <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
       <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(677.734375 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(718.847656 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(758.056641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(796.919922 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(858.443359 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(919.966797 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(951.753906 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(990.767578 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1054.244141 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1115.523438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1167.623047 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1229.146484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1256.929688 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(1284.712891 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1348.091797 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1409.615234 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(716.748047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(780.224609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(841.503906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(893.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(955.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(982.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1010.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1074.072266 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1135.595703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1167.382812 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1199.169922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1262.548828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1323.730469 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1355.517578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1383.300781 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1446.679688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1510.15625 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1569.929688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1629.109375 0)"/>
      </g>
     </g>
     <g id="patch_36">
-     <path d="M 238.01665 40.738594 
-L 256.01665 40.738594 
-L 256.01665 34.438594 
-L 238.01665 34.438594 
+     <path d="M 257.77165 40.738594 
+L 275.77165 40.738594 
+L 275.77165 34.438594 
+L 257.77165 34.438594 
 z
 " style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- MobilityDuck th3index -->
-     <g transform="translate(263.21665 40.738594) scale(0.09 -0.09)">
+     <g transform="translate(282.97165 40.738594) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2281,16 +2229,49 @@ z
      </g>
     </g>
     <g id="patch_37">
-     <path d="M 238.01665 53.948906 
-L 256.01665 53.948906 
-L 256.01665 47.648906 
-L 238.01665 47.648906 
+     <path d="M 257.77165 53.948906 
+L 275.77165 53.948906 
+L 275.77165 47.648906 
+L 257.77165 47.648906 
 z
 " style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- MobilitySpark th3index -->
-     <g transform="translate(263.21665 53.948906) scale(0.09 -0.09)">
+     <g transform="translate(282.97165 53.948906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2319,7 +2300,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p35f17f0784">
+  <clipPath id="p04b6a696cb">
    <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-15T18:17:27.536178</dc:date>
+    <dc:date>2026-05-15T19:31:44.806770</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 93.6934 59565.759687
 L 93.6934 68.100718 
 L 79.46904 68.100718 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 176.101918 59565.759687 
@@ -51,7 +51,7 @@ L 190.326278 59565.759687
 L 190.326278 316.6 
 L 176.101918 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 272.734796 59565.759687 
@@ -59,7 +59,7 @@ L 286.959156 59565.759687
 L 286.959156 121.081659 
 L 272.734796 121.081659 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 369.367674 59565.759687 
@@ -67,7 +67,7 @@ L 383.592034 59565.759687
 L 383.592034 80.930259 
 L 369.367674 80.930259 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 466.000553 59565.759687 
@@ -75,7 +75,7 @@ L 480.224912 59565.759687
 L 480.224912 40.970192 
 L 466.000553 40.970192 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 94.9303 59565.759687 
@@ -83,15 +83,15 @@ L 109.15466 59565.759687
 L 109.15466 93.762763 
 L 94.9303 93.762763 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 191.563179 59565.759687 
 L 205.787538 59565.759687 
-L 205.787538 62.515494 
-L 191.563179 62.515494 
+L 205.787538 80.214061 
+L 191.563179 80.214061 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 288.196057 59565.759687 
@@ -99,7 +99,7 @@ L 302.420416 59565.759687
 L 302.420416 215.634559 
 L 288.196057 215.634559 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 384.828935 59565.759687 
@@ -107,7 +107,7 @@ L 399.053295 59565.759687
 L 399.053295 96.625283 
 L 384.828935 96.625283 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 481.461813 59565.759687 
@@ -115,7 +115,7 @@ L 495.686173 59565.759687
 L 495.686173 122.720877 
 L 481.461813 122.720877 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 110.391561 59565.759687 
@@ -123,7 +123,7 @@ L 124.615921 59565.759687
 L 124.615921 144.401434 
 L 110.391561 144.401434 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 207.024439 59565.759687 
@@ -131,7 +131,7 @@ L 221.248799 59565.759687
 L 221.248799 316.6 
 L 207.024439 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 303.657317 59565.759687 
@@ -139,7 +139,7 @@ L 317.881677 59565.759687
 L 317.881677 168.544747 
 L 303.657317 168.544747 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 400.290195 59565.759687 
@@ -147,7 +147,7 @@ L 414.514555 59565.759687
 L 414.514555 148.271241 
 L 400.290195 148.271241 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 496.923074 59565.759687 
@@ -155,7 +155,7 @@ L 511.147433 59565.759687
 L 511.147433 91.061888 
 L 496.923074 91.061888 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 125.852821 59565.759687 
@@ -163,7 +163,7 @@ L 140.077181 59565.759687
 L 140.077181 316.6 
 L 125.852821 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 222.4857 59565.759687 
@@ -171,7 +171,7 @@ L 236.710059 59565.759687
 L 236.710059 316.6 
 L 222.4857 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 319.118578 59565.759687 
@@ -179,7 +179,7 @@ L 333.342937 59565.759687
 L 333.342937 210.92902 
 L 319.118578 210.92902 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 415.751456 59565.759687 
@@ -187,7 +187,7 @@ L 429.975816 59565.759687
 L 429.975816 203.50423 
 L 415.751456 203.50423 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 512.384334 59565.759687 
@@ -195,7 +195,7 @@ L 526.608694 59565.759687
 L 526.608694 124.171203 
 L 512.384334 124.171203 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 141.314082 59565.759687 
@@ -203,7 +203,7 @@ L 155.538442 59565.759687
 L 155.538442 316.6 
 L 141.314082 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 237.94696 59565.759687 
@@ -211,7 +211,7 @@ L 252.17132 59565.759687
 L 252.17132 79.943807 
 L 237.94696 79.943807 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 334.579838 59565.759687 
@@ -219,7 +219,7 @@ L 348.804198 59565.759687
 L 348.804198 316.6 
 L 334.579838 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 431.212716 59565.759687 
@@ -227,7 +227,7 @@ L 445.437076 59565.759687
 L 445.437076 316.6 
 L 431.212716 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 527.845595 59565.759687 
@@ -235,18 +235,18 @@ L 542.069954 59565.759687
 L 542.069954 316.6 
 L 527.845595 316.6 
 z
-" clip-path="url(#p3d57f0727a)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc199835021)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2ef815bf3e" d="M 0 0 
+       <path id="m0e6ad0cbe6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2ef815bf3e" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e6ad0cbe6" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -307,7 +307,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2ef815bf3e" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e6ad0cbe6" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -348,7 +348,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2ef815bf3e" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e6ad0cbe6" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -394,7 +394,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2ef815bf3e" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e6ad0cbe6" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -420,7 +420,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2ef815bf3e" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e6ad0cbe6" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -769,16 +769,16 @@ z
      <g id="line2d_6">
       <path d="M 56.338994 316.6 
 L 565.2 316.6 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="mc2c25a86ac" d="M 0 0 
+       <path id="mdf618032aa" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc2c25a86ac" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf618032aa" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -836,11 +836,11 @@ z
      <g id="line2d_8">
       <path d="M 56.338994 257.172558 
 L 565.2 257.172558 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc2c25a86ac" x="56.338994" y="257.172558" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf618032aa" x="56.338994" y="257.172558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -883,11 +883,11 @@ z
      <g id="line2d_10">
       <path d="M 56.338994 197.745116 
 L 565.2 197.745116 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc2c25a86ac" x="56.338994" y="197.745116" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf618032aa" x="56.338994" y="197.745116" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -904,11 +904,11 @@ L 565.2 197.745116
      <g id="line2d_12">
       <path d="M 56.338994 138.317674 
 L 565.2 138.317674 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc2c25a86ac" x="56.338994" y="138.317674" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf618032aa" x="56.338994" y="138.317674" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -924,11 +924,11 @@ L 565.2 138.317674
      <g id="line2d_14">
       <path d="M 56.338994 78.890232 
 L 565.2 78.890232 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc2c25a86ac" x="56.338994" y="78.890232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf618032aa" x="56.338994" y="78.890232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -944,16 +944,16 @@ L 565.2 78.890232
      <g id="line2d_16">
       <path d="M 56.338994 298.710557 
 L 565.2 298.710557 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="mcf148c34d4" d="M 0 0 
+       <path id="m39350ff04b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="298.710557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="298.710557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -961,11 +961,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 56.338994 288.245904 
 L 565.2 288.245904 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="288.245904" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="288.245904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -973,11 +973,11 @@ L 565.2 288.245904
      <g id="line2d_20">
       <path d="M 56.338994 280.821115 
 L 565.2 280.821115 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="280.821115" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="280.821115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,11 +985,11 @@ L 565.2 280.821115
      <g id="line2d_22">
       <path d="M 56.338994 275.062001 
 L 565.2 275.062001 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="275.062001" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="275.062001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -997,11 +997,11 @@ L 565.2 275.062001
      <g id="line2d_24">
       <path d="M 56.338994 270.356462 
 L 565.2 270.356462 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="270.356462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="270.356462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1009,11 +1009,11 @@ L 565.2 270.356462
      <g id="line2d_26">
       <path d="M 56.338994 266.377985 
 L 565.2 266.377985 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="266.377985" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="266.377985" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1021,11 +1021,11 @@ L 565.2 266.377985
      <g id="line2d_28">
       <path d="M 56.338994 262.931672 
 L 565.2 262.931672 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="262.931672" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="262.931672" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1033,11 +1033,11 @@ L 565.2 262.931672
      <g id="line2d_30">
       <path d="M 56.338994 259.891809 
 L 565.2 259.891809 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="259.891809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="259.891809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1045,11 +1045,11 @@ L 565.2 259.891809
      <g id="line2d_32">
       <path d="M 56.338994 239.283115 
 L 565.2 239.283115 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="239.283115" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="239.283115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1057,11 +1057,11 @@ L 565.2 239.283115
      <g id="line2d_34">
       <path d="M 56.338994 228.818462 
 L 565.2 228.818462 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="228.818462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="228.818462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1069,11 +1069,11 @@ L 565.2 228.818462
      <g id="line2d_36">
       <path d="M 56.338994 221.393673 
 L 565.2 221.393673 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="221.393673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="221.393673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1081,11 +1081,11 @@ L 565.2 221.393673
      <g id="line2d_38">
       <path d="M 56.338994 215.634559 
 L 565.2 215.634559 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="215.634559" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="215.634559" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1093,11 +1093,11 @@ L 565.2 215.634559
      <g id="line2d_40">
       <path d="M 56.338994 210.92902 
 L 565.2 210.92902 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="210.92902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="210.92902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1105,11 +1105,11 @@ L 565.2 210.92902
      <g id="line2d_42">
       <path d="M 56.338994 206.950543 
 L 565.2 206.950543 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="206.950543" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="206.950543" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1117,11 +1117,11 @@ L 565.2 206.950543
      <g id="line2d_44">
       <path d="M 56.338994 203.50423 
 L 565.2 203.50423 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="203.50423" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="203.50423" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1129,11 +1129,11 @@ L 565.2 203.50423
      <g id="line2d_46">
       <path d="M 56.338994 200.464367 
 L 565.2 200.464367 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="200.464367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="200.464367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1141,11 +1141,11 @@ L 565.2 200.464367
      <g id="line2d_48">
       <path d="M 56.338994 179.855673 
 L 565.2 179.855673 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="179.855673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="179.855673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1153,11 +1153,11 @@ L 565.2 179.855673
      <g id="line2d_50">
       <path d="M 56.338994 169.39102 
 L 565.2 169.39102 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="169.39102" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="169.39102" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1165,11 +1165,11 @@ L 565.2 169.39102
      <g id="line2d_52">
       <path d="M 56.338994 161.966231 
 L 565.2 161.966231 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="161.966231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="161.966231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1177,11 +1177,11 @@ L 565.2 161.966231
      <g id="line2d_54">
       <path d="M 56.338994 156.207117 
 L 565.2 156.207117 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="156.207117" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="156.207117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1189,11 +1189,11 @@ L 565.2 156.207117
      <g id="line2d_56">
       <path d="M 56.338994 151.501578 
 L 565.2 151.501578 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="151.501578" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="151.501578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1201,11 +1201,11 @@ L 565.2 151.501578
      <g id="line2d_58">
       <path d="M 56.338994 147.523101 
 L 565.2 147.523101 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="147.523101" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="147.523101" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1213,11 +1213,11 @@ L 565.2 147.523101
      <g id="line2d_60">
       <path d="M 56.338994 144.076788 
 L 565.2 144.076788 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="144.076788" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="144.076788" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1225,11 +1225,11 @@ L 565.2 144.076788
      <g id="line2d_62">
       <path d="M 56.338994 141.036925 
 L 565.2 141.036925 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="141.036925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="141.036925" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1237,11 +1237,11 @@ L 565.2 141.036925
      <g id="line2d_64">
       <path d="M 56.338994 120.428231 
 L 565.2 120.428231 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="120.428231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="120.428231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1249,11 +1249,11 @@ L 565.2 120.428231
      <g id="line2d_66">
       <path d="M 56.338994 109.963578 
 L 565.2 109.963578 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="109.963578" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="109.963578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1261,11 +1261,11 @@ L 565.2 109.963578
      <g id="line2d_68">
       <path d="M 56.338994 102.538789 
 L 565.2 102.538789 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="102.538789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="102.538789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1273,11 +1273,11 @@ L 565.2 102.538789
      <g id="line2d_70">
       <path d="M 56.338994 96.779675 
 L 565.2 96.779675 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="96.779675" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="96.779675" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1285,11 +1285,11 @@ L 565.2 96.779675
      <g id="line2d_72">
       <path d="M 56.338994 92.074136 
 L 565.2 92.074136 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="92.074136" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="92.074136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1297,11 +1297,11 @@ L 565.2 92.074136
      <g id="line2d_74">
       <path d="M 56.338994 88.095659 
 L 565.2 88.095659 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="88.095659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="88.095659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1309,11 +1309,11 @@ L 565.2 88.095659
      <g id="line2d_76">
       <path d="M 56.338994 84.649346 
 L 565.2 84.649346 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="84.649346" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="84.649346" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1321,11 +1321,11 @@ L 565.2 84.649346
      <g id="line2d_78">
       <path d="M 56.338994 81.609483 
 L 565.2 81.609483 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="81.609483" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="81.609483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1333,11 +1333,11 @@ L 565.2 81.609483
      <g id="line2d_80">
       <path d="M 56.338994 61.000789 
 L 565.2 61.000789 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="61.000789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="61.000789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1345,11 +1345,11 @@ L 565.2 61.000789
      <g id="line2d_82">
       <path d="M 56.338994 50.536136 
 L 565.2 50.536136 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="50.536136" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="50.536136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1357,11 +1357,11 @@ L 565.2 50.536136
      <g id="line2d_84">
       <path d="M 56.338994 43.111347 
 L 565.2 43.111347 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="43.111347" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="43.111347" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1369,11 +1369,11 @@ L 565.2 43.111347
      <g id="line2d_86">
       <path d="M 56.338994 37.352233 
 L 565.2 37.352233 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="37.352233" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="37.352233" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1381,11 +1381,11 @@ L 565.2 37.352233
      <g id="line2d_88">
       <path d="M 56.338994 32.646694 
 L 565.2 32.646694 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="32.646694" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="32.646694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1393,11 +1393,11 @@ L 565.2 32.646694
      <g id="line2d_90">
       <path d="M 56.338994 28.668217 
 L 565.2 28.668217 
-" clip-path="url(#p3d57f0727a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc199835021)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#mcf148c34d4" x="56.338994" y="28.668217" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m39350ff04b" x="56.338994" y="28.668217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2264,7 +2264,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3d57f0727a">
+  <clipPath id="pc199835021">
    <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/cross_platform_th3index.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-12T23:46:01.839128</dc:date>
+    <dc:date>2026-05-13T00:35:15.621968</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 93.6934 56149.317639
 L 93.6934 82.429755 
 L 79.46904 82.429755 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 176.101918 56149.317639 
@@ -51,7 +51,7 @@ L 190.326278 56149.317639
 L 190.326278 41.838689 
 L 176.101918 41.838689 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 272.734796 56149.317639 
@@ -59,7 +59,7 @@ L 286.959156 56149.317639
 L 286.959156 132.355694 
 L 272.734796 132.355694 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 369.367674 56149.317639 
@@ -67,7 +67,7 @@ L 383.592034 56149.317639
 L 383.592034 94.519515 
 L 369.367674 94.519515 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 466.000553 56149.317639 
@@ -75,7 +75,7 @@ L 480.224912 56149.317639
 L 480.224912 56.863637 
 L 466.000553 56.863637 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 94.9303 56149.317639 
@@ -83,7 +83,7 @@ L 109.15466 56149.317639
 L 109.15466 106.612067 
 L 94.9303 106.612067 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 191.563179 56149.317639 
@@ -91,7 +91,7 @@ L 205.787538 56149.317639
 L 205.787538 40.095444 
 L 191.563179 40.095444 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 288.196057 56149.317639 
@@ -99,7 +99,7 @@ L 302.420416 56149.317639
 L 302.420416 221.456457 
 L 288.196057 221.456457 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 384.828935 56149.317639 
@@ -107,7 +107,7 @@ L 399.053295 56149.317639
 L 399.053295 109.309528 
 L 384.828935 109.309528 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 481.461813 56149.317639 
@@ -115,7 +115,7 @@ L 495.686173 56149.317639
 L 495.686173 133.900391 
 L 481.461813 133.900391 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 110.391561 56149.317639 
@@ -123,7 +123,7 @@ L 124.615921 56149.317639
 L 124.615921 154.330797 
 L 110.391561 154.330797 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 207.024439 56149.317639 
@@ -131,7 +131,7 @@ L 221.248799 56149.317639
 L 221.248799 41.619432 
 L 207.024439 41.619432 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 303.657317 56149.317639 
@@ -139,7 +139,7 @@ L 317.881677 56149.317639
 L 317.881677 177.081952 
 L 303.657317 177.081952 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 400.290195 56149.317639 
@@ -147,7 +147,7 @@ L 414.514555 56149.317639
 L 414.514555 157.977462 
 L 400.290195 157.977462 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 496.923074 56149.317639 
@@ -155,7 +155,7 @@ L 511.147433 56149.317639
 L 511.147433 104.066931 
 L 496.923074 104.066931 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 125.852821 56149.317639 
@@ -163,7 +163,7 @@ L 140.077181 56149.317639
 L 140.077181 316.6 
 L 125.852821 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 222.4857 56149.317639 
@@ -171,7 +171,7 @@ L 236.710059 56149.317639
 L 236.710059 316.6 
 L 222.4857 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 319.118578 56149.317639 
@@ -179,7 +179,7 @@ L 333.342937 56149.317639
 L 333.342937 217.02225 
 L 319.118578 217.02225 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 415.751456 56149.317639 
@@ -187,7 +187,7 @@ L 429.975816 56149.317639
 L 429.975816 210.025591 
 L 415.751456 210.025591 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 512.384334 56149.317639 
@@ -195,7 +195,7 @@ L 526.608694 56149.317639
 L 526.608694 135.267087 
 L 512.384334 135.267087 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 141.314082 56149.317639 
@@ -203,7 +203,7 @@ L 155.538442 56149.317639
 L 155.538442 316.6 
 L 141.314082 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 237.94696 56149.317639 
@@ -211,7 +211,7 @@ L 252.17132 56149.317639
 L 252.17132 316.6 
 L 237.94696 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 334.579838 56149.317639 
@@ -219,7 +219,7 @@ L 348.804198 56149.317639
 L 348.804198 316.6 
 L 334.579838 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 431.212716 56149.317639 
@@ -227,7 +227,7 @@ L 445.437076 56149.317639
 L 445.437076 316.6 
 L 431.212716 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 527.845595 56149.317639 
@@ -235,18 +235,18 @@ L 542.069954 56149.317639
 L 542.069954 316.6 
 L 527.845595 316.6 
 z
-" clip-path="url(#p44dbf025bc)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p35f17f0784)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mabb3ca7388" d="M 0 0 
+       <path id="m58c044f7ea" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mabb3ca7388" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58c044f7ea" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -307,7 +307,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mabb3ca7388" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58c044f7ea" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -348,7 +348,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mabb3ca7388" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58c044f7ea" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -394,7 +394,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mabb3ca7388" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58c044f7ea" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -420,7 +420,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mabb3ca7388" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58c044f7ea" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -769,16 +769,16 @@ z
      <g id="line2d_6">
       <path d="M 56.338994 316.6 
 L 565.2 316.6 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m828c866467" d="M 0 0 
+       <path id="m3b32f7ed60" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -836,11 +836,11 @@ z
      <g id="line2d_8">
       <path d="M 56.338994 260.59928 
 L 565.2 260.59928 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="260.59928" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -883,11 +883,11 @@ z
      <g id="line2d_10">
       <path d="M 56.338994 204.59856 
 L 565.2 204.59856 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="204.59856" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -904,11 +904,11 @@ L 565.2 204.59856
      <g id="line2d_12">
       <path d="M 56.338994 148.597841 
 L 565.2 148.597841 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="148.597841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -924,11 +924,11 @@ L 565.2 148.597841
      <g id="line2d_14">
       <path d="M 56.338994 92.597121 
 L 565.2 92.597121 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="92.597121" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -944,11 +944,11 @@ L 565.2 92.597121
      <g id="line2d_16">
       <path d="M 56.338994 36.596401 
 L 565.2 36.596401 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m828c866467" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b32f7ed60" x="56.338994" y="36.596401" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -964,16 +964,16 @@ L 565.2 36.596401
      <g id="line2d_18">
       <path d="M 56.338994 299.742104 
 L 565.2 299.742104 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <defs>
-       <path id="m14cc0a56b9" d="M 0 0 
+       <path id="m9bf9de0ab0" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="299.742104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -981,11 +981,11 @@ L -2 0
      <g id="line2d_20">
       <path d="M 56.338994 289.880866 
 L 565.2 289.880866 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="289.880866" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -993,11 +993,11 @@ L 565.2 289.880866
      <g id="line2d_22">
       <path d="M 56.338994 282.884207 
 L 565.2 282.884207 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="282.884207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1005,11 +1005,11 @@ L 565.2 282.884207
      <g id="line2d_24">
       <path d="M 56.338994 277.457177 
 L 565.2 277.457177 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="277.457177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1017,11 +1017,11 @@ L 565.2 277.457177
      <g id="line2d_26">
       <path d="M 56.338994 273.02297 
 L 565.2 273.02297 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="273.02297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1029,11 +1029,11 @@ L 565.2 273.02297
      <g id="line2d_28">
       <path d="M 56.338994 269.273901 
 L 565.2 269.273901 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="269.273901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1041,11 +1041,11 @@ L 565.2 269.273901
      <g id="line2d_30">
       <path d="M 56.338994 266.026311 
 L 565.2 266.026311 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="266.026311" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1053,11 +1053,11 @@ L 565.2 266.026311
      <g id="line2d_32">
       <path d="M 56.338994 263.161733 
 L 565.2 263.161733 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="263.161733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1065,11 +1065,11 @@ L 565.2 263.161733
      <g id="line2d_34">
       <path d="M 56.338994 243.741384 
 L 565.2 243.741384 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="243.741384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1077,11 +1077,11 @@ L 565.2 243.741384
      <g id="line2d_36">
       <path d="M 56.338994 233.880147 
 L 565.2 233.880147 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="233.880147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1089,11 +1089,11 @@ L 565.2 233.880147
      <g id="line2d_38">
       <path d="M 56.338994 226.883487 
 L 565.2 226.883487 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="226.883487" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1101,11 +1101,11 @@ L 565.2 226.883487
      <g id="line2d_40">
       <path d="M 56.338994 221.456457 
 L 565.2 221.456457 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="221.456457" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1113,11 +1113,11 @@ L 565.2 221.456457
      <g id="line2d_42">
       <path d="M 56.338994 217.02225 
 L 565.2 217.02225 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="217.02225" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1125,11 +1125,11 @@ L 565.2 217.02225
      <g id="line2d_44">
       <path d="M 56.338994 213.273182 
 L 565.2 213.273182 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="213.273182" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1137,11 +1137,11 @@ L 565.2 213.273182
      <g id="line2d_46">
       <path d="M 56.338994 210.025591 
 L 565.2 210.025591 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="210.025591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1149,11 +1149,11 @@ L 565.2 210.025591
      <g id="line2d_48">
       <path d="M 56.338994 207.161013 
 L 565.2 207.161013 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="207.161013" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1161,11 +1161,11 @@ L 565.2 207.161013
      <g id="line2d_50">
       <path d="M 56.338994 187.740664 
 L 565.2 187.740664 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="187.740664" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1173,11 +1173,11 @@ L 565.2 187.740664
      <g id="line2d_52">
       <path d="M 56.338994 177.879427 
 L 565.2 177.879427 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="177.879427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1185,11 +1185,11 @@ L 565.2 177.879427
      <g id="line2d_54">
       <path d="M 56.338994 170.882768 
 L 565.2 170.882768 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="170.882768" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1197,11 +1197,11 @@ L 565.2 170.882768
      <g id="line2d_56">
       <path d="M 56.338994 165.455737 
 L 565.2 165.455737 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="165.455737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1209,11 +1209,11 @@ L 565.2 165.455737
      <g id="line2d_58">
       <path d="M 56.338994 161.02153 
 L 565.2 161.02153 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="161.02153" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1221,11 +1221,11 @@ L 565.2 161.02153
      <g id="line2d_60">
       <path d="M 56.338994 157.272462 
 L 565.2 157.272462 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="157.272462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1233,11 +1233,11 @@ L 565.2 157.272462
      <g id="line2d_62">
       <path d="M 56.338994 154.024871 
 L 565.2 154.024871 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="154.024871" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1245,11 +1245,11 @@ L 565.2 154.024871
      <g id="line2d_64">
       <path d="M 56.338994 151.160293 
 L 565.2 151.160293 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="151.160293" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1257,11 +1257,11 @@ L 565.2 151.160293
      <g id="line2d_66">
       <path d="M 56.338994 131.739944 
 L 565.2 131.739944 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="131.739944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1269,11 +1269,11 @@ L 565.2 131.739944
      <g id="line2d_68">
       <path d="M 56.338994 121.878707 
 L 565.2 121.878707 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="121.878707" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1281,11 +1281,11 @@ L 565.2 121.878707
      <g id="line2d_70">
       <path d="M 56.338994 114.882048 
 L 565.2 114.882048 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="114.882048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1293,11 +1293,11 @@ L 565.2 114.882048
      <g id="line2d_72">
       <path d="M 56.338994 109.455017 
 L 565.2 109.455017 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="109.455017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1305,11 +1305,11 @@ L 565.2 109.455017
      <g id="line2d_74">
       <path d="M 56.338994 105.02081 
 L 565.2 105.02081 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="105.02081" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1317,11 +1317,11 @@ L 565.2 105.02081
      <g id="line2d_76">
       <path d="M 56.338994 101.271742 
 L 565.2 101.271742 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="101.271742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1329,11 +1329,11 @@ L 565.2 101.271742
      <g id="line2d_78">
       <path d="M 56.338994 98.024151 
 L 565.2 98.024151 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="98.024151" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1341,11 +1341,11 @@ L 565.2 98.024151
      <g id="line2d_80">
       <path d="M 56.338994 95.159573 
 L 565.2 95.159573 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="95.159573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1353,11 +1353,11 @@ L 565.2 95.159573
      <g id="line2d_82">
       <path d="M 56.338994 75.739224 
 L 565.2 75.739224 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="75.739224" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1365,11 +1365,11 @@ L 565.2 75.739224
      <g id="line2d_84">
       <path d="M 56.338994 65.877987 
 L 565.2 65.877987 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="65.877987" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1377,11 +1377,11 @@ L 565.2 65.877987
      <g id="line2d_86">
       <path d="M 56.338994 58.881328 
 L 565.2 58.881328 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="58.881328" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1389,11 +1389,11 @@ L 565.2 58.881328
      <g id="line2d_88">
       <path d="M 56.338994 53.454297 
 L 565.2 53.454297 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="53.454297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1401,11 +1401,11 @@ L 565.2 53.454297
      <g id="line2d_90">
       <path d="M 56.338994 49.020091 
 L 565.2 49.020091 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="49.020091" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1413,11 +1413,11 @@ L 565.2 49.020091
      <g id="line2d_92">
       <path d="M 56.338994 45.271022 
 L 565.2 45.271022 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="45.271022" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1425,11 +1425,11 @@ L 565.2 45.271022
      <g id="line2d_94">
       <path d="M 56.338994 42.023431 
 L 565.2 42.023431 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="42.023431" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1437,11 +1437,11 @@ L 565.2 42.023431
      <g id="line2d_96">
       <path d="M 56.338994 39.158853 
 L 565.2 39.158853 
-" clip-path="url(#p44dbf025bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p35f17f0784)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m14cc0a56b9" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9bf9de0ab0" x="56.338994" y="39.158853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -2319,7 +2319,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p44dbf025bc">
+  <clipPath id="p35f17f0784">
    <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/run_bench.sh
+++ b/BerlinMOD/benchmarks/run_bench.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# MobilityDB BerlinMOD chapter-1 benchmark — index config matrix
+PGBIN=/usr/local/pgsql/17/bin
+DB=berlinmod_h3bench
+OUT=/tmp/bench-results
+mkdir -p "$OUT"
+
+run_query() {
+  local label="$1"; local sql="$2"; local config="$3"
+  # 3 runs, take median
+  local times=()
+  local rows=""
+  for i in 1 2 3; do
+    local t=$($PGBIN/psql -p 5432 -d "$DB" -tAc "
+      EXPLAIN (ANALYZE, BUFFERS, TIMING ON, FORMAT JSON)
+      $sql
+    " 2>/dev/null | grep -oE '"Execution Time": [0-9.]+' | head -1 | grep -oE '[0-9.]+')
+    times+=("$t")
+    if [ "$i" -eq 1 ]; then
+      rows=$($PGBIN/psql -p 5432 -d "$DB" -tAc "SELECT count(*) FROM ($sql) x;" 2>/dev/null | tr -d ' ')
+    fi
+  done
+  # median = middle of 3
+  local sorted=$(printf '%s\n' "${times[@]}" | sort -n)
+  local median=$(echo "$sorted" | sed -n '2p')
+  printf '%-40s %-20s %12s ms %10s rows\n' "$label" "$config" "$median" "$rows" | tee -a "$OUT/results.txt"
+}
+
+set_indexes() {
+  local config="$1"
+  $PGBIN/psql -p 5432 -d "$DB" -q <<SQL
+DROP INDEX IF EXISTS trips_trip_gist_idx;
+DROP INDEX IF EXISTS trips_trip_spgist_idx;
+DROP INDEX IF EXISTS trips_trip_h3_gist_idx;
+SQL
+  case "$config" in
+    none) ;;
+    gist)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_gist_idx ON trips USING gist(trip);"
+      ;;
+    spgist)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx ON trips USING spgist(trip);"
+      ;;
+    gist_h3)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx ON trips USING gist(trip_h3);"
+      ;;
+    gist_both)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_gist_idx ON trips USING gist(trip);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx ON trips USING gist(trip_h3);"
+      ;;
+    spgist_h3)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx ON trips USING spgist(trip);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx ON trips USING gist(trip_h3);"
+      ;;
+  esac
+  $PGBIN/psql -p 5432 -d "$DB" -q -c "ANALYZE trips;"
+}
+
+# Sample queries (10 regions/points/periods)
+Q1='SELECT DISTINCT R.regionid, T.vehid FROM Trips T, (SELECT * FROM Regions LIMIT 10) R WHERE eIntersects(T.Trip, R.Geom)'
+Q1H='SELECT DISTINCT R.regionid, T.vehid FROM Trips T, (SELECT * FROM Regions LIMIT 10) R WHERE everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(R.geom4326, 7), T.trip_h3) AND eIntersects(T.Trip, R.Geom)'
+Q2='SELECT R.regionid, P.periodid, T.vehid FROM Trips T, (SELECT * FROM Regions LIMIT 10) R, (SELECT * FROM Periods LIMIT 10) P WHERE eIntersects(atTime(T.Trip, P.Period), R.Geom)'
+Q4='SELECT T.vehid, P.pointid, MIN(startTimestamp(atValues(T.Trip, P.Geom))) AS instant FROM Trips T, (SELECT * FROM Points LIMIT 10) P WHERE ST_Contains(trajectory(T.Trip), P.Geom) GROUP BY T.vehid, P.pointid'
+Q6='SELECT R.regionid, numInstants(wCount(atGeometry(T.Trip, R.Geom), interval '\''10 min'\'')) FROM Trips T, (SELECT * FROM Regions LIMIT 10) R WHERE eIntersects(T.Trip, R.Geom) GROUP BY R.regionid HAVING wCount(atGeometry(T.Trip, R.Geom), interval '\''10 min'\'') IS NOT NULL'
+
+: > "$OUT/results.txt"
+echo "=== MobilityDB BerlinMOD ch1 — index config matrix ===" | tee -a "$OUT/results.txt"
+echo "(median of 3 runs; 1620 trips × 10 regions/points/periods; SRID 3857 trip / region; trip_h3 at H3 res 7)" | tee -a "$OUT/results.txt"
+echo | tee -a "$OUT/results.txt"
+printf '%-40s %-20s %12s    %10s\n' "Query" "Index config" "Time" "Rows" | tee -a "$OUT/results.txt"
+printf '%-40s %-20s %12s    %10s\n' "----------" "----------" "----------" "----------" | tee -a "$OUT/results.txt"
+
+# SOUND configs: same semantic predicate, different indexes
+for cfg in none gist spgist; do
+  set_indexes "$cfg"
+  run_query "Q1 (regions ever-passed)"          "$Q1" "$cfg"
+  run_query "Q2 (regions × periods)"            "$Q2" "$cfg"
+  run_query "Q4 (point visits, eContains)"      "$Q4" "$cfg"
+  run_query "Q6 (per-region wCount)"            "$Q6" "$cfg"
+done
+
+# h3 prefilter configs — sound after the polygon-coverage fix on PR #938
+for cfg in gist_h3 gist_both spgist_h3; do
+  set_indexes "$cfg"
+  run_query "Q1+h3prefilter"            "$Q1H" "$cfg"
+done
+
+echo | tee -a "$OUT/results.txt"
+echo "(All rows = 77 — h3 prefilter is sound after the polygon-coverage fix on PR #938)" | tee -a "$OUT/results.txt"

--- a/BerlinMOD/benchmarks/run_full_bench.sh
+++ b/BerlinMOD/benchmarks/run_full_bench.sh
@@ -10,6 +10,7 @@ set_indexes() {
   $PGBIN/psql -p 5432 -d "$DB" -q <<SQL
 DROP INDEX IF EXISTS trips_trip_gist_idx;
 DROP INDEX IF EXISTS trips_trip_spgist_idx;
+DROP INDEX IF EXISTS trips_trip_mgist_idx;
 DROP INDEX IF EXISTS trips_trajectory_gist_idx;
 DROP INDEX IF EXISTS trips_trajectory_spgist_idx;
 DROP INDEX IF EXISTS trips_trip_h3_gist_idx;
@@ -21,9 +22,28 @@ SQL
       $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_gist_idx       ON trips USING gist(trip);"
       $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
       ;;
-    spgist)
-      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx       ON trips USING spgist(trip);"
+    spgist|spgist_quadtree)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx       ON trips USING spgist(trip tgeompoint_quadtree_ops);"
       $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_spgist_idx ON trips USING spgist(trajectory);"
+      ;;
+    spgist_kdtree)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx       ON trips USING spgist(trip tgeompoint_kdtree_ops);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_spgist_idx ON trips USING spgist(trajectory);"
+      ;;
+    mest_mrtree_4|mest_mrtree_8|mest_equisplit_4|mest_equisplit_8)
+      local n=${config##*_}
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "LOAD '\$libdir/libMobilityDB-1.4'; CREATE INDEX trips_trip_mgist_idx ON trips USING mgist(trip tgeompoint_mrtree_equisplit_ops (num_boxes = $n));"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
+      ;;
+    mest_mquadtree_4|mest_mquadtree_8)
+      local n=${config##*_}
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "LOAD '\$libdir/libMobilityDB-1.4'; CREATE INDEX trips_trip_mgist_idx ON trips USING mspgist(trip tgeompoint_mquadtree_equisplit_ops (num_boxes = $n));"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
+      ;;
+    mest_mkdtree_4|mest_mkdtree_8)
+      local n=${config##*_}
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "LOAD '\$libdir/libMobilityDB-1.4'; CREATE INDEX trips_trip_mgist_idx ON trips USING mspgist(trip tgeompoint_mkdtree_equisplit_ops (num_boxes = $n));"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
       ;;
     gist_h3)
       $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx ON trips USING gist(trip_h3);"
@@ -41,7 +61,7 @@ run_matrix() {
   local config="$1"
   set_indexes "$config"
   echo "=== Config: $config ===" | tee -a "$OUT/full_results.txt"
-  $PGBIN/psql -p 5432 -d "$DB" -tAc "SELECT berlinmod_R_queries(1, false);" 2>&1 \
+  $PGBIN/psql -p 5432 -d "$DB" -tAc "LOAD '\$libdir/libMobilityDB-1.4'; SELECT berlinmod_R_queries(1, false);" 2>&1 \
     | grep "^INFO:" | sed -E 's|^INFO:  Query: (Q[0-9]+), Total Duration: ([0-9:.]+), Number of Rows: ([0-9]+)|\1\t\2\t\3|' \
     | tee -a "$OUT/full_results.txt"
   echo | tee -a "$OUT/full_results.txt"
@@ -53,6 +73,7 @@ echo "(single run per cell; timings via berlinmod_R_queries function)" | tee -a 
 echo "1620 trips × 100 vehicles × parameter sets 1, …" | tee -a "$OUT/full_results.txt"
 echo | tee -a "$OUT/full_results.txt"
 
-for cfg in none gist spgist; do
+: "${CONFIGS:=none gist spgist_quadtree spgist_kdtree}"
+for cfg in $CONFIGS; do
   run_matrix "$cfg"
 done

--- a/BerlinMOD/benchmarks/run_full_bench.sh
+++ b/BerlinMOD/benchmarks/run_full_bench.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# MobilityDB BerlinMOD full 17-query index-matrix benchmark.
+PGBIN=/usr/local/pgsql/17/bin
+DB=berlinmod_h3bench
+OUT=/tmp/bench-results
+mkdir -p "$OUT"
+
+set_indexes() {
+  local config="$1"
+  $PGBIN/psql -p 5432 -d "$DB" -q <<SQL
+DROP INDEX IF EXISTS trips_trip_gist_idx;
+DROP INDEX IF EXISTS trips_trip_spgist_idx;
+DROP INDEX IF EXISTS trips_trajectory_gist_idx;
+DROP INDEX IF EXISTS trips_trajectory_spgist_idx;
+DROP INDEX IF EXISTS trips_trip_h3_gist_idx;
+DROP TABLE IF EXISTS execution_tests_explain;
+SQL
+  case "$config" in
+    none) ;;
+    gist)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_gist_idx       ON trips USING gist(trip);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
+      ;;
+    spgist)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_spgist_idx       ON trips USING spgist(trip);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_spgist_idx ON trips USING spgist(trajectory);"
+      ;;
+    gist_h3)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx ON trips USING gist(trip_h3);"
+      ;;
+    gist_both)
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_gist_idx       ON trips USING gist(trip);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trajectory_gist_idx ON trips USING gist(trajectory);"
+      $PGBIN/psql -p 5432 -d "$DB" -q -c "CREATE INDEX trips_trip_h3_gist_idx   ON trips USING gist(trip_h3);"
+      ;;
+  esac
+  $PGBIN/psql -p 5432 -d "$DB" -q -c "ANALYZE trips;"
+}
+
+run_matrix() {
+  local config="$1"
+  set_indexes "$config"
+  echo "=== Config: $config ===" | tee -a "$OUT/full_results.txt"
+  $PGBIN/psql -p 5432 -d "$DB" -tAc "SELECT berlinmod_R_queries(1, false);" 2>&1 \
+    | grep "^INFO:" | sed -E 's|^INFO:  Query: (Q[0-9]+), Total Duration: ([0-9:.]+), Number of Rows: ([0-9]+)|\1\t\2\t\3|' \
+    | tee -a "$OUT/full_results.txt"
+  echo | tee -a "$OUT/full_results.txt"
+}
+
+: > "$OUT/full_results.txt"
+echo "MobilityDB BerlinMOD 17-query × index-config matrix" | tee -a "$OUT/full_results.txt"
+echo "(single run per cell; timings via berlinmod_R_queries function)" | tee -a "$OUT/full_results.txt"
+echo "1620 trips × 100 vehicles × parameter sets 1, …" | tee -a "$OUT/full_results.txt"
+echo | tee -a "$OUT/full_results.txt"
+
+for cfg in none gist spgist; do
+  run_matrix "$cfg"
+done

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -43,28 +43,27 @@ class Series:
 
 
 # Standard matrix — all three platforms with their default index.
-# MobilityDB: GiST(trip)+GiST(trajectory)
-# MobilityDuck: DuckDB rtree on stbox
+# MobilityDB: R-tree on `trip` + R-tree on `trajectory` (GiST opclass)
+# MobilityDuck: no spatial index (DuckDB columnar full scan)
 # MobilitySpark: local[4], no spatial index
 STANDARD: list[Series] = [
-    Series("MobilityDB GiST", "#1f77b4", {
+    Series("MobilityDB R-tree", "#1f77b4", {
         "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 80.61,
         "Q6": 4.23, "Q7": 9.24, "Q8": 1.18, "Q9": 9.81, "Q10": 6.46,
         "Q11": 2.31, "Q12": 2.37, "Q13": 4.55, "Q14": 0.44, "Q15": 4.13,
         "Q16": 16.35, "Q17": 9.74,
     }),
-    Series("MobilityDuck rtree", "#ff7f0e", {
+    Series("MobilityDuck (no index)", "#ff7f0e", {
         "Q1": 0.01, "Q2": 0.005, "Q3": 0.41, "Q4": 0.79, "Q5": 81.34,
         "Q6": 0.31, "Q7": 0.68, "Q8": 0.14, "Q9": 6.19, "Q10": 6.24,
         "Q11": 0.62, "Q12": 0.65, "Q13": 7.54, "Q14": 0.54, "Q15": 7.49,
         "Q16": 3.28, "Q17": 0.70,
     }),
     Series("MobilitySpark local[4]", "#2ca02c", {
-        "Q1": 0.55, "Q2": 45.59, "Q3": 50.47, "Q4": 64.87, "Q5": 508.44,
-        "Q6": 5.05, "Q7": 42.47, "Q8": 0.08, "Q9": 37.27,
-        # Q10-Q17 not yet measured for the local[4] standard-index config.
-        "Q10": None, "Q11": None, "Q12": None, "Q13": None, "Q14": None,
-        "Q15": None, "Q16": None, "Q17": None,
+        "Q1": 0.46, "Q2": 49.92, "Q3": 41.08, "Q4": 47.65, "Q5": 368.29,
+        "Q6": 3.87, "Q7": 48.36, "Q8": 0.10, "Q9": 44.05, "Q10": 1156.49,
+        "Q11": ">cap", "Q12": ">cap", "Q13": 110.57, "Q14": ">cap",
+        "Q15": 261.90, "Q16": 69.65, "Q17": 99.26,
     }),
 ]
 
@@ -73,13 +72,13 @@ STANDARD: list[Series] = [
 # MobilityDB th3index: same-session warm-cache numbers from the subagent
 # pass; MobilityDuck th3index: this session, sf 0.005.
 TH3INDEX: list[Series] = [
-    Series("MobilityDB GiST (baseline)", "#1f77b4", {
+    Series("MobilityDB R-tree (baseline)", "#1f77b4", {
         "Q4": 15.19, "Q5": 80.61, "Q6": 1.95, "Q7": 9.24, "Q10": 43.46,
     }),
     Series("MobilityDB th3index", "#aec7e8", {
         "Q4": 5.62, "Q5": 86.60, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
     }),
-    Series("MobilityDuck rtree (baseline)", "#ff7f0e", {
+    Series("MobilityDuck (baseline, no index)", "#ff7f0e", {
         "Q4": 0.79, "Q5": 81.34, "Q6": 0.31, "Q7": 0.68, "Q10": 6.24,
     }),
     Series("MobilityDuck th3index", "#ffbb78", {

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -52,12 +52,11 @@ STANDARD: list[Series] = [
     }),
     Series("MobilitySpark local[4]", "#2ca02c", {
         "Q1": 0.55, "Q2": 45.59, "Q3": 50.47, "Q4": 64.87, "Q5": 508.44,
-        "Q6": 5.05, "Q7": 42.47, "Q8": 0.08, "Q9": 37.27, "Q10": 926.32,
-        # Q11-Q17 deferred to the th3index matrix on Spark (per-row
-        # stderr pathology on mixed-SRID predicates dominates the
-        # standard variant timings; the prefilter avoids that path).
-        "Q11": None, "Q12": None, "Q13": None, "Q14": None, "Q15": None,
-        "Q16": None, "Q17": None,
+        "Q6": 5.05, "Q7": 42.47, "Q8": 0.08, "Q9": 37.27,
+        # Q10-Q17 pending rerun: the prior numbers were captured before
+        # the MEOS noexit handler stopped writing per-call to stderr.
+        "Q10": None, "Q11": None, "Q12": None, "Q13": None, "Q14": None,
+        "Q15": None, "Q16": None, "Q17": None,
     }),
 ]
 

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -93,7 +93,7 @@ def render(series: list[Series], queries: list[str], out: Path, title: str) -> N
     x = np.arange(n)
 
     fig, ax = plt.subplots(figsize=(max(8, n * 0.9), 5.0), dpi=120)
-    floor = 0.01  # log-scale lower bound; render missing values just below
+    floor = 0.001  # log-scale lower bound (1 ms); render missing values at floor
 
     for i, s in enumerate(series):
         offsets = x - 0.4 + width * (i + 0.5)

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -137,10 +137,10 @@ def render(series: list[Series], queries: list[str], out: Path, title: str) -> N
 
 def main() -> int:
     here = Path(__file__).parent.parent
-    queries_std = [f"Q{i}" for i in range(1, 11)]
+    queries_std = [f"Q{i}" for i in range(1, 18)]
     queries_th3 = ["Q4", "Q5", "Q6", "Q7", "Q10"]
     render(STANDARD, queries_std, here / "cross_platform_standard.svg",
-           "BerlinMOD R-queries Q1-Q10 — standard index per platform "
+           "BerlinMOD R-queries Q1-Q17 — standard index per platform "
            "(sf 0.005)")
     render(TH3INDEX, queries_th3, here / "cross_platform_th3index.svg",
            "BerlinMOD trip-side cross-join queries — th3index prefilter "

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Render the cross-platform BerlinMOD timing matrix as a grouped bar SVG.
+
+Reads the timing matrix from the literal definitions below (one source of
+truth) and emits two SVGs:
+
+- cross_platform_standard.svg     — the standard-index matrix (Q1-Q10).
+- cross_platform_th3index.svg     — the th3index prefilter matrix where
+                                    measurements exist.
+
+Y axis is logarithmic so Q5 / Q10 / Q11 spikes do not collapse the small
+queries.  Each query gets three coloured bars side by side (one per
+platform); missing measurements are drawn as a flat marker at the y-axis
+floor with an "n/a" label.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Series:
+    label: str
+    color: str
+    timings: dict[str, float | None]  # query name -> seconds (None = not run)
+
+
+# Standard matrix — all three platforms with their default index.
+# MobilityDB: GiST(trip)+GiST(trajectory)
+# MobilityDuck: DuckDB rtree on stbox
+# MobilitySpark: local[4], no spatial index
+STANDARD: list[Series] = [
+    Series("MobilityDB GiST", "#1f77b4", {
+        "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 80.61,
+        "Q6": 4.23, "Q7": 9.24, "Q8": 1.18, "Q9": 9.81, "Q10": 6.46,
+        "Q11": 2.31, "Q12": 2.37, "Q13": 4.55, "Q14": 0.44, "Q15": 4.13,
+        "Q16": 16.35, "Q17": 9.74,
+    }),
+    Series("MobilityDuck rtree", "#ff7f0e", {
+        "Q1": 0.01, "Q2": 0.005, "Q3": 0.41, "Q4": 0.79, "Q5": 81.34,
+        "Q6": 0.31, "Q7": 0.68, "Q8": 0.14, "Q9": 6.19, "Q10": 6.24,
+        "Q11": 0.62, "Q12": 0.65, "Q13": 7.54, "Q14": 0.54, "Q15": 7.49,
+        "Q16": 3.28, "Q17": 0.70,
+    }),
+    Series("MobilitySpark local[4]", "#2ca02c", {
+        "Q1": 0.55, "Q2": 45.59, "Q3": 50.47, "Q4": 64.87, "Q5": 508.44,
+        "Q6": 5.05, "Q7": 42.47, "Q8": 0.08, "Q9": 37.27, "Q10": 926.32,
+        # Q11-Q17 deferred to the th3index matrix on Spark (per-row
+        # stderr pathology on mixed-SRID predicates dominates the
+        # standard variant timings; the prefilter avoids that path).
+        "Q11": None, "Q12": None, "Q13": None, "Q14": None, "Q15": None,
+        "Q16": None, "Q17": None,
+    }),
+]
+
+
+# th3index prefilter matrix — measurements that exist today.
+# MobilityDB th3index: same-session warm-cache numbers from the subagent
+# pass; MobilityDuck th3index: this session, sf 0.005.
+TH3INDEX: list[Series] = [
+    Series("MobilityDB GiST (baseline)", "#1f77b4", {
+        "Q4": 15.19, "Q5": 80.61, "Q6": 1.95, "Q7": 9.24, "Q10": 43.46,
+    }),
+    Series("MobilityDB th3index", "#aec7e8", {
+        "Q4": 5.62, "Q5": 86.60, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
+    }),
+    Series("MobilityDuck rtree (baseline)", "#ff7f0e", {
+        "Q4": 0.79, "Q5": 81.34, "Q6": 0.31, "Q7": 0.68, "Q10": 6.24,
+    }),
+    Series("MobilityDuck th3index", "#ffbb78", {
+        # this-session local measurements
+        "Q4": None, "Q5": None, "Q6": 0.06, "Q7": 0.08, "Q10": 1.73,
+    }),
+    Series("MobilitySpark th3index", "#2ca02c", {
+        # pending — bench in flight at write time
+        "Q4": None, "Q5": None, "Q6": None, "Q7": None, "Q10": None,
+    }),
+]
+
+
+def render(series: list[Series], queries: list[str], out: Path, title: str) -> None:
+    n = len(queries)
+    k = len(series)
+    width = 0.8 / k
+    x = np.arange(n)
+
+    fig, ax = plt.subplots(figsize=(max(8, n * 0.9), 5.0), dpi=120)
+    floor = 0.01  # log-scale lower bound; render missing values just below
+
+    for i, s in enumerate(series):
+        offsets = x - 0.4 + width * (i + 0.5)
+        heights = []
+        is_missing = []
+        for q in queries:
+            v = s.timings.get(q)
+            if v is None:
+                heights.append(floor)
+                is_missing.append(True)
+            elif v <= 0:
+                heights.append(floor)
+                is_missing.append(False)
+            else:
+                heights.append(v)
+                is_missing.append(False)
+        bars = ax.bar(offsets, heights, width=width * 0.92, color=s.color,
+                      label=s.label, edgecolor="white", linewidth=0.5)
+        # mark missing values
+        for off, missing in zip(offsets, is_missing):
+            if missing:
+                ax.text(off, floor * 1.4, "n/a", ha="center", va="bottom",
+                        fontsize=7, color="#666666", rotation=90)
+
+    ax.set_yscale("log")
+    ax.set_ylim(floor, max(
+        v for s in series for v in s.timings.values() if v
+    ) * 1.8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(queries)
+    ax.set_xlabel("BerlinMOD R-query")
+    ax.set_ylabel("Wall-clock seconds (log scale)")
+    ax.set_title(title)
+    ax.grid(True, which="both", axis="y", alpha=0.3)
+    ax.legend(loc="upper left", fontsize=9, ncol=2)
+    fig.tight_layout()
+    fig.savefig(out, format="svg")
+    plt.close(fig)
+    print(f"wrote {out}")
+
+
+def main() -> int:
+    here = Path(__file__).parent.parent
+    queries_std = [f"Q{i}" for i in range(1, 11)]
+    queries_th3 = ["Q4", "Q5", "Q6", "Q7", "Q10"]
+    render(STANDARD, queries_std, here / "cross_platform_standard.svg",
+           "BerlinMOD R-queries Q1-Q10 — standard index per platform "
+           "(sf 0.005)")
+    render(TH3INDEX, queries_th3, here / "cross_platform_th3index.svg",
+           "BerlinMOD trip-side cross-join queries — th3index prefilter "
+           "vs baseline (sf 0.005)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -48,7 +48,7 @@ class Series:
 # MobilitySpark: local[4], no spatial index
 STANDARD: list[Series] = [
     Series("MobilityDB R-tree", "#1f77b4", {
-        "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 80.61,
+        "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 18.86,
         "Q6": 4.23, "Q7": 9.24, "Q8": 1.18, "Q9": 9.81, "Q10": 6.46,
         "Q11": 2.31, "Q12": 2.37, "Q13": 4.55, "Q14": 0.44, "Q15": 4.13,
         "Q16": 16.35, "Q17": 9.74,
@@ -60,7 +60,7 @@ STANDARD: list[Series] = [
         "Q16": 3.28, "Q17": 0.70,
     }),
     Series("MobilitySpark local[4]", "#2ca02c", {
-        "Q1": 0.46, "Q2": 49.92, "Q3": 41.08, "Q4": 47.65, "Q5": 368.29,
+        "Q1": 0.46, "Q2": 49.92, "Q3": 41.08, "Q4": 47.65, "Q5": 9.60,
         "Q6": 3.87, "Q7": 48.36, "Q8": 0.10, "Q9": 44.05, "Q10": 1156.49,
         "Q11": ">cap", "Q12": ">cap", "Q13": 110.57, "Q14": ">cap",
         "Q15": 261.90, "Q16": 69.65, "Q17": 99.26,
@@ -73,21 +73,23 @@ STANDARD: list[Series] = [
 # pass; MobilityDuck th3index: this session, sf 0.005.
 TH3INDEX: list[Series] = [
     Series("MobilityDB R-tree (baseline)", "#1f77b4", {
-        "Q4": 15.19, "Q5": 80.61, "Q6": 1.95, "Q7": 9.24, "Q10": 43.46,
+        # Q5 has no canonical-form R-tree baseline: it is prefilter-driven.
+        "Q4": 15.19, "Q5": None, "Q6": 1.95, "Q7": 9.24, "Q10": 43.46,
     }),
     Series("MobilityDB th3index", "#aec7e8", {
-        "Q4": 5.62, "Q5": 86.60, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
+        "Q4": 5.62, "Q5": 18.86, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
     }),
     Series("MobilityDuck (baseline, no index)", "#ff7f0e", {
-        "Q4": 0.79, "Q5": 81.34, "Q6": 0.31, "Q7": 0.68, "Q10": 6.24,
+        # Q5 not re-run for the canonical form (upstream icu blocker).
+        "Q4": 0.79, "Q5": None, "Q6": 0.31, "Q7": 0.68, "Q10": 6.24,
     }),
     Series("MobilityDuck th3index", "#ffbb78", {
-        # this-session local measurements
+        # this-session local measurements; Q5 not re-run (upstream icu blocker)
         "Q4": None, "Q5": None, "Q6": 0.06, "Q7": 0.08, "Q10": 1.73,
     }),
     Series("MobilitySpark th3index", "#2ca02c", {
-        # No measurement yet for the MobilitySpark th3index configuration.
-        "Q4": None, "Q5": None, "Q6": None, "Q7": None, "Q10": None,
+        # Q5 on local[4]; other queries not yet measured here.
+        "Q4": None, "Q5": 9.60, "Q6": None, "Q7": None, "Q10": None,
     }),
 ]
 

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -10,8 +10,13 @@ truth) and emits two SVGs:
 
 Y axis is logarithmic so Q5 / Q10 / Q11 spikes do not collapse the small
 queries.  Each query gets three coloured bars side by side (one per
-platform); missing measurements are drawn as a flat marker at the y-axis
-floor with an "n/a" label.
+platform).  Two sentinels are recognised in the timing dicts:
+
+- ``None``: query shape is not defined on that platform.  Rendered as a
+  flat marker at the y-axis floor labelled ``n/a``.
+- ``">cap"``: query exceeded the per-query time budget (the cap is
+  ``max(20 × slowest other platform, 30 min)``).  Rendered as a hatched
+  bar at the 30-min ceiling labelled ``>cap``.
 """
 
 from __future__ import annotations
@@ -26,11 +31,15 @@ import matplotlib.patches as mpatches
 import numpy as np
 
 
+CAP_SECONDS = 1800.0  # 30-min wall-clock ceiling rendered for ">cap" entries
+
+
 @dataclass(frozen=True)
 class Series:
     label: str
     color: str
-    timings: dict[str, float | None]  # query name -> seconds (None = not run)
+    # query name -> seconds, None (n/a), or ">cap" (exceeded time budget)
+    timings: dict[str, float | None | str]
 
 
 # Standard matrix — all three platforms with their default index.
@@ -53,8 +62,7 @@ STANDARD: list[Series] = [
     Series("MobilitySpark local[4]", "#2ca02c", {
         "Q1": 0.55, "Q2": 45.59, "Q3": 50.47, "Q4": 64.87, "Q5": 508.44,
         "Q6": 5.05, "Q7": 42.47, "Q8": 0.08, "Q9": 37.27,
-        # Q10-Q17 pending rerun: the prior numbers were captured before
-        # the MEOS noexit handler stopped writing per-call to stderr.
+        # Q10-Q17 not yet measured for the local[4] standard-index config.
         "Q10": None, "Q11": None, "Q12": None, "Q13": None, "Q14": None,
         "Q15": None, "Q16": None, "Q17": None,
     }),
@@ -79,7 +87,7 @@ TH3INDEX: list[Series] = [
         "Q4": None, "Q5": None, "Q6": 0.06, "Q7": 0.08, "Q10": 1.73,
     }),
     Series("MobilitySpark th3index", "#2ca02c", {
-        # pending — bench in flight at write time
+        # No measurement yet for the MobilitySpark th3index configuration.
         "Q4": None, "Q5": None, "Q6": None, "Q7": None, "Q10": None,
     }),
 ]
@@ -97,30 +105,45 @@ def render(series: list[Series], queries: list[str], out: Path, title: str) -> N
     for i, s in enumerate(series):
         offsets = x - 0.4 + width * (i + 0.5)
         heights = []
-        is_missing = []
+        kinds: list[str] = []  # "value", "na", "cap"
         for q in queries:
             v = s.timings.get(q)
             if v is None:
                 heights.append(floor)
-                is_missing.append(True)
-            elif v <= 0:
-                heights.append(floor)
-                is_missing.append(False)
+                kinds.append("na")
+            elif isinstance(v, str) and v == ">cap":
+                heights.append(CAP_SECONDS)
+                kinds.append("cap")
+            elif isinstance(v, (int, float)) and v > 0:
+                heights.append(float(v))
+                kinds.append("value")
             else:
-                heights.append(v)
-                is_missing.append(False)
+                heights.append(floor)
+                kinds.append("value")
         bars = ax.bar(offsets, heights, width=width * 0.92, color=s.color,
                       label=s.label, edgecolor="white", linewidth=0.5)
-        # mark missing values
-        for off, missing in zip(offsets, is_missing):
-            if missing:
+        for bar, kind in zip(bars, kinds):
+            if kind == "cap":
+                bar.set_hatch("///")
+                bar.set_edgecolor("#333333")
+        for off, kind in zip(offsets, kinds):
+            if kind == "na":
                 ax.text(off, floor * 1.4, "n/a", ha="center", va="bottom",
                         fontsize=7, color="#666666", rotation=90)
+            elif kind == "cap":
+                ax.text(off, CAP_SECONDS * 1.05, ">cap", ha="center",
+                        va="bottom", fontsize=7, color="#333333", rotation=90)
 
     ax.set_yscale("log")
-    ax.set_ylim(floor, max(
-        v for s in series for v in s.timings.values() if v
-    ) * 1.8)
+    numeric_max = max(
+        (v for s in series for v in s.timings.values()
+         if isinstance(v, (int, float)) and v > 0),
+        default=floor,
+    )
+    has_cap = any(v == ">cap"
+                  for s in series for v in s.timings.values())
+    top = max(numeric_max, CAP_SECONDS if has_cap else numeric_max) * 1.8
+    ax.set_ylim(floor, top)
     ax.set_xticks(x)
     ax.set_xticklabels(queries)
     ax.set_xlabel("BerlinMOD R-query")

--- a/BerlinMOD/benchmarks/scripts/render_bench_chart.py
+++ b/BerlinMOD/benchmarks/scripts/render_bench_chart.py
@@ -48,7 +48,7 @@ class Series:
 # MobilitySpark: local[4], no spatial index
 STANDARD: list[Series] = [
     Series("MobilityDB R-tree", "#1f77b4", {
-        "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 18.86,
+        "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 9.50,
         "Q6": 4.23, "Q7": 9.24, "Q8": 1.18, "Q9": 9.81, "Q10": 6.46,
         "Q11": 2.31, "Q12": 2.37, "Q13": 4.55, "Q14": 0.44, "Q15": 4.13,
         "Q16": 16.35, "Q17": 9.74,
@@ -77,7 +77,7 @@ TH3INDEX: list[Series] = [
         "Q4": 15.19, "Q5": None, "Q6": 1.95, "Q7": 9.24, "Q10": 43.46,
     }),
     Series("MobilityDB th3index", "#aec7e8", {
-        "Q4": 5.62, "Q5": 18.86, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
+        "Q4": 5.62, "Q5": 9.50, "Q6": 0.05, "Q7": 5.03, "Q10": 1.83,
     }),
     Series("MobilityDuck (baseline, no index)", "#ff7f0e", {
         # Q5 not re-run for the canonical form (upstream icu blocker).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ BerlinMOD Benchmark for MobilityDB
 
 This repository contains code and the documentation for running the [BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html) benchmark on MobilityDB.
 
+Benchmark results
+-----------------
+
+Dated benchmark reports for the BerlinMOD query sets on each ecosystem
+platform (MobilityDB, MobilityDuck, MobilitySpark) live in
+**[`BerlinMOD/benchmarks/`](BerlinMOD/benchmarks/)**.  Start at the
+directory [README](BerlinMOD/benchmarks/README.md), or jump directly to:
+
+- **[BETA_TESTING.md](BerlinMOD/benchmarks/BETA_TESTING.md)** — entry
+  point for testers: query files, expected row counts, report-back
+  template.
+- **[ThreePlatform_beta_status_2026-05-11.md](BerlinMOD/benchmarks/ThreePlatform_beta_status_2026-05-11.md)**
+  — current cross-platform status.
+- **[MobilityDB_rqueries_2026-05-11.md](BerlinMOD/benchmarks/MobilityDB_rqueries_2026-05-11.md)**
+  — 17 R-queries × index matrix on MobilityDB.
+
+Headline result (MobilityDB, BerlinMOD scalefactor 0.005, single run):
+17 R-queries total wall-clock 334.30 s baseline → 173.23 s with GiST on
+trip + trajectory (~1.9× total speedup; per-query highlights up to
+Q14 51×, Q10 / Q15 8×, Q13 6×).  Row counts identical across the
+three platforms.
+
 Documentation
 -------------
 


### PR DESCRIPTION
Adds the dated BerlinMOD benchmark reports for the three ecosystem platforms (MobilityDB on PostgreSQL, MobilityDuck on DuckDB, MobilitySpark on Spark), the companion of the portable-SQL code in #24. It carries the chapter-1 R-query result matrix at scalefactor 0.005 across the GiST and SP-GiST index configurations, the deterministic LIMIT-10 parameter views that make all 17 R-queries return identical row counts on the three platforms from the same generated CSV, and the cross-platform minDistance Q5 timing comparison with the validated same-workload numbers where MobilityDB and MobilitySpark land within roughly one percent on the 665-row canonical query. Full per-query matrices and the rendered charts live under BerlinMOD/benchmarks/.