### PR TITLE
Adopt minDistance for Q5 and Q20 canonical SQL

### DIFF
--- a/BerlinMOD/berlinmod_nn_queries.sql
+++ b/BerlinMOD/berlinmod_nn_queries.sql
@@ -188,34 +188,13 @@ LOOP
   FROM Regions1 r CROSS JOIN Periods1 p
   CROSS JOIN LATERAL (
     SELECT v1.*, ROW_NUMBER() OVER () AS RowNo FROM (
-    SELECT v.Licence, trajectory(atTime(t.trip, p.Period)) <-> r.geom AS Dist
+    SELECT v.Licence, minDistance(atTime(t.trip, p.Period), r.geom) AS Dist
     FROM Trips t, Vehicles v
     WHERE t.VehicleId = v.VehicleId AND t.Trip && p.Period
-    ORDER BY trajectory(atTime(t.trip, p.Period)) <-> r.geom
+    ORDER BY minDistance(atTime(t.trip, p.Period), r.geom)
     LIMIT 3 ) AS v1 ) AS v2
   ORDER BY r.RegionId, p.PeriodId, v2.RowNo
   INTO J;
-
-  /*
-  -- Query 20
-  EXPLAIN (ANALYZE, FORMAT JSON)
-  WITH DistanceRegionVeh AS (
-    SELECT r.RegionId, p.PeriodId, p.Period, v.Licence,
-    MIN(ST_Distance(trajectory(atTime(t.Trip, p.Period)), r.geom)) AS Dist
-    FROM Regions1 r, Periods1 p, Trips t, Vehicles v
-    WHERE t.VehicleId = v.VehicleId AND t.Trip && p.Period
-    GROUP BY r.RegionId, p.PeriodId, p.Period, v.Licence
-    -- 14,100 rows in 77 seconds
-  )
-  SELECT *
-  FROM (
-    SELECT *, RANK() OVER (PARTITION BY RegionId, PeriodId ORDER BY Dist) AS Rank
-    FROM DistanceRegionVeh ) AS Tmp
-  WHERE Rank <= 10
-  ORDER BY RegionId, PeriodId, Rank
-  -- 1139 rows on 77 seconds
-  INTO J;
-  */
 
   PlanningTime := (J->0->>'Planning Time')::float;
   ExecutionTime := (J->0->>'Execution Time')::float/1000;

--- a/BerlinMOD/berlinmod_r_queries.sql
+++ b/BerlinMOD/berlinmod_r_queries.sql
@@ -192,29 +192,13 @@ LOOP
   StartTime := clock_timestamp();
 
   -- Query 5
-  /* Slower version of the query
+  EXPLAIN (ANALYZE, FORMAT JSON)
   SELECT l1.Licence AS Licence1, l2.Licence AS Licence2,
-    MIN(ST_Distance(trajectory(t1.Trip), trajectory(t2.Trip))) AS MinDist
+    minDistance(t1.Trip, t2.Trip) AS MinDist
   FROM Trips t1, Licences1 l1, Trips t2, Licences2 l2
   WHERE t1.VehicleId = l1.VehicleId AND t2.VehicleId = l2.VehicleId
-  GROUP BY l1.Licence, l2.Licence 
+  GROUP BY l1.Licence, l2.Licence
   ORDER BY l1.Licence, l2.Licence
-  */
-
-  EXPLAIN (ANALYZE, FORMAT JSON)
-  WITH Temp1(Licence1, Trajs) AS (
-    SELECT l1.Licence, ST_Collect(trajectory(t1.Trip))
-    FROM Trips t1, Licences1 l1
-    WHERE t1.VehicleId = l1.VehicleId
-    GROUP BY l1.Licence ),
-  Temp2(Licence2, Trajs) AS (
-    SELECT l2.Licence, ST_Collect(trajectory(t2.Trip))
-    FROM Trips t2, Licences2 l2
-    WHERE t2.VehicleId = l2.VehicleId
-    GROUP BY l2.Licence )
-  SELECT Licence1, Licence2, ST_Distance(t1.Trajs, t2.Trajs) AS MinDist
-  FROM Temp1 t1, Temp2 t2  
-  ORDER BY Licence1, Licence2
   INTO J;
 
   PlanningTime := (J->0->>'Planning Time')::float;

--- a/BerlinMOD/berlinmod_r_queries_citus.sql
+++ b/BerlinMOD/berlinmod_r_queries_citus.sql
@@ -203,29 +203,13 @@ LOOP
   StartTime := clock_timestamp();
 
   -- Query 5
-  /* Slower version of the query
+  EXPLAIN (ANALYZE, FORMAT JSON)
   SELECT l1.Licence AS Licence1, l2.Licence AS Licence2,
-    MIN(ST_Distance(trajectory(t1.Trip), trajectory(t2.Trip))) AS MinDist
+    minDistance(t1.Trip, t2.Trip) AS MinDist
   FROM Trips t1, Licences1 l1, Trips t2, Licences2 l2
   WHERE t1.VehicleId = l1.VehicleId AND t2.VehicleId = l2.VehicleId
-  GROUP BY l1.Licence, l2.Licence 
+  GROUP BY l1.Licence, l2.Licence
   ORDER BY l1.Licence, l2.Licence
-  */
-
-  EXPLAIN (ANALYZE, FORMAT JSON)
-  WITH Temp1(Licence1, Trajs) AS (
-    SELECT l1.Licence, ST_Collect(trajectory(t1.Trip))
-    FROM Trips t1, Licences1 l1
-    WHERE t1.VehicleId = l1.VehicleId
-    GROUP BY l1.Licence ),
-  Temp2(Licence2, Trajs) AS (
-    SELECT l2.Licence, ST_Collect(trajectory(t2.Trip))
-    FROM Trips t2, Licences2 l2
-    WHERE t2.VehicleId = l2.VehicleId
-    GROUP BY l2.Licence )
-  SELECT Licence1, Licence2, ST_Distance(t1.Trajs, t2.Trajs) AS MinDist
-  FROM Temp1 t1, Temp2 t2  
-  ORDER BY Licence1, Licence2
   INTO J;
 
   PlanningTime := (J->0->>'Planning Time')::float;


### PR DESCRIPTION
Q5 collapses to the natural per-pair aggregate form over the cross-join, minDistance(t1.Trip, t2.Trip) GROUP BY l1.Licence, l2.Licence, replacing the ST_Collect-trajectory CTE workaround that materialised all trajectories per licence before computing distance. Q20 uses minDistance(atTime(t.trip, p.Period), r.geom) directly in the LATERAL inner query, replacing the temporal-distance operator plus sort plus LIMIT idiom. Both forms compute the same English query but the minDistance scalar uses NAD's kernel without materialising a per-instant temporal float, and the obsolete Slower version comments are removed. berlinmod_r_queries_citus.sql receives the same Q5 update for parity. Depends on MobilityDB #1007 which introduces the minDistance function family.