### PR TITLE
doc(bench): add the 3-stream BerlinMOD streaming benchmark catalog and timings

### DIFF
--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
@@ -1,66 +1,75 @@
 # Cross-platform streaming timings — 2026-05-29
 
 Throughput of the streaming query set across the three stream platforms, per
-(query, form). The Flink column is measured; the Nebula and Kafka columns are
-not yet measured. See [`README.md`](README.md) for the query set, the streaming
-forms, and the shared result schema.
+(query, form). The Flink column is measured on the real BerlinMOD instants
+corpus; the Nebula and Kafka columns are not yet measured. See
+[`README.md`](README.md) for the query set, the streaming forms, and the shared
+result schema.
 
 ## Method
 
-Each cell runs as one streaming job over a shared synthetic BerlinMOD corpus and
-is terminated by a counting sink; throughput is input events ÷ wall-clock and
-`output rows` is the sink cardinality. The spatial predicates evaluate through
-MEOS. The Flink figures below are a 30 000-event corpus (50 vehicles × 600
-events over 600 s of event time) on a single-node Flink 1.16 local mini-cluster,
-parallelism 1, Java 21, 16-core x86-64 Linux, with libmeos built
-`-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON`. The wall-clock includes
-the per-job mini-cluster startup (~0.7–0.8 s), so these are end-to-end job
-throughputs; the steady-state row below amortises startup over a larger corpus.
+Each cell runs as one streaming job over a shared corpus and is terminated by a
+counting sink; throughput is input events ÷ wall-clock and `output rows` is the
+sink cardinality. The spatial predicates evaluate through MEOS. The Flink figures
+are the BerlinMOD `berlinmod_instants.csv` (216 075 instants, 5 vehicles, ~11
+days), reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load, on a
+single-node Flink 1.16 local mini-cluster, parallelism 1, Java 21, 16-core
+x86-64 Linux, libmeos built `-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON
+-DRGEO=ON`. The point `P`, region box, road segment, points of interest, and
+target vehicle ids are derived from the corpus (`P` = centroid), and the
+window/tick granularity is scaled to the corpus span. The harness is
+[`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
 
 ## Throughput (events/s) and output rows
 
 | Query | Form | Flink events in | Flink output rows | Flink ev/s | Nebula ev/s | Kafka ev/s |
 |---|---|---:|---:|---:|---:|---:|
-| Q1 | continuous | 30000 | 50 | 13,435 | — | — |
-| Q1 | windowed | 30000 | 60 | 28,169 | — | — |
-| Q1 | snapshot | 30000 | 6000 | 33,520 | — | — |
-| Q2 | continuous | 30000 | 600 | 37,594 | — | — |
-| Q2 | windowed | 30000 | 60 | 39,894 | — | — |
-| Q2 | snapshot | 30000 | 120 | 38,810 | — | — |
-| Q3 | continuous | 30000 | 30000 | 19,023 | — | — |
-| Q3 | windowed | 30000 | 60 | 23,603 | — | — |
-| Q3 | snapshot | 30000 | 3120 | 34,722 | — | — |
-| Q4 | continuous | 30000 | 8 | 27,248 | — | — |
-| Q4 | windowed | 30000 | 480 | 26,525 | — | — |
-| Q4 | snapshot | 30000 | 960 | 27,959 | — | — |
-| Q5 | continuous | 30000 | 7171498 | 403 | — | — |
-| Q5 | windowed | 30000 | 14359 | 32,787 | — | — |
-| Q5 | snapshot | 30000 | 29640 | 27,804 | — | — |
-| Q6 | continuous | 30000 | 30000 | 29,326 | — | — |
-| Q6 | windowed | 30000 | 3000 | 31,283 | — | — |
-| Q6 | snapshot | 30000 | 6000 | 32,293 | — | — |
-| Q7 | continuous | 30000 | 15 | 23,585 | — | — |
-| Q7 | windowed | 30000 | 766 | 23,006 | — | — |
-| Q7 | snapshot | 30000 | 1790 | 20,422 | — | — |
-| Q8 | continuous | 30000 | 30000 | 28,763 | — | — |
-| Q8 | windowed | 30000 | 60 | 29,528 | — | — |
-| Q8 | snapshot | 30000 | 3720 | 36,320 | — | — |
-| Q9 | continuous | 30000 | 1199 | 39,012 | — | — |
-| Q9 | windowed | 30000 | 60 | 37,927 | — | — |
-| Q9 | snapshot | 30000 | 120 | 42,493 | — | — |
+| Q1 | continuous | 216075 | 5 | 86,154 | — | — |
+| Q1 | windowed | 216075 | 86 | 166,982 | — | — |
+| Q1 | snapshot | 216075 | 274 | 204,616 | — | — |
+| Q2 | continuous | 216075 | 61170 | 201,187 | — | — |
+| Q2 | windowed | 216075 | 50 | 210,394 | — | — |
+| Q2 | snapshot | 216075 | 71 | 219,365 | — | — |
+| Q3 | continuous | 216075 | 216075 | 73,796 | — | — |
+| Q3 | windowed | 216075 | 86 | 86,189 | — | — |
+| Q3 | snapshot | 216075 | 0 | 233,342 | — | — |
+| Q4 | continuous | 216075 | 62 | 66,403 | — | — |
+| Q4 | windowed | 216075 | 98 | 66,814 | — | — |
+| Q4 | snapshot | 216075 | 1944 | 67,042 | — | — |
+| Q5 | continuous | 216075 | 73063 | 23,586 | — | — |
+| Q5 | windowed | 216075 | 6 | 226,494 | — | — |
+| Q5 | snapshot | 216075 | 0 | 236,148 | — | — |
+| Q6 | continuous | 216075 | 216075 | 90,712 | — | — |
+| Q6 | windowed | 216075 | 203 | 81,940 | — | — |
+| Q6 | snapshot | 216075 | 274 | 97,595 | — | — |
+| Q7 | continuous | 216075 | 5 | 54,386 | — | — |
+| Q7 | windowed | 216075 | 53 | 43,180 | — | — |
+| Q7 | snapshot | 216075 | 288 | 54,967 | — | — |
+| Q8 | continuous | 216075 | 216075 | 74,948 | — | — |
+| Q8 | windowed | 216075 | 86 | 75,445 | — | — |
+| Q8 | snapshot | 216075 | 126 | 232,839 | — | — |
+| Q9 | continuous | 216075 | 107870 | 116,294 | — | — |
+| Q9 | windowed | 216075 | 22 | 233,847 | — | — |
+| Q9 | snapshot | 216075 | 95 | 217,818 | — | — |
 
-## Steady-state per-event predicate
+## Parity — streaming ≡ batch on the same MEOS predicate
 
-Q3-continuous applies one MEOS `edwithin_tgeo_geo` per event. Over a
-200 000-event corpus with the per-job startup amortised:
+The continuous form emits `predicate(event)` for every event, checked
+event-for-event against a batch pass over the same corpus through the same MEOS
+call. On the 216 075-event corpus both spatial-membership queries match exactly,
+which is the cross-family link to the 3-DB benchmark (the batch result is the
+oracle).
 
-| Query | Form | Flink events in | Flink output rows | Flink ev/s |
-|---|---|---:|---:|---:|
-| Q3 | continuous | 200000 | 200000 | 45,096 |
+| Query | Events | Streaming-true | Batch-true | Mismatches | Parity |
+|---|---:|---:|---:|---:|---|
+| Q3 (`edwithin_tgeo_geo`, within `d` of `P`) | 216075 | 56086 | 56086 | 0 | exact |
+| Q8 (`edwithin_tgeo_geo`, within `d` of segment) | 216075 | 118498 | 118498 | 0 | exact |
 
 ## Characteristics
 
 Q5-continuous enumerates every meeting pair across all vehicles on each event
-(O(V²) per event, keyed to a single subtask), producing 7 171 498 rows from
-30 000 events — the lowest throughput, inherent to the all-pairs meeting query
-rather than to the predicate path.
+(O(V²) per event, keyed to a single subtask) — the lowest throughput. The
+snapshot form is a sampled form (each vehicle's last-known position at tick
+instants), so a within-`P` snapshot can be empty when no vehicle is within `d` of
+`P` at a tick boundary even though the continuous form reports near-`P` events
+between boundaries.

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
@@ -59,6 +59,20 @@ once the application has read the whole input topic. The harness is
 | Q9 | windowed | 216075 | 22 | 233,847 | — | 90,636 |
 | Q9 | snapshot | 216075 | 95 | 217,818 | — | 94,729 |
 
+## Throughput charts (events/s, log scale, higher is better)
+
+One grouped bar chart per streaming form, Flink against Kafka on the same corpus.
+The Nebula column is not yet measured and is omitted from the bars. The charts
+are regenerated from
+[`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) — run
+`python3 scripts/render_streaming_chart.py` to refresh all three SVGs.
+
+![Continuous-form streaming throughput, Flink vs Kafka](streaming_continuous.svg)
+
+![Windowed-form streaming throughput, Flink vs Kafka](streaming_windowed.svg)
+
+![Snapshot-form streaming throughput, Flink vs Kafka](streaming_snapshot.svg)
+
 ## Parity — streaming ≡ batch on the same MEOS predicate
 
 The continuous form emits `predicate(event)` for every event, checked

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
@@ -1,8 +1,8 @@
 # Cross-platform streaming timings — 2026-05-29
 
 Throughput of the streaming query set across the three stream platforms, per
-(query, form). The Flink column is measured on the real BerlinMOD instants
-corpus; the Nebula and Kafka columns are not yet measured. See
+(query, form). The Flink and Kafka columns are measured on the same real
+BerlinMOD instants corpus; the Nebula column is not yet measured. See
 [`README.md`](README.md) for the query set, the streaming forms, and the shared
 result schema.
 
@@ -20,37 +20,44 @@ target vehicle ids are derived from the corpus (`P` = centroid), and the
 window/tick granularity is scaled to the corpus span. The harness is
 [`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
 
+The Kafka figures use the same corpus and the same corpus-derived parameters on
+Kafka Streams 3.6: each cell runs as one `KafkaStreams` application against its
+own fresh in-process `EmbeddedKafkaCluster` (a real `KafkaServer` over the
+loopback network), one stream thread, throughput = events consumed ÷ wall-clock
+once the application has read the whole input topic. The harness is
+[`MobilityKafka` `EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
+
 ## Throughput (events/s) and output rows
 
 | Query | Form | Flink events in | Flink output rows | Flink ev/s | Nebula ev/s | Kafka ev/s |
 |---|---|---:|---:|---:|---:|---:|
-| Q1 | continuous | 216075 | 5 | 86,154 | — | — |
-| Q1 | windowed | 216075 | 86 | 166,982 | — | — |
-| Q1 | snapshot | 216075 | 274 | 204,616 | — | — |
-| Q2 | continuous | 216075 | 61170 | 201,187 | — | — |
-| Q2 | windowed | 216075 | 50 | 210,394 | — | — |
-| Q2 | snapshot | 216075 | 71 | 219,365 | — | — |
-| Q3 | continuous | 216075 | 216075 | 73,796 | — | — |
-| Q3 | windowed | 216075 | 86 | 86,189 | — | — |
-| Q3 | snapshot | 216075 | 0 | 233,342 | — | — |
-| Q4 | continuous | 216075 | 62 | 66,403 | — | — |
-| Q4 | windowed | 216075 | 98 | 66,814 | — | — |
-| Q4 | snapshot | 216075 | 1944 | 67,042 | — | — |
-| Q5 | continuous | 216075 | 73063 | 23,586 | — | — |
-| Q5 | windowed | 216075 | 6 | 226,494 | — | — |
-| Q5 | snapshot | 216075 | 0 | 236,148 | — | — |
-| Q6 | continuous | 216075 | 216075 | 90,712 | — | — |
-| Q6 | windowed | 216075 | 203 | 81,940 | — | — |
-| Q6 | snapshot | 216075 | 274 | 97,595 | — | — |
-| Q7 | continuous | 216075 | 5 | 54,386 | — | — |
-| Q7 | windowed | 216075 | 53 | 43,180 | — | — |
-| Q7 | snapshot | 216075 | 288 | 54,967 | — | — |
-| Q8 | continuous | 216075 | 216075 | 74,948 | — | — |
-| Q8 | windowed | 216075 | 86 | 75,445 | — | — |
-| Q8 | snapshot | 216075 | 126 | 232,839 | — | — |
-| Q9 | continuous | 216075 | 107870 | 116,294 | — | — |
-| Q9 | windowed | 216075 | 22 | 233,847 | — | — |
-| Q9 | snapshot | 216075 | 95 | 217,818 | — | — |
+| Q1 | continuous | 216075 | 5 | 86,154 | — | 113,785 |
+| Q1 | windowed | 216075 | 86 | 166,982 | — | 130,956 |
+| Q1 | snapshot | 216075 | 274 | 204,616 | — | 127,029 |
+| Q2 | continuous | 216075 | 61170 | 201,187 | — | 167,631 |
+| Q2 | windowed | 216075 | 50 | 210,394 | — | 126,806 |
+| Q2 | snapshot | 216075 | 71 | 219,365 | — | 128,388 |
+| Q3 | continuous | 216075 | 216075 | 73,796 | — | 46,790 |
+| Q3 | windowed | 216075 | 86 | 86,189 | — | 51,594 |
+| Q3 | snapshot | 216075 | 0 | 233,342 | — | 82,883 |
+| Q4 | continuous | 216075 | 62 | 66,403 | — | 23,095 |
+| Q4 | windowed | 216075 | 98 | 66,814 | — | 22,182 |
+| Q4 | snapshot | 216075 | 1944 | 67,042 | — | 20,581 |
+| Q5 | continuous | 216075 | 73063 | 23,586 | — | 9,440 |
+| Q5 | windowed | 216075 | 6 | 226,494 | — | 74,612 |
+| Q5 | snapshot | 216075 | 0 | 236,148 | — | 107,715 |
+| Q6 | continuous | 216075 | 216075 | 90,712 | — | 24,814 |
+| Q6 | windowed | 216075 | 203 | 81,940 | — | 34,473 |
+| Q6 | snapshot | 216075 | 274 | 97,595 | — | 29,771 |
+| Q7 | continuous | 216075 | 5 | 54,386 | — | 50,006 |
+| Q7 | windowed | 216075 | 53 | 43,180 | — | 18,587 |
+| Q7 | snapshot | 216075 | 288 | 54,967 | — | 28,860 |
+| Q8 | continuous | 216075 | 216075 | 74,948 | — | 44,950 |
+| Q8 | windowed | 216075 | 86 | 75,445 | — | 36,340 |
+| Q8 | snapshot | 216075 | 126 | 232,839 | — | 76,487 |
+| Q9 | continuous | 216075 | 107870 | 116,294 | — | 47,375 |
+| Q9 | windowed | 216075 | 22 | 233,847 | — | 90,636 |
+| Q9 | snapshot | 216075 | 95 | 217,818 | — | 94,729 |
 
 ## Parity — streaming ≡ batch on the same MEOS predicate
 
@@ -73,3 +80,9 @@ snapshot form is a sampled form (each vehicle's last-known position at tick
 instants), so a within-`P` snapshot can be empty when no vehicle is within `d` of
 `P` at a tick boundary even though the continuous form reports near-`P` events
 between boundaries.
+
+Kafka Streams routes every record through the broker (produce then fetch), so its
+per-event spatial cells (Q3/Q8/Q9-continuous) run below Flink's in-JVM
+mini-cluster pipeline on the same corpus, while the per-cell shape matches across
+both engines — the O(V²) Q5-continuous is the floor and the non-spatial Q1/Q2
+cells the ceiling.

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
@@ -1,102 +1,147 @@
-# Cross-platform streaming timings — 2026-05-29
+# BerlinMOD three-platform stream benchmark
 
-Throughput of the streaming query set across the three stream platforms, per
-(query, form). The Flink and Kafka columns are measured on the same real
-BerlinMOD instants corpus; the Nebula column is not yet measured. See
-[`README.md`](README.md) for the query set, the streaming forms, and the shared
-result schema.
+## What this benchmark measures
 
-## Method
+The streaming benchmark runs the BerlinMOD query set as continuous stream jobs
+rather than batch SQL: each query evaluated event-by-event over a corpus of
+vehicle instants, in three forms — continuous, windowed, snapshot.
 
-Each cell runs as one streaming job over a shared corpus and is terminated by a
-counting sink; throughput is input events ÷ wall-clock and `output rows` is the
-sink cardinality. The spatial predicates evaluate through MEOS. The Flink figures
-are the BerlinMOD `berlinmod_instants.csv` (216 075 instants, 5 vehicles, ~11
-days), reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load, on a
-single-node Flink 1.16 local mini-cluster, parallelism 1, Java 21, 16-core
-x86-64 Linux, libmeos built `-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON
--DRGEO=ON`. The point `P`, region box, road segment, points of interest, and
-target vehicle ids are derived from the corpus (`P` = centroid), and the
-window/tick granularity is scaled to the corpus span. The harness is
-[`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
+This benchmark measures per-query throughput across three stream engines —
+MobilityFlink, MobilityKafka, and MobilityNebula — that share the same MEOS
+kernel and evaluate the same predicates over the same corpus. The aim is a
+diagnostic, not a leaderboard: where each engine pays its cost, with the batch
+result as the correctness oracle.
 
-The Kafka figures use the same corpus and the same corpus-derived parameters on
-Kafka Streams 3.6: each cell runs as one `KafkaStreams` application against its
-own fresh in-process `EmbeddedKafkaCluster` (a real `KafkaServer` over the
-loopback network), one stream thread, throughput = events consumed ÷ wall-clock
-once the application has read the whole input topic. The harness is
-[`MobilityKafka` `EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
+## Workload
 
-## Throughput (events/s) and output rows
+The query set is the BerlinMOD R-queries recast in the forms suited to a stream
+(see [`README.md`](README.md) for the full set and each query's R-query lineage).
+Every query runs in three forms:
 
-| Query | Form | Flink events in | Flink output rows | Flink ev/s | Nebula ev/s | Kafka ev/s |
-|---|---|---:|---:|---:|---:|---:|
-| Q1 | continuous | 216075 | 5 | 86,154 | — | 113,785 |
-| Q1 | windowed | 216075 | 86 | 166,982 | — | 130,956 |
-| Q1 | snapshot | 216075 | 274 | 204,616 | — | 127,029 |
-| Q2 | continuous | 216075 | 61170 | 201,187 | — | 167,631 |
-| Q2 | windowed | 216075 | 50 | 210,394 | — | 126,806 |
-| Q2 | snapshot | 216075 | 71 | 219,365 | — | 128,388 |
-| Q3 | continuous | 216075 | 216075 | 73,796 | — | 46,790 |
-| Q3 | windowed | 216075 | 86 | 86,189 | — | 51,594 |
-| Q3 | snapshot | 216075 | 0 | 233,342 | — | 82,883 |
-| Q4 | continuous | 216075 | 62 | 66,403 | — | 23,095 |
-| Q4 | windowed | 216075 | 98 | 66,814 | — | 22,182 |
-| Q4 | snapshot | 216075 | 1944 | 67,042 | — | 20,581 |
-| Q5 | continuous | 216075 | 73063 | 23,586 | — | 9,440 |
-| Q5 | windowed | 216075 | 6 | 226,494 | — | 74,612 |
-| Q5 | snapshot | 216075 | 0 | 236,148 | — | 107,715 |
-| Q6 | continuous | 216075 | 216075 | 90,712 | — | 24,814 |
-| Q6 | windowed | 216075 | 203 | 81,940 | — | 34,473 |
-| Q6 | snapshot | 216075 | 274 | 97,595 | — | 29,771 |
-| Q7 | continuous | 216075 | 5 | 54,386 | — | 50,006 |
-| Q7 | windowed | 216075 | 53 | 43,180 | — | 18,587 |
-| Q7 | snapshot | 216075 | 288 | 54,967 | — | 28,860 |
-| Q8 | continuous | 216075 | 216075 | 74,948 | — | 44,950 |
-| Q8 | windowed | 216075 | 86 | 75,445 | — | 36,340 |
-| Q8 | snapshot | 216075 | 126 | 232,839 | — | 76,487 |
-| Q9 | continuous | 216075 | 107870 | 116,294 | — | 47,375 |
-| Q9 | windowed | 216075 | 22 | 233,847 | — | 90,636 |
-| Q9 | snapshot | 216075 | 95 | 217,818 | — | 94,729 |
+- **continuous** — emits `predicate(event)` for every event as it arrives.
+- **windowed** — aggregates the predicate over tumbling windows.
+- **snapshot** — samples each vehicle's last-known position at tick instants; by
+  contract the snapshot at watermark `T` equals the batch result at `T`, which is
+  the bridge to the DB benchmark.
 
-## Throughput charts (events/s, log scale, higher is better)
+The cell shared with the DB benchmark is the within-distance predicate
+(`edwithin_tgeo_geo`), evaluated through the same MEOS call on every platform.
 
-One grouped bar chart per streaming form, Flink against Kafka on the same corpus.
-The Nebula column is not yet measured and is omitted from the bars. The charts
-are regenerated from
-[`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) — run
-`python3 scripts/render_streaming_chart.py` to refresh all three SVGs.
+## Dataset, hardware, methodology
 
-![Continuous-form streaming throughput, Flink vs Kafka](streaming_continuous.svg)
+The corpus is BerlinMOD `berlinmod_instants.csv` — 216 075 instants, 5 vehicles,
+~11 days — reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load.
+The point `P`, region box, road segment, points of interest, and target vehicle
+ids derive from the corpus (`P` = centroid), and the window/tick granularity
+scales to the corpus span. libmeos is built `-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON
+-DPOSE=ON -DRGEO=ON`; hardware is a 16-core x86-64 Linux machine, Java 21.
 
-![Windowed-form streaming throughput, Flink vs Kafka](streaming_windowed.svg)
+- **Flink** — Flink 1.16 single-node local mini-cluster, parallelism 1. Harness
+  [`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
+- **Kafka** — Kafka Streams 3.6, one stream thread, each cell a `KafkaStreams`
+  application against its own fresh in-process `EmbeddedKafkaCluster` (a real
+  `KafkaServer` over loopback). Harness
+  [`MobilityKafka` `EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
+- **Nebula** — NebulaStream harness.
 
-![Snapshot-form streaming throughput, Flink vs Kafka](streaming_snapshot.svg)
+## Invariants held fixed
 
-## Parity — streaming ≡ batch on the same MEOS predicate
+These hold for every (query, form, engine) cell.
 
-The continuous form emits `predicate(event)` for every event, checked
-event-for-event against a batch pass over the same corpus through the same MEOS
-call. On the 216 075-event corpus both spatial-membership queries match exactly,
-which is the cross-family link to the 3-DB benchmark (the batch result is the
-oracle).
+- **Same MEOS predicate.** Every platform evaluates the identical MEOS spatial
+  call; the per-cell query shape is the same across engines.
+- **Throughput definition.** Each cell runs as one streaming job over the shared
+  corpus, terminated by a counting sink; throughput is input events ÷ wall-clock
+  and `output rows` is the sink cardinality.
+- **Corpus-derived parameters.** All query parameters and the window/tick
+  granularity derive from the same corpus, identical on every platform.
+- **Batch oracle.** The continuous form is checked event-for-event against a
+  batch pass over the same corpus through the same MEOS call (see Parity).
 
-| Query | Events | Streaming-true | Batch-true | Mismatches | Parity |
-|---|---:|---:|---:|---:|---|
-| Q3 (`edwithin_tgeo_geo`, within `d` of `P`) | 216075 | 56086 | 56086 | 0 | exact |
-| Q8 (`edwithin_tgeo_geo`, within `d` of segment) | 216075 | 118498 | 118498 | 0 | exact |
+## Results — throughput (events/s)
 
-## Characteristics
+Each engine fills its column; see [Contributing your numbers](#contributing-your-numbers).
+The charts below regenerate once columns land.
 
-Q5-continuous enumerates every meeting pair across all vehicles on each event
-(O(V²) per event, keyed to a single subtask) — the lowest throughput. The
-snapshot form is a sampled form (each vehicle's last-known position at tick
-instants), so a within-`P` snapshot can be empty when no vehicle is within `d` of
+| Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
+|---|---|---:|---:|---:|
+| Q1 | continuous | — | — | — |
+| Q1 | windowed | — | — | — |
+| Q1 | snapshot | — | — | — |
+| Q2 | continuous | — | — | — |
+| Q2 | windowed | — | — | — |
+| Q2 | snapshot | — | — | — |
+| Q3 | continuous | — | — | — |
+| Q3 | windowed | — | — | — |
+| Q3 | snapshot | — | — | — |
+| Q4 | continuous | — | — | — |
+| Q4 | windowed | — | — | — |
+| Q4 | snapshot | — | — | — |
+| Q5 | continuous | — | — | — |
+| Q5 | windowed | — | — | — |
+| Q5 | snapshot | — | — | — |
+| Q6 | continuous | — | — | — |
+| Q6 | windowed | — | — | — |
+| Q6 | snapshot | — | — | — |
+| Q7 | continuous | — | — | — |
+| Q7 | windowed | — | — | — |
+| Q7 | snapshot | — | — | — |
+| Q8 | continuous | — | — | — |
+| Q8 | windowed | — | — | — |
+| Q8 | snapshot | — | — | — |
+| Q9 | continuous | — | — | — |
+| Q9 | windowed | — | — | — |
+| Q9 | snapshot | — | — | — |
+
+### Throughput charts (events/s, log scale, higher is better)
+
+One grouped bar chart per streaming form, all three engines on the same corpus.
+
+![Continuous-form streaming throughput](streaming_continuous.svg)
+
+![Windowed-form streaming throughput](streaming_windowed.svg)
+
+![Snapshot-form streaming throughput](streaming_snapshot.svg)
+
+## Reading the results
+
+Filled once the runs land. Expected shape: the per-event spatial cells
+(Q3/Q8/Q9-continuous) are the throughput floor; the non-spatial Q1/Q2 cells the
+ceiling. Q5-continuous enumerates every meeting pair across all vehicles on each
+event (O(V²) per event), so it is the floor on each engine. The snapshot form is
+sampled, so a within-`P` snapshot can be empty when no vehicle is within `d` of
 `P` at a tick boundary even though the continuous form reports near-`P` events
 between boundaries.
 
-Kafka Streams routes every record through the broker (produce then fetch), so its
-per-event spatial cells (Q3/Q8/Q9-continuous) run below Flink's in-JVM
-mini-cluster pipeline on the same corpus, while the per-cell shape matches across
-both engines — the O(V²) Q5-continuous is the floor and the non-spatial Q1/Q2
-cells the ceiling.
+## Parity with the DB benchmark
+
+The continuous form emits `predicate(event)` for every event, checked
+event-for-event against a batch pass over the same corpus through the same MEOS
+call — the cross-family link to the
+[3-DB benchmark](../CrossPlatform_timings_2026-05-12.md), whose batch result is
+the oracle. A query is `exact` when streaming-true equals batch-true with zero
+mismatches.
+
+| Query | Events | Streaming-true | Batch-true | Mismatches | Parity |
+|---|---:|---:|---:|---:|---|
+| Q3 (`edwithin_tgeo_geo`, within `d` of `P`) | — | — | — | — | — |
+| Q8 (`edwithin_tgeo_geo`, within `d` of segment) | — | — | — | — | — |
+
+## Contributing your numbers
+
+Each engine owns one column of the throughput grid and its parity rows.
+
+1. Run your harness over the corpus (links under [Methodology](#dataset-hardware-methodology)),
+   producing one throughput value per (query, form).
+2. Fill your engine's column in the **Results** grid and, for the continuous
+   spatial queries, your **Parity** counts.
+3. Add your series to
+   [`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) and run
+   `python3 scripts/render_streaming_chart.py` to replace the empty charts.
+
+## Reproduce
+
+Regenerate the charts from
+[`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) — run
+`python3 scripts/render_streaming_chart.py` to refresh all three SVGs. The
+per-engine run harnesses are linked under Methodology.

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings_2026-05-29.md
@@ -1,0 +1,66 @@
+# Cross-platform streaming timings — 2026-05-29
+
+Throughput of the streaming query set across the three stream platforms, per
+(query, form). The Flink column is measured; the Nebula and Kafka columns are
+not yet measured. See [`README.md`](README.md) for the query set, the streaming
+forms, and the shared result schema.
+
+## Method
+
+Each cell runs as one streaming job over a shared synthetic BerlinMOD corpus and
+is terminated by a counting sink; throughput is input events ÷ wall-clock and
+`output rows` is the sink cardinality. The spatial predicates evaluate through
+MEOS. The Flink figures below are a 30 000-event corpus (50 vehicles × 600
+events over 600 s of event time) on a single-node Flink 1.16 local mini-cluster,
+parallelism 1, Java 21, 16-core x86-64 Linux, with libmeos built
+`-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON`. The wall-clock includes
+the per-job mini-cluster startup (~0.7–0.8 s), so these are end-to-end job
+throughputs; the steady-state row below amortises startup over a larger corpus.
+
+## Throughput (events/s) and output rows
+
+| Query | Form | Flink events in | Flink output rows | Flink ev/s | Nebula ev/s | Kafka ev/s |
+|---|---|---:|---:|---:|---:|---:|
+| Q1 | continuous | 30000 | 50 | 13,435 | — | — |
+| Q1 | windowed | 30000 | 60 | 28,169 | — | — |
+| Q1 | snapshot | 30000 | 6000 | 33,520 | — | — |
+| Q2 | continuous | 30000 | 600 | 37,594 | — | — |
+| Q2 | windowed | 30000 | 60 | 39,894 | — | — |
+| Q2 | snapshot | 30000 | 120 | 38,810 | — | — |
+| Q3 | continuous | 30000 | 30000 | 19,023 | — | — |
+| Q3 | windowed | 30000 | 60 | 23,603 | — | — |
+| Q3 | snapshot | 30000 | 3120 | 34,722 | — | — |
+| Q4 | continuous | 30000 | 8 | 27,248 | — | — |
+| Q4 | windowed | 30000 | 480 | 26,525 | — | — |
+| Q4 | snapshot | 30000 | 960 | 27,959 | — | — |
+| Q5 | continuous | 30000 | 7171498 | 403 | — | — |
+| Q5 | windowed | 30000 | 14359 | 32,787 | — | — |
+| Q5 | snapshot | 30000 | 29640 | 27,804 | — | — |
+| Q6 | continuous | 30000 | 30000 | 29,326 | — | — |
+| Q6 | windowed | 30000 | 3000 | 31,283 | — | — |
+| Q6 | snapshot | 30000 | 6000 | 32,293 | — | — |
+| Q7 | continuous | 30000 | 15 | 23,585 | — | — |
+| Q7 | windowed | 30000 | 766 | 23,006 | — | — |
+| Q7 | snapshot | 30000 | 1790 | 20,422 | — | — |
+| Q8 | continuous | 30000 | 30000 | 28,763 | — | — |
+| Q8 | windowed | 30000 | 60 | 29,528 | — | — |
+| Q8 | snapshot | 30000 | 3720 | 36,320 | — | — |
+| Q9 | continuous | 30000 | 1199 | 39,012 | — | — |
+| Q9 | windowed | 30000 | 60 | 37,927 | — | — |
+| Q9 | snapshot | 30000 | 120 | 42,493 | — | — |
+
+## Steady-state per-event predicate
+
+Q3-continuous applies one MEOS `edwithin_tgeo_geo` per event. Over a
+200 000-event corpus with the per-job startup amortised:
+
+| Query | Form | Flink events in | Flink output rows | Flink ev/s |
+|---|---|---:|---:|---:|
+| Q3 | continuous | 200000 | 200000 | 45,096 |
+
+## Characteristics
+
+Q5-continuous enumerates every meeting pair across all vehicles on each event
+(O(V²) per event, keyed to a single subtask), producing 7 171 498 rows from
+30 000 events — the lowest throughput, inherent to the all-pairs meeting query
+rather than to the predicate path.

--- a/BerlinMOD/benchmarks/streaming/README.md
+++ b/BerlinMOD/benchmarks/streaming/README.md
@@ -78,7 +78,7 @@ flink,Q3,snapshot,30000,3120,34722,
 
 - **Flink** — [`BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java); figures in [`benchmark-results.md`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/docs/benchmark-results.md).
 - **Nebula** — `systest -b -g benchmark` → [bench.nebula.stream](https://bench.nebula.stream); queries in [`MobilityNebula/Queries`](https://github.com/MobilityDB/MobilityNebula/tree/main/Queries).
-- **Kafka** — shares the Flink `MEOSBridge` over JMEOS.
+- **Kafka** — [`EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java) over an in-process `EmbeddedKafkaCluster`; shares the Flink `MEOSBridge` over JMEOS; figures in [`benchmark.md`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/docs/benchmark.md).
 
 The cross-platform comparison is in
 [`CrossPlatform_streaming_timings_2026-05-29.md`](CrossPlatform_streaming_timings_2026-05-29.md).

--- a/BerlinMOD/benchmarks/streaming/README.md
+++ b/BerlinMOD/benchmarks/streaming/README.md
@@ -1,0 +1,84 @@
+# BerlinMOD streaming benchmark (3-stream)
+
+The streaming sibling of the cross-platform BerlinMOD benchmark. The 3-DB
+benchmark (`../`) runs the BerlinMOD/r queries as batch SQL on PostgreSQL
+(MobilityDB), DuckDB (MobilityDuck), and Spark (MobilitySpark) and requires
+identical results. This benchmark runs a streaming query set on the three
+stream platforms — Flink (MobilityFlink), Kafka (MobilityKafka), and
+NebulaStream (MobilityNebula) — in three streaming forms, and measures
+throughput.
+
+The Flink and Kafka platforms reach MEOS through a single `MEOSBridge` over
+[JMEOS](https://github.com/MobilityDB/JMEOS); MobilityNebula calls MEOS C
+directly. Every spatial predicate is a MEOS operator (`edwithin_tgeo_geo`,
+`eintersects_tgeo_geo`, `geog_distance`) — the streaming layer contributes no
+spatial mathematics of its own.
+
+## Streaming forms
+
+| Form | Question | Notes |
+|---|---|---|
+| Continuous | "At every moment, which holds now?" | per-event output, watermark-independent |
+| Windowed | "Per tumbling window, what holds?" | event-time tumbling window |
+| Snapshot | "At time T, what holds?" | watermark-driven; the parity oracle |
+
+The **snapshot form is the bridge to the 3-DB benchmark**: by contract, for a
+spatial-selection query the streaming snapshot at watermark `T` equals the batch
+BerlinMOD result on the same data up to `T` at the same scale factor. Where a
+streaming query has a batch analog, its snapshot output cardinality is checked
+against the 3-DB result as the oracle.
+
+## Streaming query set
+
+The streaming set has its own numbering and intents; it is **not** the
+BerlinMOD/r numbering. It covers a 9-query subset of the BerlinMOD intents in
+forms suited to streaming. The `r-query` column records the canonical
+BerlinMOD/r analog where one exists, and is left blank for streaming-only
+queries.
+
+| # | Streaming intent | MEOS operator | BerlinMOD/r analog |
+|---|---|---|---|
+| Q1 | Which vehicles have been seen | — | — (stream enumeration) |
+| Q2 | A target vehicle's positions | id filter | cf. r-Q3 (where have given vehicles been) |
+| Q3 | Vehicles within `d` of point `P` | `edwithin_tgeo_geo` | cf. r-Q11 / r-Q15 (passed a point) |
+| Q4 | Vehicles entering region `R` | `eintersects_tgeo_geo` | cf. r-Q13 / r-Q14 (within regions) |
+| Q5 | Pairs of vehicles meeting near `P` | `edwithin_tgeo_geo` + `geog_distance` | cf. r-Q12 (met at a point) |
+| Q6 | Cumulative distance per vehicle | `geog_distance` | ≈ r-Q8 (overall travelled distance) |
+| Q7 | Vehicles near points of interest | `edwithin_tgeo_geo` | cf. r-Q4 / r-Q17 (passed / visited points) |
+| Q8 | Vehicles within `d` of a road segment | `edwithin_tgeo_geo` | cf. r-Q4 (passed points) |
+| Q9 | Distance between two vehicles | `geog_distance` | cf. r-Q5 (minimum distance) |
+
+The within-distance query (Q3) is the canonical shared cell: it is
+[`MobilityNebula/Queries/Query1.yaml`](https://github.com/MobilityDB/MobilityNebula/blob/main/Queries/Query1.yaml)
+(`edwithin_tgeo_geo … WINDOW TUMBLING`) and
+[`MobilityFlink` `Q3{Continuous,Windowed,Snapshot}Function`](https://github.com/MobilityDB/MobilityFlink/tree/main/flink-processor/src/main/java/berlinmod),
+expressed through the same MEOS operator on both engines.
+
+## Shared result schema
+
+Each platform's harness emits one row per (query, form) with these fields, so
+the three emissions join into the comparison table without hand-merging:
+
+| Field | Meaning |
+|---|---|
+| `engine` | flink \| kafka \| nebula |
+| `query` | Q1 … Q9 |
+| `form` | continuous \| windowed \| snapshot |
+| `events_in` | input events fed to the job |
+| `output_rows` | rows emitted to the sink |
+| `throughput_eps` | `events_in` ÷ wall-clock, events per second |
+| `snapshot_equals_batch` | for the snapshot form: whether output matches the 3-DB oracle (else blank) |
+
+```
+engine,query,form,events_in,output_rows,throughput_eps,snapshot_equals_batch
+flink,Q3,snapshot,30000,3120,34722,
+```
+
+## Per-platform harnesses
+
+- **Flink** — [`BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java); figures in [`benchmark-results.md`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/docs/benchmark-results.md).
+- **Nebula** — `systest -b -g benchmark` → [bench.nebula.stream](https://bench.nebula.stream); queries in [`MobilityNebula/Queries`](https://github.com/MobilityDB/MobilityNebula/tree/main/Queries).
+- **Kafka** — shares the Flink `MEOSBridge` over JMEOS.
+
+The cross-platform comparison is in
+[`CrossPlatform_streaming_timings_2026-05-29.md`](CrossPlatform_streaming_timings_2026-05-29.md).

--- a/BerlinMOD/benchmarks/streaming/scripts/render_streaming_chart.py
+++ b/BerlinMOD/benchmarks/streaming/scripts/render_streaming_chart.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Render the cross-platform BerlinMOD streaming throughput as grouped bar SVGs.
+
+Reads the throughput matrix from the literal definitions below (one source of
+truth, kept in step with ``CrossPlatform_streaming_timings_2026-05-29.md``) and
+emits one SVG per streaming form:
+
+- streaming_continuous.svg
+- streaming_windowed.svg
+- streaming_snapshot.svg
+
+Each query gets one coloured bar per platform (higher is better). The y axis is
+logarithmic so the O(V^2) Q5-continuous floor does not collapse the fast cells.
+A ``None`` timing means the platform has not been measured for that cell and is
+rendered as a flat ``n/a`` marker at the y-axis floor (the Nebula column is not
+yet measured).
+
+Run ``python3 scripts/render_streaming_chart.py`` to refresh all three SVGs.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+QUERIES = [f"Q{i}" for i in range(1, 10)]
+FORMS = ["continuous", "windowed", "snapshot"]
+
+
+@dataclass(frozen=True)
+class Series:
+    label: str
+    color: str
+    # form -> {query -> events/s, or None when not measured}
+    throughput: dict[str, dict[str, float | None]]
+
+
+# Throughput in events/s, on the 216 075-instant real BerlinMOD corpus.
+FLINK = Series("Flink (MobilityFlink)", "#1f77b4", {
+    "continuous": {"Q1": 86154, "Q2": 201187, "Q3": 73796, "Q4": 66403,
+                   "Q5": 23586, "Q6": 90712, "Q7": 54386, "Q8": 74948,
+                   "Q9": 116294},
+    "windowed":   {"Q1": 166982, "Q2": 210394, "Q3": 86189, "Q4": 66814,
+                   "Q5": 226494, "Q6": 81940, "Q7": 43180, "Q8": 75445,
+                   "Q9": 233847},
+    "snapshot":   {"Q1": 204616, "Q2": 219365, "Q3": 233342, "Q4": 67042,
+                   "Q5": 236148, "Q6": 97595, "Q7": 54967, "Q8": 232839,
+                   "Q9": 217818},
+})
+
+KAFKA = Series("Kafka (MobilityKafka)", "#ff7f0e", {
+    "continuous": {"Q1": 113785, "Q2": 167631, "Q3": 46790, "Q4": 23095,
+                   "Q5": 9440, "Q6": 24814, "Q7": 50006, "Q8": 44950,
+                   "Q9": 47375},
+    "windowed":   {"Q1": 130956, "Q2": 126806, "Q3": 51594, "Q4": 22182,
+                   "Q5": 74612, "Q6": 34473, "Q7": 18587, "Q8": 36340,
+                   "Q9": 90636},
+    "snapshot":   {"Q1": 127029, "Q2": 128388, "Q3": 82883, "Q4": 20581,
+                   "Q5": 107715, "Q6": 29771, "Q7": 28860, "Q8": 76487,
+                   "Q9": 94729},
+})
+
+# The Nebula (MobilityNebula) column is not yet measured, so it is omitted from
+# the bars; the n/a handling below stays for any future partially-measured row.
+SERIES = [FLINK, KAFKA]
+
+
+def render(form: str, out: Path) -> None:
+    n = len(QUERIES)
+    k = len(SERIES)
+    width = 0.8 / k
+    x = np.arange(n)
+    floor = 1000.0  # log-scale lower bound (1k ev/s); render missing values here
+
+    fig, ax = plt.subplots(figsize=(max(8, n * 0.9), 5.0), dpi=120)
+    for i, s in enumerate(SERIES):
+        offsets = x - 0.4 + width * (i + 0.5)
+        heights, kinds = [], []
+        for q in QUERIES:
+            v = s.throughput[form].get(q)
+            if v is None or v <= 0:
+                heights.append(floor)
+                kinds.append("na")
+            else:
+                heights.append(float(v))
+                kinds.append("value")
+        ax.bar(offsets, heights, width=width * 0.92, color=s.color,
+               label=s.label, edgecolor="white", linewidth=0.5)
+        for off, kind in zip(offsets, kinds):
+            if kind == "na":
+                ax.text(off, floor * 1.4, "n/a", ha="center", va="bottom",
+                        fontsize=7, color="#666666", rotation=90)
+
+    ax.set_yscale("log")
+    numeric_max = max(
+        (v for s in SERIES for v in s.throughput[form].values()
+         if isinstance(v, (int, float)) and v > 0),
+        default=floor,
+    )
+    ax.set_ylim(floor, numeric_max * 1.8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(QUERIES)
+    ax.set_xlabel("BerlinMOD streaming query")
+    ax.set_ylabel("Throughput events/s (log scale, higher is better)")
+    ax.set_title(f"BerlinMOD streaming throughput — {form} form "
+                 "(216,075-instant real corpus)")
+    ax.grid(True, which="both", axis="y", alpha=0.3)
+    ax.legend(loc="upper right", fontsize=9, ncol=1)
+    fig.tight_layout()
+    fig.savefig(out, format="svg")
+    plt.close(fig)
+    print(f"wrote {out}")
+
+
+def main() -> int:
+    here = Path(__file__).parent.parent
+    for form in FORMS:
+        render(form, here / f"streaming_{form}.svg")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/BerlinMOD/benchmarks/streaming/streaming_continuous.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_continuous.svg
@@ -1,0 +1,1818 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-01T14:04:19.264235</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 583.2 360 
+L 583.2 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+L 572.4 25.8 
+L 50.610298 25.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 74.328012 114301.337083 
+L 94.237041 114301.337083 
+L 94.237041 96.667933 
+L 74.328012 96.667933 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 128.428636 114301.337083 
+L 148.337666 114301.337083 
+L 148.337666 54.810139 
+L 128.428636 54.810139 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 182.52926 114301.337083 
+L 202.43829 114301.337083 
+L 202.43829 104.309641 
+L 182.52926 104.309641 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 236.629885 114301.337083 
+L 256.538915 114301.337083 
+L 256.538915 109.519655 
+L 236.629885 109.519655 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 290.730509 114301.337083 
+L 310.639539 114301.337083 
+L 310.639539 160.606342 
+L 290.730509 160.606342 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 344.831134 114301.337083 
+L 364.740163 114301.337083 
+L 364.740163 94.123528 
+L 344.831134 94.123528 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 398.931758 114301.337083 
+L 418.840788 114301.337083 
+L 418.840788 119.372639 
+L 398.931758 119.372639 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 453.032382 114301.337083 
+L 472.941412 114301.337083 
+L 472.941412 103.545133 
+L 453.032382 103.545133 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 507.133007 114301.337083 
+L 527.042037 114301.337083 
+L 527.042037 81.862207 
+L 507.133007 81.862207 
+z
+" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 95.968261 114301.337083 
+L 115.877291 114301.337083 
+L 115.877291 82.938674 
+L 95.968261 82.938674 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 150.068886 114301.337083 
+L 169.977916 114301.337083 
+L 169.977916 63.815908 
+L 150.068886 63.815908 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 204.16951 114301.337083 
+L 224.07854 114301.337083 
+L 224.07854 126.797452 
+L 204.16951 126.797452 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 258.270135 114301.337083 
+L 278.179164 114301.337083 
+L 278.179164 161.644629 
+L 258.270135 161.644629 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 312.370759 114301.337083 
+L 332.279789 114301.337083 
+L 332.279789 205.800472 
+L 312.370759 205.800472 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 366.471383 114301.337083 
+L 386.380413 114301.337083 
+L 386.380413 158.10135 
+L 366.471383 158.10135 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 420.572008 114301.337083 
+L 440.481037 114301.337083 
+L 440.481037 123.516661 
+L 420.572008 123.516661 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 474.672632 114301.337083 
+L 494.581662 114301.337083 
+L 494.581662 128.777508 
+L 474.672632 128.777508 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 528.773256 114301.337083 
+L 548.682286 114301.337083 
+L 548.682286 126.18421 
+L 528.773256 126.18421 
+z
+" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m6a38a5f173" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6a38a5f173" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Q1 -->
+      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Q2 -->
+      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Q3 -->
+      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Q4 -->
+      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Q5 -->
+      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- Q6 -->
+      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- Q7 -->
+      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Q8 -->
+      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m6a38a5f173" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- Q9 -->
+      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- BerlinMOD streaming query -->
+     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="m923338c76a" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m923338c76a" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.610298 202.956194 
+L 572.4 202.956194 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m923338c76a" x="50.610298" y="202.956194" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(26.010298 206.755413) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.610298 89.312389 
+L 572.4 89.312389 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m923338c76a" x="50.610298" y="89.312389" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(26.010298 93.111607) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.610298 282.389806 
+L 572.4 282.389806 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <defs>
+       <path id="m9a33373bde" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="282.389806" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.610298 262.378125 
+L 572.4 262.378125 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="262.378125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.610298 248.179611 
+L 572.4 248.179611 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="248.179611" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.610298 237.166389 
+L 572.4 237.166389 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="237.166389" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.610298 228.167931 
+L 572.4 228.167931 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="228.167931" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.610298 220.559843 
+L 572.4 220.559843 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="220.559843" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.610298 213.969417 
+L 572.4 213.969417 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="213.969417" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.610298 208.15625 
+L 572.4 208.15625 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="208.15625" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.610298 168.746 
+L 572.4 168.746 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="168.746" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.610298 148.734319 
+L 572.4 148.734319 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="148.734319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.610298 134.535806 
+L 572.4 134.535806 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="134.535806" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.610298 123.522583 
+L 572.4 123.522583 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="123.522583" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.610298 114.524125 
+L 572.4 114.524125 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="114.524125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.610298 106.916037 
+L 572.4 106.916037 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="106.916037" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.610298 100.325611 
+L 572.4 100.325611 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="100.325611" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.610298 94.512444 
+L 572.4 94.512444 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="94.512444" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.610298 55.102194 
+L 572.4 55.102194 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="55.102194" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.610298 35.090514 
+L 572.4 35.090514 
+" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m9a33373bde" x="50.610298" y="35.090514" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput events/s (log scale, higher is better) -->
+     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(124.462891 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(163.326172 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(224.507812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(287.886719 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(351.363281 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(414.742188 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_21">
+    <path d="M 50.610298 316.6 
+L 50.610298 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 572.4 316.6 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 50.610298 25.8 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- BerlinMOD streaming throughput — continuous form (216,075-instant real corpus) -->
+    <g transform="translate(63.518586 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1823.283203 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1878.263672 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1939.445312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2002.824219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2042.033203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2069.816406 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2133.195312 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2196.574219 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2257.755859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2321.134766 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2373.234375 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2405.021484 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2440.226562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2501.408203 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2540.771484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2638.183594 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2669.970703 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(2708.984375 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2772.607422 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2836.230469 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2899.853516 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2931.640625 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2995.263672 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3058.886719 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3122.509766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3158.59375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3186.376953 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3249.755859 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3301.855469 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3341.064453 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3402.34375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3465.722656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3504.931641 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3536.71875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3575.582031 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3637.105469 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3698.384766 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3726.167969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3757.955078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3812.935547 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3874.117188 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3915.230469 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(3978.707031 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4042.085938 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4094.185547 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_25">
+     <path d="M 442.08 59.420625 
+L 566.1 59.420625 
+Q 567.9 59.420625 567.9 57.620625 
+L 567.9 32.1 
+Q 567.9 30.3 566.1 30.3 
+L 442.08 30.3 
+Q 440.28 30.3 440.28 32.1 
+L 440.28 57.620625 
+Q 440.28 59.420625 442.08 59.420625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_26">
+     <path d="M 443.88 40.738594 
+L 461.88 40.738594 
+L 461.88 34.438594 
+L 443.88 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_16">
+     <!-- Flink (MobilityFlink) -->
+     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 443.88 53.948906 
+L 461.88 53.948906 
+L 461.88 47.648906 
+L 443.88 47.648906 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_17">
+     <!-- Kafka (MobilityKafka) -->
+     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4b"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p885187356c">
+   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/BerlinMOD/benchmarks/streaming/streaming_continuous.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_continuous.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="792pt" height="331.2pt" viewBox="0 0 792 331.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-01T14:04:19.264235</dc:date>
+    <dc:date>2026-06-01T18:04:52.242424</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,181 +21,37 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 583.2 360 
-L 583.2 0 
+   <path d="M 0 331.2 
+L 792 331.2 
+L 792 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
-L 572.4 25.8 
-L 50.610298 25.8 
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
+L 774.09 25.44 
+L 50.092685 25.44 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 74.328012 114301.337083 
-L 94.237041 114301.337083 
-L 94.237041 96.667933 
-L 74.328012 96.667933 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 128.428636 114301.337083 
-L 148.337666 114301.337083 
-L 148.337666 54.810139 
-L 128.428636 54.810139 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 182.52926 114301.337083 
-L 202.43829 114301.337083 
-L 202.43829 104.309641 
-L 182.52926 104.309641 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 236.629885 114301.337083 
-L 256.538915 114301.337083 
-L 256.538915 109.519655 
-L 236.629885 109.519655 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 290.730509 114301.337083 
-L 310.639539 114301.337083 
-L 310.639539 160.606342 
-L 290.730509 160.606342 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 344.831134 114301.337083 
-L 364.740163 114301.337083 
-L 364.740163 94.123528 
-L 344.831134 94.123528 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 398.931758 114301.337083 
-L 418.840788 114301.337083 
-L 418.840788 119.372639 
-L 398.931758 119.372639 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 453.032382 114301.337083 
-L 472.941412 114301.337083 
-L 472.941412 103.545133 
-L 453.032382 103.545133 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 507.133007 114301.337083 
-L 527.042037 114301.337083 
-L 527.042037 81.862207 
-L 507.133007 81.862207 
-z
-" clip-path="url(#p885187356c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 95.968261 114301.337083 
-L 115.877291 114301.337083 
-L 115.877291 82.938674 
-L 95.968261 82.938674 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 150.068886 114301.337083 
-L 169.977916 114301.337083 
-L 169.977916 63.815908 
-L 150.068886 63.815908 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 204.16951 114301.337083 
-L 224.07854 114301.337083 
-L 224.07854 126.797452 
-L 204.16951 126.797452 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 258.270135 114301.337083 
-L 278.179164 114301.337083 
-L 278.179164 161.644629 
-L 258.270135 161.644629 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 312.370759 114301.337083 
-L 332.279789 114301.337083 
-L 332.279789 205.800472 
-L 312.370759 205.800472 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 366.471383 114301.337083 
-L 386.380413 114301.337083 
-L 386.380413 158.10135 
-L 366.471383 158.10135 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 420.572008 114301.337083 
-L 440.481037 114301.337083 
-L 440.481037 123.516661 
-L 420.572008 123.516661 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 474.672632 114301.337083 
-L 494.581662 114301.337083 
-L 494.581662 128.777508 
-L 474.672632 128.777508 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 528.773256 114301.337083 
-L 548.682286 114301.337083 
-L 548.682286 126.18421 
-L 528.773256 126.18421 
-z
-" clip-path="url(#p885187356c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m6a38a5f173" d="M 0 0 
+       <path id="m01938822f6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6a38a5f173" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(42.975497 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -246,12 +102,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m6a38a5f173" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="140.592349" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(133.475162 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -286,12 +142,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m6a38a5f173" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="231.092014" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(223.974826 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -334,12 +190,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6a38a5f173" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="321.591678" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(314.47449 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -369,12 +225,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m6a38a5f173" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="412.091342" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(404.974155 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -410,12 +266,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6a38a5f173" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="502.591007" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(495.473819 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -456,12 +312,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m6a38a5f173" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="593.090671" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(585.973484 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -482,12 +338,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6a38a5f173" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="683.590336" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(676.473148 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -537,12 +393,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m6a38a5f173" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01938822f6" x="774.09" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(766.972813 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -580,65 +436,441 @@ z
       </g>
      </g>
     </g>
-    <g id="text_10">
-     <!-- BerlinMOD streaming query -->
-     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.092685 303.32 
+L 774.09 303.32 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <defs>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
+       <path id="m748da48f22" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m748da48f22" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(25.492685 307.119219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
 z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.092685 210.693333 
+L 774.09 210.693333 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m748da48f22" x="50.092685" y="210.693333" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(25.492685 214.492552) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.092685 118.066667 
+L 774.09 118.066667 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m748da48f22" x="50.092685" y="118.066667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(25.492685 121.865885) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.092685 25.44 
+L 774.09 25.44 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m748da48f22" x="50.092685" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(25.492685 29.239219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.092685 275.436595 
+L 774.09 275.436595 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <defs>
+       <path id="m1dcceb7d46" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="275.436595" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.092685 259.125849 
+L 774.09 259.125849 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="259.125849" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.092685 247.55319 
+L 774.09 247.55319 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="247.55319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.092685 238.576738 
+L 774.09 238.576738 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="238.576738" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.092685 231.242444 
+L 774.09 231.242444 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="231.242444" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.092685 225.041386 
+L 774.09 225.041386 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="225.041386" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.092685 219.669785 
+L 774.09 219.669785 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="219.669785" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.092685 214.931697 
+L 774.09 214.931697 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="214.931697" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.092685 182.809928 
+L 774.09 182.809928 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="182.809928" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.092685 166.499182 
+L 774.09 166.499182 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="166.499182" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.092685 154.926523 
+L 774.09 154.926523 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="154.926523" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.092685 145.950072 
+L 774.09 145.950072 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="145.950072" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.092685 138.615777 
+L 774.09 138.615777 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="138.615777" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.092685 132.414719 
+L 774.09 132.414719 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="132.414719" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.092685 127.043118 
+L 774.09 127.043118 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="127.043118" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.092685 122.30503 
+L 774.09 122.30503 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="122.30503" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.092685 90.183262 
+L 774.09 90.183262 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="90.183262" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 50.092685 73.872515 
+L 774.09 73.872515 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="73.872515" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_54">
+      <path d="M 50.092685 62.299857 
+L 774.09 62.299857 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="62.299857" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_56">
+      <path d="M 50.092685 53.323405 
+L 774.09 53.323405 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="53.323405" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_58">
+      <path d="M 50.092685 45.98911 
+L 774.09 45.98911 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="45.98911" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_60">
+      <path d="M 50.092685 39.788052 
+L 774.09 39.788052 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="39.788052" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_62">
+      <path d="M 50.092685 34.416451 
+L 774.09 34.416451 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="34.416451" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_64">
+      <path d="M 50.092685 29.678364 
+L 774.09 29.678364 
+" clip-path="url(#pd23112239a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m1dcceb7d46" x="50.092685" y="29.678364" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput (events/s) -->
+     <g transform="translate(19.412997 220.045625) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
 z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-72" d="M 2631 2963 
@@ -658,215 +890,47 @@ Q 2541 3569 2628 3553
 L 2631 2963 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
 z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-44" d="M 1259 4147 
-L 1259 519 
-L 2022 519 
-Q 2988 519 3436 956 
-Q 3884 1394 3884 2338 
-Q 3884 3275 3436 3711 
-Q 2988 4147 2022 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 1925 4666 
-Q 3281 4666 3915 4102 
-Q 4550 3538 4550 2338 
-Q 4550 1131 3912 565 
-Q 3275 0 1925 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-67" d="M 2906 1791 
@@ -903,465 +967,6 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-71" d="M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-M 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-L 2906 3500 
-L 3481 3500 
-L 3481 -1331 
-L 2906 -1331 
-L 2906 525 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-42"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
-      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
-      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_10">
-      <path d="M 50.610298 316.6 
-L 572.4 316.6 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_11">
-      <defs>
-       <path id="m923338c76a" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m923338c76a" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_12">
-      <path d="M 50.610298 202.956194 
-L 572.4 202.956194 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m923338c76a" x="50.610298" y="202.956194" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(26.010298 206.755413) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_14">
-      <path d="M 50.610298 89.312389 
-L 572.4 89.312389 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m923338c76a" x="50.610298" y="89.312389" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(26.010298 93.111607) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_16">
-      <path d="M 50.610298 282.389806 
-L 572.4 282.389806 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_17">
-      <defs>
-       <path id="m9a33373bde" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="282.389806" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_18">
-      <path d="M 50.610298 262.378125 
-L 572.4 262.378125 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="262.378125" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_20">
-      <path d="M 50.610298 248.179611 
-L 572.4 248.179611 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="248.179611" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_22">
-      <path d="M 50.610298 237.166389 
-L 572.4 237.166389 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="237.166389" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_24">
-      <path d="M 50.610298 228.167931 
-L 572.4 228.167931 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="228.167931" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_26">
-      <path d="M 50.610298 220.559843 
-L 572.4 220.559843 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="220.559843" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_28">
-      <path d="M 50.610298 213.969417 
-L 572.4 213.969417 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="213.969417" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_11">
-     <g id="line2d_30">
-      <path d="M 50.610298 208.15625 
-L 572.4 208.15625 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="208.15625" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_32">
-      <path d="M 50.610298 168.746 
-L 572.4 168.746 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="168.746" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_13">
-     <g id="line2d_34">
-      <path d="M 50.610298 148.734319 
-L 572.4 148.734319 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="148.734319" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_36">
-      <path d="M 50.610298 134.535806 
-L 572.4 134.535806 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="134.535806" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_38">
-      <path d="M 50.610298 123.522583 
-L 572.4 123.522583 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="123.522583" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_40">
-      <path d="M 50.610298 114.524125 
-L 572.4 114.524125 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="114.524125" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_17">
-     <g id="line2d_42">
-      <path d="M 50.610298 106.916037 
-L 572.4 106.916037 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="106.916037" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_18">
-     <g id="line2d_44">
-      <path d="M 50.610298 100.325611 
-L 572.4 100.325611 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="100.325611" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_19">
-     <g id="line2d_46">
-      <path d="M 50.610298 94.512444 
-L 572.4 94.512444 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="94.512444" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_20">
-     <g id="line2d_48">
-      <path d="M 50.610298 55.102194 
-L 572.4 55.102194 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="55.102194" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_21">
-     <g id="line2d_50">
-      <path d="M 50.610298 35.090514 
-L 572.4 35.090514 
-" clip-path="url(#p885187356c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#m9a33373bde" x="50.610298" y="35.090514" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
-     <!-- Throughput events/s (log scale, higher is better) -->
-     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
        <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
@@ -1388,23 +993,28 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
        <path id="DejaVuSans-28" d="M 1984 4856 
 Q 1566 4138 1362 3434 
 Q 1159 2731 1159 2009 
@@ -1418,60 +1028,96 @@ Q 1013 4119 1484 4856
 L 1984 4856 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2c" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
 L 1159 0 
 L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-29" d="M 513 4856 
@@ -1499,76 +1145,659 @@ z
       <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
-      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(651.607422 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(713.130859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(772.310547 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(833.833984 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(897.212891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(936.421875 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(988.521484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1022.212891 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1074.3125 0)"/>
      </g>
     </g>
    </g>
-   <g id="patch_21">
-    <path d="M 50.610298 316.6 
-L 50.610298 25.8 
+   <g id="patch_3">
+    <path d="M 50.092685 303.32 
+L 50.092685 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_22">
-    <path d="M 572.4 316.6 
-L 572.4 25.8 
+   <g id="patch_4">
+    <path d="M 774.09 303.32 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_23">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
+   <g id="patch_5">
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_24">
-    <path d="M 50.610298 25.8 
-L 572.4 25.8 
+   <g id="patch_6">
+    <path d="M 50.092685 25.44 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_15">
-    <!-- BerlinMOD streaming throughput — continuous form (216,075-instant real corpus) -->
-    <g transform="translate(63.518586 19.8) scale(0.12 -0.12)">
+    <!-- awaiting benchmark numbers -->
+    <g style="fill: #b0b0b0" transform="translate(301.53262 184.097755) rotate(-8) scale(0.15 -0.15)">
      <defs>
+      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-77" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-69" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-68" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-75" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-73" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-61"/>
+     <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(143.066406 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(204.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(232.128906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(271.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(299.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(362.5 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(425.976562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(457.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(521.240234 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(582.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(646.142578 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(701.123047 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(764.501953 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(861.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(923.193359 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(964.306641 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1022.216797 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1054.003906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1117.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(1180.761719 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1278.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1341.650391 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1403.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1444.287109 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- BerlinMOD stream throughput — continuous form (log scale, higher is better) -->
+    <g transform="translate(199.300639 19.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
 L 6088 1528 
 L 313 1528 
 L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-66" d="M 2375 4863 
@@ -1592,11 +1821,39 @@ Q 1241 4863 1831 4863
 L 2375 4863 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1616,96 +1873,124 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1823.283203 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1878.263672 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1939.445312 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2002.824219 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2042.033203 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2069.816406 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(2133.195312 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2196.574219 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(2257.755859 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2321.134766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2373.234375 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2405.021484 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2440.226562 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2501.408203 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2540.771484 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2638.183594 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(2669.970703 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(2708.984375 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(2772.607422 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(2836.230469 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(2899.853516 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2931.640625 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(2995.263672 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(3058.886719 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(3122.509766 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3158.59375 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3186.376953 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3249.755859 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3301.855469 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3341.064453 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3402.34375 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3465.722656 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3504.931641 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3536.71875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3575.582031 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3637.105469 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3698.384766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3726.167969 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3757.955078 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3812.935547 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3874.117188 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(3915.230469 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(3978.707031 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4042.085938 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(4094.185547 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(946.138672 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(985.347656 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1048.726562 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1087.589844 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1148.771484 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1212.150391 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1275.626953 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1339.005859 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1402.482422 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1465.861328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1505.070312 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1536.857422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1636.857422 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1668.644531 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1723.625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1784.806641 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1848.185547 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1887.394531 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1915.177734 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1978.556641 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2041.935547 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2103.117188 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2166.496094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2218.595703 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2250.382812 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2285.587891 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2346.769531 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2386.132812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2483.544922 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2515.332031 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2554.345703 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2582.128906 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2643.310547 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2706.787109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2738.574219 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2790.673828 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2845.654297 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2906.933594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2934.716797 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2996.240234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3028.027344 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3059.814453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3123.193359 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(3150.976562 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3214.453125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3277.832031 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3339.355469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3380.46875 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3412.255859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3440.039062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3492.138672 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3523.925781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3587.402344 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3648.925781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3688.134766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3727.34375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3788.867188 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3829.980469 0)"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_25">
-     <path d="M 442.08 59.420625 
-L 566.1 59.420625 
-Q 567.9 59.420625 567.9 57.620625 
-L 567.9 32.1 
-Q 567.9 30.3 566.1 30.3 
-L 442.08 30.3 
-Q 440.28 30.3 440.28 32.1 
-L 440.28 57.620625 
-Q 440.28 59.420625 442.08 59.420625 
+    <g id="patch_7">
+     <path d="M 671.944219 86.449063 
+L 767.79 86.449063 
+Q 769.59 86.449063 769.59 84.649063 
+L 769.59 31.74 
+Q 769.59 29.94 767.79 29.94 
+L 671.944219 29.94 
+Q 670.144219 29.94 670.144219 31.74 
+L 670.144219 84.649063 
+Q 670.144219 86.449063 671.944219 86.449063 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="patch_26">
-     <path d="M 443.88 40.738594 
-L 461.88 40.738594 
-L 461.88 34.438594 
-L 443.88 34.438594 
+    <g id="text_17">
+     <!-- platforms -->
+     <g transform="translate(696.017109 41.138438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.539062 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(191.748047 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(226.953125 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(288.134766 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(327.498047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(424.910156 0)"/>
+     </g>
+    </g>
+    <g id="patch_8">
+     <path d="M 673.744219 54.556719 
+L 691.744219 54.556719 
+L 691.744219 48.256719 
+L 673.744219 48.256719 
 z
-" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #3a7bd5; stroke: #3a7bd5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_16">
-     <!-- Flink (MobilityFlink) -->
-     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+    <g id="text_18">
+     <!-- MobilityFlink -->
+     <g transform="translate(698.944219 54.556719) scale(0.09 -0.09)">
       <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-46" d="M 628 4666 
 L 3309 4666 
 L 3309 4134 
@@ -1734,40 +2019,32 @@ L 581 4863
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
-      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(450.195312 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(477.978516 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(505.761719 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(569.140625 0)"/>
      </g>
     </g>
-    <g id="patch_27">
-     <path d="M 443.88 53.948906 
-L 461.88 53.948906 
-L 461.88 47.648906 
-L 443.88 47.648906 
+    <g id="patch_9">
+     <path d="M 673.744219 67.767031 
+L 691.744219 67.767031 
+L 691.744219 61.467031 
+L 673.744219 61.467031 
 z
-" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #e07b39; stroke: #e07b39; stroke-linejoin: miter"/>
     </g>
-    <g id="text_17">
-     <!-- Kafka (MobilityKafka) -->
-     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+    <g id="text_19">
+     <!-- MobilityKafka -->
+     <g transform="translate(698.944219 67.767031) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-4b" d="M 628 4666 
 L 1259 4666 
@@ -1784,35 +2061,69 @@ L 628 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
-      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(456.501953 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(517.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(552.986328 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(609.146484 0)"/>
+     </g>
+    </g>
+    <g id="patch_10">
+     <path d="M 673.744219 80.977344 
+L 691.744219 80.977344 
+L 691.744219 74.677344 
+L 673.744219 74.677344 
+z
+" style="fill: #1f9e6e; stroke: #1f9e6e; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- MobilityNebula -->
+     <g transform="translate(698.944219 80.977344) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(467.480469 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(529.003906 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(592.480469 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(655.859375 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(683.642578 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p885187356c">
-   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  <clipPath id="pd23112239a">
+   <rect x="50.092685" y="25.44" width="723.997315" height="277.88"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/streaming/streaming_snapshot.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_snapshot.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="792pt" height="331.2pt" viewBox="0 0 792 331.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-01T14:04:19.643834</dc:date>
+    <dc:date>2026-06-01T18:04:53.740390</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,181 +21,37 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 583.2 360 
-L 583.2 0 
+   <path d="M 0 331.2 
+L 792 331.2 
+L 792 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
-L 572.4 25.8 
-L 50.610298 25.8 
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
+L 774.09 25.44 
+L 50.092685 25.44 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 74.328012 111283.766197 
-L 94.237041 111283.766197 
-L 94.237041 60.928597 
-L 74.328012 60.928597 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 128.428636 111283.766197 
-L 148.337666 111283.766197 
-L 148.337666 57.584342 
-L 128.428636 57.584342 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 182.52926 111283.766197 
-L 202.43829 111283.766197 
-L 202.43829 54.616487 
-L 182.52926 54.616487 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 236.629885 111283.766197 
-L 256.538915 111283.766197 
-L 256.538915 114.541628 
-L 236.629885 114.541628 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 290.730509 111283.766197 
-L 310.639539 111283.766197 
-L 310.639539 54.04214 
-L 290.730509 54.04214 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 344.831134 111283.766197 
-L 364.740163 111283.766197 
-L 364.740163 96.499163 
-L 344.831134 96.499163 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 398.931758 111283.766197 
-L 418.840788 111283.766197 
-L 418.840788 124.083358 
-L 398.931758 124.083358 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 453.032382 111283.766197 
-L 472.941412 111283.766197 
-L 472.941412 54.720173 
-L 453.032382 54.720173 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 507.133007 111283.766197 
-L 527.042037 111283.766197 
-L 527.042037 57.924387 
-L 507.133007 57.924387 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 95.968261 111283.766197 
-L 115.877291 111283.766197 
-L 115.877291 83.834157 
-L 95.968261 83.834157 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 150.068886 111283.766197 
-L 169.977916 111283.766197 
-L 169.977916 83.32285 
-L 150.068886 83.32285 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 204.16951 111283.766197 
-L 224.07854 111283.766197 
-L 224.07854 104.350074 
-L 204.16951 104.350074 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 258.270135 111283.766197 
-L 278.179164 111283.766197 
-L 278.179164 171.284295 
-L 258.270135 171.284295 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 312.370759 111283.766197 
-L 332.279789 111283.766197 
-L 332.279789 91.758595 
-L 312.370759 91.758595 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 366.471383 111283.766197 
-L 386.380413 111283.766197 
-L 386.380413 153.546481 
-L 366.471383 153.546481 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 420.572008 111283.766197 
-L 440.481037 111283.766197 
-L 440.481037 155.039736 
-L 420.572008 155.039736 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 474.672632 111283.766197 
-L 494.581662 111283.766197 
-L 494.581662 108.208792 
-L 474.672632 108.208792 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 528.773256 111283.766197 
-L 548.682286 111283.766197 
-L 548.682286 97.931294 
-L 528.773256 97.931294 
-z
-" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m26d15b2baa" d="M 0 0 
+       <path id="md9adb8cc6e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m26d15b2baa" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(42.975497 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -246,12 +102,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m26d15b2baa" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="140.592349" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(133.475162 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -286,12 +142,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m26d15b2baa" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="231.092014" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(223.974826 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -334,12 +190,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m26d15b2baa" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="321.591678" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(314.47449 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -369,12 +225,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m26d15b2baa" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="412.091342" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(404.974155 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -410,12 +266,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m26d15b2baa" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="502.591007" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(495.473819 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -456,12 +312,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m26d15b2baa" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="593.090671" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(585.973484 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -482,12 +338,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m26d15b2baa" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="683.590336" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(676.473148 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -537,12 +393,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m26d15b2baa" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9adb8cc6e" x="774.09" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(766.972813 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -580,65 +436,441 @@ z
       </g>
      </g>
     </g>
-    <g id="text_10">
-     <!-- BerlinMOD streaming query -->
-     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.092685 303.32 
+L 774.09 303.32 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <defs>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
+       <path id="m4315c883a7" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4315c883a7" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(25.492685 307.119219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
 z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.092685 210.693333 
+L 774.09 210.693333 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m4315c883a7" x="50.092685" y="210.693333" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(25.492685 214.492552) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.092685 118.066667 
+L 774.09 118.066667 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m4315c883a7" x="50.092685" y="118.066667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(25.492685 121.865885) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.092685 25.44 
+L 774.09 25.44 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m4315c883a7" x="50.092685" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(25.492685 29.239219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.092685 275.436595 
+L 774.09 275.436595 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <defs>
+       <path id="m97776bd071" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="275.436595" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.092685 259.125849 
+L 774.09 259.125849 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="259.125849" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.092685 247.55319 
+L 774.09 247.55319 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="247.55319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.092685 238.576738 
+L 774.09 238.576738 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="238.576738" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.092685 231.242444 
+L 774.09 231.242444 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="231.242444" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.092685 225.041386 
+L 774.09 225.041386 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="225.041386" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.092685 219.669785 
+L 774.09 219.669785 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="219.669785" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.092685 214.931697 
+L 774.09 214.931697 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="214.931697" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.092685 182.809928 
+L 774.09 182.809928 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="182.809928" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.092685 166.499182 
+L 774.09 166.499182 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="166.499182" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.092685 154.926523 
+L 774.09 154.926523 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="154.926523" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.092685 145.950072 
+L 774.09 145.950072 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="145.950072" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.092685 138.615777 
+L 774.09 138.615777 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="138.615777" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.092685 132.414719 
+L 774.09 132.414719 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="132.414719" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.092685 127.043118 
+L 774.09 127.043118 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="127.043118" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.092685 122.30503 
+L 774.09 122.30503 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="122.30503" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.092685 90.183262 
+L 774.09 90.183262 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="90.183262" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 50.092685 73.872515 
+L 774.09 73.872515 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="73.872515" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_54">
+      <path d="M 50.092685 62.299857 
+L 774.09 62.299857 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="62.299857" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_56">
+      <path d="M 50.092685 53.323405 
+L 774.09 53.323405 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="53.323405" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_58">
+      <path d="M 50.092685 45.98911 
+L 774.09 45.98911 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="45.98911" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_60">
+      <path d="M 50.092685 39.788052 
+L 774.09 39.788052 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="39.788052" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_62">
+      <path d="M 50.092685 34.416451 
+L 774.09 34.416451 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="34.416451" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_64">
+      <path d="M 50.092685 29.678364 
+L 774.09 29.678364 
+" clip-path="url(#pc42496c15a)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m97776bd071" x="50.092685" y="29.678364" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput (events/s) -->
+     <g transform="translate(19.412997 220.045625) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
 z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-72" d="M 2631 2963 
@@ -658,215 +890,47 @@ Q 2541 3569 2628 3553
 L 2631 2963 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
 z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-44" d="M 1259 4147 
-L 1259 519 
-L 2022 519 
-Q 2988 519 3436 956 
-Q 3884 1394 3884 2338 
-Q 3884 3275 3436 3711 
-Q 2988 4147 2022 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 1925 4666 
-Q 3281 4666 3915 4102 
-Q 4550 3538 4550 2338 
-Q 4550 1131 3912 565 
-Q 3275 0 1925 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-67" d="M 2906 1791 
@@ -903,477 +967,6 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-71" d="M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-M 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-L 2906 3500 
-L 3481 3500 
-L 3481 -1331 
-L 2906 -1331 
-L 2906 525 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-42"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
-      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
-      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_10">
-      <path d="M 50.610298 316.6 
-L 572.4 316.6 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_11">
-      <defs>
-       <path id="m4533a1fdac" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m4533a1fdac" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_12">
-      <path d="M 50.610298 205.96474 
-L 572.4 205.96474 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#m4533a1fdac" x="50.610298" y="205.96474" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(26.010298 209.763958) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_14">
-      <path d="M 50.610298 95.329479 
-L 572.4 95.329479 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#m4533a1fdac" x="50.610298" y="95.329479" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(26.010298 99.128698) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_16">
-      <path d="M 50.610298 283.295468 
-L 572.4 283.295468 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_17">
-      <defs>
-       <path id="md68b1c7d81" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="283.295468" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_18">
-      <path d="M 50.610298 263.813566 
-L 572.4 263.813566 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="263.813566" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_20">
-      <path d="M 50.610298 249.990936 
-L 572.4 249.990936 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="249.990936" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_22">
-      <path d="M 50.610298 239.269272 
-L 572.4 239.269272 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="239.269272" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_24">
-      <path d="M 50.610298 230.509034 
-L 572.4 230.509034 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="230.509034" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_26">
-      <path d="M 50.610298 223.102358 
-L 572.4 223.102358 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="223.102358" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_28">
-      <path d="M 50.610298 216.686404 
-L 572.4 216.686404 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="216.686404" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_11">
-     <g id="line2d_30">
-      <path d="M 50.610298 211.027131 
-L 572.4 211.027131 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="211.027131" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_32">
-      <path d="M 50.610298 172.660208 
-L 572.4 172.660208 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="172.660208" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_13">
-     <g id="line2d_34">
-      <path d="M 50.610298 153.178305 
-L 572.4 153.178305 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="153.178305" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_36">
-      <path d="M 50.610298 139.355676 
-L 572.4 139.355676 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="139.355676" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_38">
-      <path d="M 50.610298 128.634011 
-L 572.4 128.634011 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="128.634011" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_40">
-      <path d="M 50.610298 119.873773 
-L 572.4 119.873773 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="119.873773" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_17">
-     <g id="line2d_42">
-      <path d="M 50.610298 112.467098 
-L 572.4 112.467098 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="112.467098" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_18">
-     <g id="line2d_44">
-      <path d="M 50.610298 106.051144 
-L 572.4 106.051144 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="106.051144" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_19">
-     <g id="line2d_46">
-      <path d="M 50.610298 100.391871 
-L 572.4 100.391871 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="100.391871" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_20">
-     <g id="line2d_48">
-      <path d="M 50.610298 62.024947 
-L 572.4 62.024947 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="62.024947" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_21">
-     <g id="line2d_50">
-      <path d="M 50.610298 42.543045 
-L 572.4 42.543045 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="42.543045" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_22">
-     <g id="line2d_52">
-      <path d="M 50.610298 28.720415 
-L 572.4 28.720415 
-" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#md68b1c7d81" x="50.610298" y="28.720415" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
-     <!-- Throughput events/s (log scale, higher is better) -->
-     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
        <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
@@ -1400,23 +993,28 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
        <path id="DejaVuSans-28" d="M 1984 4856 
 Q 1566 4138 1362 3434 
 Q 1159 2731 1159 2009 
@@ -1430,60 +1028,96 @@ Q 1013 4119 1484 4856
 L 1984 4856 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2c" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
 L 1159 0 
 L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-29" d="M 513 4856 
@@ -1511,71 +1145,633 @@ z
       <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
-      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(651.607422 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(713.130859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(772.310547 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(833.833984 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(897.212891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(936.421875 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(988.521484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1022.212891 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1074.3125 0)"/>
      </g>
     </g>
    </g>
-   <g id="patch_21">
-    <path d="M 50.610298 316.6 
-L 50.610298 25.8 
+   <g id="patch_3">
+    <path d="M 50.092685 303.32 
+L 50.092685 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_22">
-    <path d="M 572.4 316.6 
-L 572.4 25.8 
+   <g id="patch_4">
+    <path d="M 774.09 303.32 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_23">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
+   <g id="patch_5">
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_24">
-    <path d="M 50.610298 25.8 
-L 572.4 25.8 
+   <g id="patch_6">
+    <path d="M 50.092685 25.44 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_15">
-    <!-- BerlinMOD streaming throughput — snapshot form (216,075-instant real corpus) -->
-    <g transform="translate(69.149211 19.8) scale(0.12 -0.12)">
+    <!-- awaiting benchmark numbers -->
+    <g style="fill: #b0b0b0" transform="translate(301.53262 184.097755) rotate(-8) scale(0.15 -0.15)">
      <defs>
+      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-77" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-69" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-68" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-75" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-73" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-61"/>
+     <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(143.066406 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(204.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(232.128906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(271.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(299.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(362.5 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(425.976562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(457.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(521.240234 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(582.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(646.142578 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(701.123047 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(764.501953 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(861.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(923.193359 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(964.306641 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1022.216797 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1054.003906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1117.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(1180.761719 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1278.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1341.650391 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1403.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1444.287109 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- BerlinMOD stream throughput — snapshot form (log scale, higher is better) -->
+    <g transform="translate(204.462046 19.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
 L 6088 1528 
@@ -1604,11 +1800,60 @@ Q 1241 4863 1831 4863
 L 2375 4863 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1628,94 +1873,122 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1823.283203 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1875.382812 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1938.761719 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(2000.041016 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2063.517578 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2115.617188 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2178.996094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2240.177734 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2279.386719 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2311.173828 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2346.378906 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2407.560547 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2446.923828 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2544.335938 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(2576.123047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(2615.136719 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(2678.759766 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(2742.382812 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(2806.005859 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2837.792969 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(2901.416016 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(2965.039062 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(3028.662109 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3064.746094 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3092.529297 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3155.908203 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3208.007812 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3247.216797 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3308.496094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3371.875 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3411.083984 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3442.871094 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3481.734375 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3543.257812 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3604.537109 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3632.320312 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3664.107422 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3719.087891 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3780.269531 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(3821.382812 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(3884.859375 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3948.238281 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(4000.337891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(946.138672 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(985.347656 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1048.726562 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1087.589844 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1148.771484 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1212.150391 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1275.626953 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1339.005859 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1402.482422 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1465.861328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1505.070312 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1536.857422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1636.857422 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1668.644531 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1720.744141 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1784.123047 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1845.402344 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1908.878906 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1960.978516 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2024.357422 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2085.539062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2124.748047 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2156.535156 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2191.740234 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2252.921875 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2292.285156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2389.697266 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2421.484375 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2460.498047 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2488.28125 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2549.462891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2612.939453 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2644.726562 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2696.826172 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2751.806641 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2813.085938 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2840.869141 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2902.392578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2934.179688 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2965.966797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3029.345703 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(3057.128906 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3120.605469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3183.984375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3245.507812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3286.621094 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3318.408203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3346.191406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3398.291016 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3430.078125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3493.554688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3555.078125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3594.287109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3633.496094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3695.019531 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3736.132812 0)"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_25">
-     <path d="M 442.08 59.420625 
-L 566.1 59.420625 
-Q 567.9 59.420625 567.9 57.620625 
-L 567.9 32.1 
-Q 567.9 30.3 566.1 30.3 
-L 442.08 30.3 
-Q 440.28 30.3 440.28 32.1 
-L 440.28 57.620625 
-Q 440.28 59.420625 442.08 59.420625 
+    <g id="patch_7">
+     <path d="M 671.944219 86.449063 
+L 767.79 86.449063 
+Q 769.59 86.449063 769.59 84.649063 
+L 769.59 31.74 
+Q 769.59 29.94 767.79 29.94 
+L 671.944219 29.94 
+Q 670.144219 29.94 670.144219 31.74 
+L 670.144219 84.649063 
+Q 670.144219 86.449063 671.944219 86.449063 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="patch_26">
-     <path d="M 443.88 40.738594 
-L 461.88 40.738594 
-L 461.88 34.438594 
-L 443.88 34.438594 
+    <g id="text_17">
+     <!-- platforms -->
+     <g transform="translate(696.017109 41.138438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.539062 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(191.748047 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(226.953125 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(288.134766 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(327.498047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(424.910156 0)"/>
+     </g>
+    </g>
+    <g id="patch_8">
+     <path d="M 673.744219 54.556719 
+L 691.744219 54.556719 
+L 691.744219 48.256719 
+L 673.744219 48.256719 
 z
-" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #3a7bd5; stroke: #3a7bd5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_16">
-     <!-- Flink (MobilityFlink) -->
-     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+    <g id="text_18">
+     <!-- MobilityFlink -->
+     <g transform="translate(698.944219 54.556719) scale(0.09 -0.09)">
       <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-46" d="M 628 4666 
 L 3309 4666 
 L 3309 4134 
@@ -1744,40 +2017,32 @@ L 581 4863
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
-      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(450.195312 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(477.978516 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(505.761719 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(569.140625 0)"/>
      </g>
     </g>
-    <g id="patch_27">
-     <path d="M 443.88 53.948906 
-L 461.88 53.948906 
-L 461.88 47.648906 
-L 443.88 47.648906 
+    <g id="patch_9">
+     <path d="M 673.744219 67.767031 
+L 691.744219 67.767031 
+L 691.744219 61.467031 
+L 673.744219 61.467031 
 z
-" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #e07b39; stroke: #e07b39; stroke-linejoin: miter"/>
     </g>
-    <g id="text_17">
-     <!-- Kafka (MobilityKafka) -->
-     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+    <g id="text_19">
+     <!-- MobilityKafka -->
+     <g transform="translate(698.944219 67.767031) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-4b" d="M 628 4666 
 L 1259 4666 
@@ -1794,35 +2059,69 @@ L 628 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
-      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(456.501953 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(517.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(552.986328 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(609.146484 0)"/>
+     </g>
+    </g>
+    <g id="patch_10">
+     <path d="M 673.744219 80.977344 
+L 691.744219 80.977344 
+L 691.744219 74.677344 
+L 673.744219 74.677344 
+z
+" style="fill: #1f9e6e; stroke: #1f9e6e; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- MobilityNebula -->
+     <g transform="translate(698.944219 80.977344) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(467.480469 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(529.003906 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(592.480469 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(655.859375 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(683.642578 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf8b8461b77">
-   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  <clipPath id="pc42496c15a">
+   <rect x="50.092685" y="25.44" width="723.997315" height="277.88"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/streaming/streaming_snapshot.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_snapshot.svg
@@ -1,0 +1,1828 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-01T14:04:19.643834</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 583.2 360 
+L 583.2 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+L 572.4 25.8 
+L 50.610298 25.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 74.328012 111283.766197 
+L 94.237041 111283.766197 
+L 94.237041 60.928597 
+L 74.328012 60.928597 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 128.428636 111283.766197 
+L 148.337666 111283.766197 
+L 148.337666 57.584342 
+L 128.428636 57.584342 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 182.52926 111283.766197 
+L 202.43829 111283.766197 
+L 202.43829 54.616487 
+L 182.52926 54.616487 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 236.629885 111283.766197 
+L 256.538915 111283.766197 
+L 256.538915 114.541628 
+L 236.629885 114.541628 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 290.730509 111283.766197 
+L 310.639539 111283.766197 
+L 310.639539 54.04214 
+L 290.730509 54.04214 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 344.831134 111283.766197 
+L 364.740163 111283.766197 
+L 364.740163 96.499163 
+L 344.831134 96.499163 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 398.931758 111283.766197 
+L 418.840788 111283.766197 
+L 418.840788 124.083358 
+L 398.931758 124.083358 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 453.032382 111283.766197 
+L 472.941412 111283.766197 
+L 472.941412 54.720173 
+L 453.032382 54.720173 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 507.133007 111283.766197 
+L 527.042037 111283.766197 
+L 527.042037 57.924387 
+L 507.133007 57.924387 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 95.968261 111283.766197 
+L 115.877291 111283.766197 
+L 115.877291 83.834157 
+L 95.968261 83.834157 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 150.068886 111283.766197 
+L 169.977916 111283.766197 
+L 169.977916 83.32285 
+L 150.068886 83.32285 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 204.16951 111283.766197 
+L 224.07854 111283.766197 
+L 224.07854 104.350074 
+L 204.16951 104.350074 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 258.270135 111283.766197 
+L 278.179164 111283.766197 
+L 278.179164 171.284295 
+L 258.270135 171.284295 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 312.370759 111283.766197 
+L 332.279789 111283.766197 
+L 332.279789 91.758595 
+L 312.370759 91.758595 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 366.471383 111283.766197 
+L 386.380413 111283.766197 
+L 386.380413 153.546481 
+L 366.471383 153.546481 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 420.572008 111283.766197 
+L 440.481037 111283.766197 
+L 440.481037 155.039736 
+L 420.572008 155.039736 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 474.672632 111283.766197 
+L 494.581662 111283.766197 
+L 494.581662 108.208792 
+L 474.672632 108.208792 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 528.773256 111283.766197 
+L 548.682286 111283.766197 
+L 548.682286 97.931294 
+L 528.773256 97.931294 
+z
+" clip-path="url(#pf8b8461b77)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m26d15b2baa" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m26d15b2baa" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Q1 -->
+      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Q2 -->
+      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Q3 -->
+      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Q4 -->
+      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Q5 -->
+      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- Q6 -->
+      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- Q7 -->
+      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Q8 -->
+      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m26d15b2baa" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- Q9 -->
+      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- BerlinMOD streaming query -->
+     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="m4533a1fdac" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4533a1fdac" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.610298 205.96474 
+L 572.4 205.96474 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m4533a1fdac" x="50.610298" y="205.96474" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(26.010298 209.763958) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.610298 95.329479 
+L 572.4 95.329479 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m4533a1fdac" x="50.610298" y="95.329479" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(26.010298 99.128698) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.610298 283.295468 
+L 572.4 283.295468 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <defs>
+       <path id="md68b1c7d81" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="283.295468" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.610298 263.813566 
+L 572.4 263.813566 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="263.813566" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.610298 249.990936 
+L 572.4 249.990936 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="249.990936" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.610298 239.269272 
+L 572.4 239.269272 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="239.269272" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.610298 230.509034 
+L 572.4 230.509034 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="230.509034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.610298 223.102358 
+L 572.4 223.102358 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="223.102358" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.610298 216.686404 
+L 572.4 216.686404 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="216.686404" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.610298 211.027131 
+L 572.4 211.027131 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="211.027131" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.610298 172.660208 
+L 572.4 172.660208 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="172.660208" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.610298 153.178305 
+L 572.4 153.178305 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="153.178305" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.610298 139.355676 
+L 572.4 139.355676 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="139.355676" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.610298 128.634011 
+L 572.4 128.634011 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="128.634011" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.610298 119.873773 
+L 572.4 119.873773 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="119.873773" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.610298 112.467098 
+L 572.4 112.467098 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="112.467098" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.610298 106.051144 
+L 572.4 106.051144 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="106.051144" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.610298 100.391871 
+L 572.4 100.391871 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="100.391871" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.610298 62.024947 
+L 572.4 62.024947 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="62.024947" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.610298 42.543045 
+L 572.4 42.543045 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="42.543045" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 50.610298 28.720415 
+L 572.4 28.720415 
+" clip-path="url(#pf8b8461b77)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#md68b1c7d81" x="50.610298" y="28.720415" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput events/s (log scale, higher is better) -->
+     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(124.462891 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(163.326172 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(224.507812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(287.886719 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(351.363281 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(414.742188 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_21">
+    <path d="M 50.610298 316.6 
+L 50.610298 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 572.4 316.6 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 50.610298 25.8 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- BerlinMOD streaming throughput — snapshot form (216,075-instant real corpus) -->
+    <g transform="translate(69.149211 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1823.283203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1875.382812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1938.761719 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2000.041016 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2063.517578 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2115.617188 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2178.996094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2240.177734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2279.386719 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2311.173828 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2346.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2407.560547 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2446.923828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2544.335938 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2576.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(2615.136719 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2678.759766 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2742.382812 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2806.005859 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2837.792969 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2901.416016 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(2965.039062 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3028.662109 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3064.746094 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3092.529297 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3155.908203 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3208.007812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3247.216797 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3308.496094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3371.875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3411.083984 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3442.871094 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3481.734375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3543.257812 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3604.537109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3632.320312 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3664.107422 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3719.087891 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3780.269531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3821.382812 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(3884.859375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3948.238281 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4000.337891 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_25">
+     <path d="M 442.08 59.420625 
+L 566.1 59.420625 
+Q 567.9 59.420625 567.9 57.620625 
+L 567.9 32.1 
+Q 567.9 30.3 566.1 30.3 
+L 442.08 30.3 
+Q 440.28 30.3 440.28 32.1 
+L 440.28 57.620625 
+Q 440.28 59.420625 442.08 59.420625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_26">
+     <path d="M 443.88 40.738594 
+L 461.88 40.738594 
+L 461.88 34.438594 
+L 443.88 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_16">
+     <!-- Flink (MobilityFlink) -->
+     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 443.88 53.948906 
+L 461.88 53.948906 
+L 461.88 47.648906 
+L 443.88 47.648906 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_17">
+     <!-- Kafka (MobilityKafka) -->
+     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4b"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pf8b8461b77">
+   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/BerlinMOD/benchmarks/streaming/streaming_windowed.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_windowed.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="792pt" height="331.2pt" viewBox="0 0 792 331.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-01T14:04:19.452952</dc:date>
+    <dc:date>2026-06-01T18:04:52.984888</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,181 +21,37 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 360 
-L 583.2 360 
-L 583.2 0 
+   <path d="M 0 331.2 
+L 792 331.2 
+L 792 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
-L 572.4 25.8 
-L 50.610298 25.8 
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
+L 774.09 25.44 
+L 50.092685 25.44 
 z
 " style="fill: #ffffff"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 74.328012 111463.586203 
-L 94.237041 111463.586203 
-L 94.237041 70.295879 
-L 74.328012 70.295879 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 128.428636 111463.586203 
-L 148.337666 111463.586203 
-L 148.337666 59.174122 
-L 128.428636 59.174122 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 182.52926 111463.586203 
-L 202.43829 111463.586203 
-L 202.43829 102.123789 
-L 182.52926 102.123789 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 236.629885 111463.586203 
-L 256.538915 111463.586203 
-L 256.538915 114.378146 
-L 236.629885 114.378146 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 290.730509 111463.586203 
-L 310.639539 111463.586203 
-L 310.639539 55.625469 
-L 290.730509 55.625469 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 344.831134 111463.586203 
-L 364.740163 111463.586203 
-L 364.740163 104.556821 
-L 344.831134 104.556821 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 398.931758 111463.586203 
-L 418.840788 111463.586203 
-L 418.840788 135.386902 
-L 398.931758 135.386902 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 453.032382 111463.586203 
-L 472.941412 111463.586203 
-L 472.941412 108.531239 
-L 453.032382 108.531239 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 507.133007 111463.586203 
-L 527.042037 111463.586203 
-L 527.042037 54.087906 
-L 507.133007 54.087906 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 95.968261 111463.586203 
-L 115.877291 111463.586203 
-L 115.877291 81.991717 
-L 95.968261 81.991717 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 150.068886 111463.586203 
-L 169.977916 111463.586203 
-L 169.977916 83.541525 
-L 150.068886 83.541525 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 204.16951 111463.586203 
-L 224.07854 111463.586203 
-L 224.07854 126.819103 
-L 204.16951 126.819103 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 258.270135 111463.586203 
-L 278.179164 111463.586203 
-L 278.179164 167.443548 
-L 258.270135 167.443548 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 312.370759 111463.586203 
-L 332.279789 111463.586203 
-L 332.279789 109.065563 
-L 312.370759 109.065563 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 366.471383 111463.586203 
-L 386.380413 111463.586203 
-L 386.380413 146.224959 
-L 366.471383 146.224959 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 420.572008 111463.586203 
-L 440.481037 111463.586203 
-L 440.481037 175.953152 
-L 420.572008 175.953152 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 474.672632 111463.586203 
-L 494.581662 111463.586203 
-L 494.581662 143.686659 
-L 474.672632 143.686659 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 528.773256 111463.586203 
-L 548.682286 111463.586203 
-L 548.682286 99.702615 
-L 528.773256 99.702615 
-z
-" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m371aab8991" d="M 0 0 
+       <path id="mf4a253db44" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m371aab8991" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(42.975497 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -246,12 +102,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m371aab8991" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="140.592349" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(133.475162 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -286,12 +142,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m371aab8991" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="231.092014" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(223.974826 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -334,12 +190,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m371aab8991" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="321.591678" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(314.47449 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -369,12 +225,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m371aab8991" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="412.091342" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(404.974155 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -410,12 +266,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m371aab8991" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="502.591007" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(495.473819 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -456,12 +312,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m371aab8991" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="593.090671" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(585.973484 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -482,12 +338,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m371aab8991" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="683.590336" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(676.473148 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -537,12 +393,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m371aab8991" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4a253db44" x="774.09" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+      <g transform="translate(766.972813 317.918437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -580,65 +436,441 @@ z
       </g>
      </g>
     </g>
-    <g id="text_10">
-     <!-- BerlinMOD streaming query -->
-     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.092685 303.32 
+L 774.09 303.32 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <defs>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
+       <path id="m2697749ad9" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2697749ad9" x="50.092685" y="303.32" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(25.492685 307.119219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
 z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.092685 210.693333 
+L 774.09 210.693333 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m2697749ad9" x="50.092685" y="210.693333" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(25.492685 214.492552) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.092685 118.066667 
+L 774.09 118.066667 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m2697749ad9" x="50.092685" y="118.066667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(25.492685 121.865885) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.092685 25.44 
+L 774.09 25.44 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m2697749ad9" x="50.092685" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(25.492685 29.239219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.092685 275.436595 
+L 774.09 275.436595 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <defs>
+       <path id="mbc0d6fbf08" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="275.436595" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.092685 259.125849 
+L 774.09 259.125849 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="259.125849" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.092685 247.55319 
+L 774.09 247.55319 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="247.55319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.092685 238.576738 
+L 774.09 238.576738 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="238.576738" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.092685 231.242444 
+L 774.09 231.242444 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="231.242444" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.092685 225.041386 
+L 774.09 225.041386 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="225.041386" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.092685 219.669785 
+L 774.09 219.669785 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="219.669785" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.092685 214.931697 
+L 774.09 214.931697 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="214.931697" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.092685 182.809928 
+L 774.09 182.809928 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="182.809928" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.092685 166.499182 
+L 774.09 166.499182 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="166.499182" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.092685 154.926523 
+L 774.09 154.926523 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="154.926523" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.092685 145.950072 
+L 774.09 145.950072 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="145.950072" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.092685 138.615777 
+L 774.09 138.615777 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="138.615777" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.092685 132.414719 
+L 774.09 132.414719 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="132.414719" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.092685 127.043118 
+L 774.09 127.043118 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="127.043118" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.092685 122.30503 
+L 774.09 122.30503 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="122.30503" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.092685 90.183262 
+L 774.09 90.183262 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="90.183262" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 50.092685 73.872515 
+L 774.09 73.872515 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="73.872515" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_54">
+      <path d="M 50.092685 62.299857 
+L 774.09 62.299857 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="62.299857" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_56">
+      <path d="M 50.092685 53.323405 
+L 774.09 53.323405 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="53.323405" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_58">
+      <path d="M 50.092685 45.98911 
+L 774.09 45.98911 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="45.98911" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_60">
+      <path d="M 50.092685 39.788052 
+L 774.09 39.788052 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="39.788052" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_62">
+      <path d="M 50.092685 34.416451 
+L 774.09 34.416451 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="34.416451" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_64">
+      <path d="M 50.092685 29.678364 
+L 774.09 29.678364 
+" clip-path="url(#pd544b29a31)" style="fill: none; stroke: #e3e3e3; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#mbc0d6fbf08" x="50.092685" y="29.678364" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput (events/s) -->
+     <g transform="translate(19.412997 220.045625) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
 z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-72" d="M 2631 2963 
@@ -658,215 +890,47 @@ Q 2541 3569 2628 3553
 L 2631 2963 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
 z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-44" d="M 1259 4147 
-L 1259 519 
-L 2022 519 
-Q 2988 519 3436 956 
-Q 3884 1394 3884 2338 
-Q 3884 3275 3436 3711 
-Q 2988 4147 2022 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 1925 4666 
-Q 3281 4666 3915 4102 
-Q 4550 3538 4550 2338 
-Q 4550 1131 3912 565 
-Q 3275 0 1925 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-73" d="M 2834 3397 
-L 2834 2853 
-Q 2591 2978 2328 3040 
-Q 2066 3103 1784 3103 
-Q 1356 3103 1142 2972 
-Q 928 2841 928 2578 
-Q 928 2378 1081 2264 
-Q 1234 2150 1697 2047 
-L 1894 2003 
-Q 2506 1872 2764 1633 
-Q 3022 1394 3022 966 
-Q 3022 478 2636 193 
-Q 2250 -91 1575 -91 
-Q 1294 -91 989 -36 
-Q 684 19 347 128 
-L 347 722 
-Q 666 556 975 473 
-Q 1284 391 1588 391 
-Q 1994 391 2212 530 
-Q 2431 669 2431 922 
-Q 2431 1156 2273 1281 
-Q 2116 1406 1581 1522 
-L 1381 1569 
-Q 847 1681 609 1914 
-Q 372 2147 372 2553 
-Q 372 3047 722 3315 
-Q 1072 3584 1716 3584 
-Q 2034 3584 2315 3537 
-Q 2597 3491 2834 3397 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-67" d="M 2906 1791 
@@ -903,477 +967,6 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-71" d="M 947 1747 
-Q 947 1113 1208 752 
-Q 1469 391 1925 391 
-Q 2381 391 2643 752 
-Q 2906 1113 2906 1747 
-Q 2906 2381 2643 2742 
-Q 2381 3103 1925 3103 
-Q 1469 3103 1208 2742 
-Q 947 2381 947 1747 
-z
-M 2906 525 
-Q 2725 213 2448 61 
-Q 2172 -91 1784 -91 
-Q 1150 -91 751 415 
-Q 353 922 353 1747 
-Q 353 2572 751 3078 
-Q 1150 3584 1784 3584 
-Q 2172 3584 2448 3432 
-Q 2725 3281 2906 2969 
-L 2906 3500 
-L 3481 3500 
-L 3481 -1331 
-L 2906 -1331 
-L 2906 525 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-42"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
-      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
-      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_10">
-      <path d="M 50.610298 316.6 
-L 572.4 316.6 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_11">
-      <defs>
-       <path id="mcfcaddacda" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#mcfcaddacda" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_12">
-      <path d="M 50.610298 205.785457 
-L 572.4 205.785457 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_13">
-      <g>
-       <use xlink:href="#mcfcaddacda" x="50.610298" y="205.785457" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(26.010298 209.584676) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_14">
-      <path d="M 50.610298 94.970915 
-L 572.4 94.970915 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_15">
-      <g>
-       <use xlink:href="#mcfcaddacda" x="50.610298" y="94.970915" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(26.010298 98.770134) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_16">
-      <path d="M 50.610298 283.241499 
-L 572.4 283.241499 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_17">
-      <defs>
-       <path id="m6e77b0b22c" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="283.241499" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_18">
-      <path d="M 50.610298 263.728026 
-L 572.4 263.728026 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="263.728026" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_20">
-      <path d="M 50.610298 249.882997 
-L 572.4 249.882997 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="249.882997" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_22">
-      <path d="M 50.610298 239.143959 
-L 572.4 239.143959 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="239.143959" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_24">
-      <path d="M 50.610298 230.369525 
-L 572.4 230.369525 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="230.369525" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_26">
-      <path d="M 50.610298 222.950847 
-L 572.4 222.950847 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="222.950847" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_28">
-      <path d="M 50.610298 216.524496 
-L 572.4 216.524496 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="216.524496" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_11">
-     <g id="line2d_30">
-      <path d="M 50.610298 210.856053 
-L 572.4 210.856053 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="210.856053" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_32">
-      <path d="M 50.610298 172.426956 
-L 572.4 172.426956 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="172.426956" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_13">
-     <g id="line2d_34">
-      <path d="M 50.610298 152.913484 
-L 572.4 152.913484 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="152.913484" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_36">
-      <path d="M 50.610298 139.068455 
-L 572.4 139.068455 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="139.068455" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_38">
-      <path d="M 50.610298 128.329416 
-L 572.4 128.329416 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="128.329416" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_40">
-      <path d="M 50.610298 119.554983 
-L 572.4 119.554983 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="119.554983" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_17">
-     <g id="line2d_42">
-      <path d="M 50.610298 112.136305 
-L 572.4 112.136305 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="112.136305" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_18">
-     <g id="line2d_44">
-      <path d="M 50.610298 105.709954 
-L 572.4 105.709954 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="105.709954" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_19">
-     <g id="line2d_46">
-      <path d="M 50.610298 100.04151 
-L 572.4 100.04151 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="100.04151" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_20">
-     <g id="line2d_48">
-      <path d="M 50.610298 61.612414 
-L 572.4 61.612414 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="61.612414" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_21">
-     <g id="line2d_50">
-      <path d="M 50.610298 42.098941 
-L 572.4 42.098941 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="42.098941" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_22">
-     <g id="line2d_52">
-      <path d="M 50.610298 28.253912 
-L 572.4 28.253912 
-" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#m6e77b0b22c" x="50.610298" y="28.253912" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
-     <!-- Throughput events/s (log scale, higher is better) -->
-     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
        <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
@@ -1400,23 +993,28 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
        <path id="DejaVuSans-28" d="M 1984 4856 
 Q 1566 4138 1362 3434 
 Q 1159 2731 1159 2009 
@@ -1430,60 +1028,96 @@ Q 1013 4119 1484 4856
 L 1984 4856 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2c" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
 L 1159 0 
 L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-29" d="M 513 4856 
@@ -1511,71 +1145,633 @@ z
       <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
-      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
-      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(651.607422 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(713.130859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(772.310547 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(833.833984 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(897.212891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(936.421875 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(988.521484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1022.212891 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1074.3125 0)"/>
      </g>
     </g>
    </g>
-   <g id="patch_21">
-    <path d="M 50.610298 316.6 
-L 50.610298 25.8 
+   <g id="patch_3">
+    <path d="M 50.092685 303.32 
+L 50.092685 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_22">
-    <path d="M 572.4 316.6 
-L 572.4 25.8 
+   <g id="patch_4">
+    <path d="M 774.09 303.32 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_23">
-    <path d="M 50.610298 316.6 
-L 572.4 316.6 
+   <g id="patch_5">
+    <path d="M 50.092685 303.32 
+L 774.09 303.32 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_24">
-    <path d="M 50.610298 25.8 
-L 572.4 25.8 
+   <g id="patch_6">
+    <path d="M 50.092685 25.44 
+L 774.09 25.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_15">
-    <!-- BerlinMOD streaming throughput — windowed form (216,075-instant real corpus) -->
-    <g transform="translate(66.250461 19.8) scale(0.12 -0.12)">
+    <!-- awaiting benchmark numbers -->
+    <g style="fill: #b0b0b0" transform="translate(301.53262 184.097755) rotate(-8) scale(0.15 -0.15)">
      <defs>
+      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-77" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-69" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-68" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-75" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-73" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Oblique-61"/>
+     <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(143.066406 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(204.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(232.128906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(271.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(299.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(362.5 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(425.976562 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(457.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(521.240234 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(582.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(646.142578 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(701.123047 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(764.501953 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(861.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(923.193359 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(964.306641 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1022.216797 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1054.003906 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1117.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(1180.761719 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1278.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1341.650391 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1403.173828 0)"/>
+     <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1444.287109 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- BerlinMOD stream throughput — windowed form (log scale, higher is better) -->
+    <g transform="translate(201.804858 19.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
 L 6088 1528 
@@ -1646,11 +1842,60 @@ Q 1241 4863 1831 4863
 L 2375 4863 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1670,94 +1915,122 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(1823.283203 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1905.070312 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1932.853516 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(1996.232422 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2059.708984 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(2120.890625 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2202.677734 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2264.201172 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2327.677734 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2359.464844 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2394.669922 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2455.851562 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2495.214844 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2592.626953 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(2624.414062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(2663.427734 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(2727.050781 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(2790.673828 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(2854.296875 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2886.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(2949.707031 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(3013.330078 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(3076.953125 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3113.037109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3140.820312 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3204.199219 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3256.298828 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3295.507812 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3356.787109 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3420.166016 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3459.375 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3491.162109 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3530.025391 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3591.548828 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3652.828125 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3680.611328 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3712.398438 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3767.378906 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3828.560547 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(3869.673828 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(3933.150391 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3996.529297 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(4048.628906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(946.138672 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(985.347656 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1048.726562 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1087.589844 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1148.771484 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1212.150391 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1275.626953 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1339.005859 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1402.482422 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1465.861328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1505.070312 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1536.857422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1636.857422 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(1668.644531 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1750.431641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1778.214844 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1841.59375 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1905.070312 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(1966.251953 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2048.039062 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2109.5625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2173.039062 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2204.826172 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2240.03125 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2301.212891 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2340.576172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2437.988281 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2469.775391 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2508.789062 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2536.572266 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2597.753906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2661.230469 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2693.017578 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2745.117188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2800.097656 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2861.376953 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2889.160156 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2950.683594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2982.470703 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3014.257812 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3077.636719 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(3105.419922 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3168.896484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3232.275391 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3293.798828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3334.912109 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3366.699219 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3394.482422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3446.582031 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3478.369141 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3541.845703 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3603.369141 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3642.578125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3681.787109 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3743.310547 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3784.423828 0)"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_25">
-     <path d="M 442.08 59.420625 
-L 566.1 59.420625 
-Q 567.9 59.420625 567.9 57.620625 
-L 567.9 32.1 
-Q 567.9 30.3 566.1 30.3 
-L 442.08 30.3 
-Q 440.28 30.3 440.28 32.1 
-L 440.28 57.620625 
-Q 440.28 59.420625 442.08 59.420625 
+    <g id="patch_7">
+     <path d="M 671.944219 86.449063 
+L 767.79 86.449063 
+Q 769.59 86.449063 769.59 84.649063 
+L 769.59 31.74 
+Q 769.59 29.94 767.79 29.94 
+L 671.944219 29.94 
+Q 670.144219 29.94 670.144219 31.74 
+L 670.144219 84.649063 
+Q 670.144219 86.449063 671.944219 86.449063 
 z
-" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="patch_26">
-     <path d="M 443.88 40.738594 
-L 461.88 40.738594 
-L 461.88 34.438594 
-L 443.88 34.438594 
+    <g id="text_17">
+     <!-- platforms -->
+     <g transform="translate(696.017109 41.138438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.539062 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(191.748047 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(226.953125 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(288.134766 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(327.498047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(424.910156 0)"/>
+     </g>
+    </g>
+    <g id="patch_8">
+     <path d="M 673.744219 54.556719 
+L 691.744219 54.556719 
+L 691.744219 48.256719 
+L 673.744219 48.256719 
 z
-" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #3a7bd5; stroke: #3a7bd5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_16">
-     <!-- Flink (MobilityFlink) -->
-     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+    <g id="text_18">
+     <!-- MobilityFlink -->
+     <g transform="translate(698.944219 54.556719) scale(0.09 -0.09)">
       <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-46" d="M 628 4666 
 L 3309 4666 
 L 3309 4134 
@@ -1786,40 +2059,32 @@ L 581 4863
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-46"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
-      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(450.195312 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(477.978516 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(505.761719 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(569.140625 0)"/>
      </g>
     </g>
-    <g id="patch_27">
-     <path d="M 443.88 53.948906 
-L 461.88 53.948906 
-L 461.88 47.648906 
-L 443.88 47.648906 
+    <g id="patch_9">
+     <path d="M 673.744219 67.767031 
+L 691.744219 67.767031 
+L 691.744219 61.467031 
+L 673.744219 61.467031 
 z
-" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: #e07b39; stroke: #e07b39; stroke-linejoin: miter"/>
     </g>
-    <g id="text_17">
-     <!-- Kafka (MobilityKafka) -->
-     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+    <g id="text_19">
+     <!-- MobilityKafka -->
+     <g transform="translate(698.944219 67.767031) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-4b" d="M 628 4666 
 L 1259 4666 
@@ -1836,35 +2101,69 @@ L 628 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-4b"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
-      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
-      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
-      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(456.501953 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(517.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(552.986328 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(609.146484 0)"/>
+     </g>
+    </g>
+    <g id="patch_10">
+     <path d="M 673.744219 80.977344 
+L 691.744219 80.977344 
+L 691.744219 74.677344 
+L 673.744219 74.677344 
+z
+" style="fill: #1f9e6e; stroke: #1f9e6e; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- MobilityNebula -->
+     <g transform="translate(698.944219 80.977344) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(467.480469 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(529.003906 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(592.480469 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(655.859375 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(683.642578 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5805b37f3c">
-   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  <clipPath id="pd544b29a31">
+   <rect x="50.092685" y="25.44" width="723.997315" height="277.88"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/streaming/streaming_windowed.svg
+++ b/BerlinMOD/benchmarks/streaming/streaming_windowed.svg
@@ -1,0 +1,1870 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.2pt" height="360pt" viewBox="0 0 583.2 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-01T14:04:19.452952</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 583.2 360 
+L 583.2 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+L 572.4 25.8 
+L 50.610298 25.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 74.328012 111463.586203 
+L 94.237041 111463.586203 
+L 94.237041 70.295879 
+L 74.328012 70.295879 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 128.428636 111463.586203 
+L 148.337666 111463.586203 
+L 148.337666 59.174122 
+L 128.428636 59.174122 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 182.52926 111463.586203 
+L 202.43829 111463.586203 
+L 202.43829 102.123789 
+L 182.52926 102.123789 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 236.629885 111463.586203 
+L 256.538915 111463.586203 
+L 256.538915 114.378146 
+L 236.629885 114.378146 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 290.730509 111463.586203 
+L 310.639539 111463.586203 
+L 310.639539 55.625469 
+L 290.730509 55.625469 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 344.831134 111463.586203 
+L 364.740163 111463.586203 
+L 364.740163 104.556821 
+L 344.831134 104.556821 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 398.931758 111463.586203 
+L 418.840788 111463.586203 
+L 418.840788 135.386902 
+L 398.931758 135.386902 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 453.032382 111463.586203 
+L 472.941412 111463.586203 
+L 472.941412 108.531239 
+L 453.032382 108.531239 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 507.133007 111463.586203 
+L 527.042037 111463.586203 
+L 527.042037 54.087906 
+L 507.133007 54.087906 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 95.968261 111463.586203 
+L 115.877291 111463.586203 
+L 115.877291 81.991717 
+L 95.968261 81.991717 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 150.068886 111463.586203 
+L 169.977916 111463.586203 
+L 169.977916 83.541525 
+L 150.068886 83.541525 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 204.16951 111463.586203 
+L 224.07854 111463.586203 
+L 224.07854 126.819103 
+L 204.16951 126.819103 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 258.270135 111463.586203 
+L 278.179164 111463.586203 
+L 278.179164 167.443548 
+L 258.270135 167.443548 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 312.370759 111463.586203 
+L 332.279789 111463.586203 
+L 332.279789 109.065563 
+L 312.370759 109.065563 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 366.471383 111463.586203 
+L 386.380413 111463.586203 
+L 386.380413 146.224959 
+L 366.471383 146.224959 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 420.572008 111463.586203 
+L 440.481037 111463.586203 
+L 440.481037 175.953152 
+L 420.572008 175.953152 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 474.672632 111463.586203 
+L 494.581662 111463.586203 
+L 494.581662 143.686659 
+L 474.672632 143.686659 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 528.773256 111463.586203 
+L 548.682286 111463.586203 
+L 548.682286 99.702615 
+L 528.773256 99.702615 
+z
+" clip-path="url(#p5805b37f3c)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m371aab8991" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m371aab8991" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Q1 -->
+      <g transform="translate(87.985464 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m371aab8991" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Q2 -->
+      <g transform="translate(142.086088 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m371aab8991" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Q3 -->
+      <g transform="translate(196.186713 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m371aab8991" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Q4 -->
+      <g transform="translate(250.287337 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m371aab8991" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Q5 -->
+      <g transform="translate(304.387961 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m371aab8991" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- Q6 -->
+      <g transform="translate(358.488586 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m371aab8991" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- Q7 -->
+      <g transform="translate(412.58921 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m371aab8991" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Q8 -->
+      <g transform="translate(466.689835 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m371aab8991" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- Q9 -->
+      <g transform="translate(520.790459 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- BerlinMOD streaming query -->
+     <g transform="translate(242.032493 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(1100.777344 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1164.253906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1227.632812 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1289.15625 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1330.269531 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="mcfcaddacda" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mcfcaddacda" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(26.010298 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 50.610298 205.785457 
+L 572.4 205.785457 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mcfcaddacda" x="50.610298" y="205.785457" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(26.010298 209.584676) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 50.610298 94.970915 
+L 572.4 94.970915 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mcfcaddacda" x="50.610298" y="94.970915" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(26.010298 98.770134) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 50.610298 283.241499 
+L 572.4 283.241499 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <defs>
+       <path id="m6e77b0b22c" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="283.241499" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 50.610298 263.728026 
+L 572.4 263.728026 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="263.728026" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 50.610298 249.882997 
+L 572.4 249.882997 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="249.882997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 50.610298 239.143959 
+L 572.4 239.143959 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="239.143959" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 50.610298 230.369525 
+L 572.4 230.369525 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="230.369525" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 50.610298 222.950847 
+L 572.4 222.950847 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="222.950847" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_28">
+      <path d="M 50.610298 216.524496 
+L 572.4 216.524496 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="216.524496" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_30">
+      <path d="M 50.610298 210.856053 
+L 572.4 210.856053 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="210.856053" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <path d="M 50.610298 172.426956 
+L 572.4 172.426956 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="172.426956" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <path d="M 50.610298 152.913484 
+L 572.4 152.913484 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="152.913484" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_36">
+      <path d="M 50.610298 139.068455 
+L 572.4 139.068455 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="139.068455" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_38">
+      <path d="M 50.610298 128.329416 
+L 572.4 128.329416 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="128.329416" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_40">
+      <path d="M 50.610298 119.554983 
+L 572.4 119.554983 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="119.554983" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_42">
+      <path d="M 50.610298 112.136305 
+L 572.4 112.136305 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="112.136305" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_44">
+      <path d="M 50.610298 105.709954 
+L 572.4 105.709954 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="105.709954" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 50.610298 100.04151 
+L 572.4 100.04151 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="100.04151" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 50.610298 61.612414 
+L 572.4 61.612414 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="61.612414" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 50.610298 42.098941 
+L 572.4 42.098941 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="42.098941" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 50.610298 28.253912 
+L 572.4 28.253912 
+" clip-path="url(#p5805b37f3c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m6e77b0b22c" x="50.610298" y="28.253912" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Throughput events/s (log scale, higher is better) -->
+     <g transform="translate(19.93061 292.235937) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(124.462891 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(163.326172 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(224.507812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(287.886719 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(351.363281 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(414.742188 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(478.21875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(541.597656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(580.806641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(612.59375 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(674.117188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(733.296875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(794.820312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(858.199219 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(897.408203 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(949.507812 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(983.199219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1035.298828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1067.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.099609 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1133.882812 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1195.064453 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1258.541016 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.328125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1342.427734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1397.408203 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1458.6875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1486.470703 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1547.994141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1579.78125 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1611.568359 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1674.947266 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1702.730469 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1766.207031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1829.585938 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1891.109375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1932.222656 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1964.009766 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1991.792969 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2043.892578 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2075.679688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2139.15625 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2200.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2239.888672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2279.097656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2340.621094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2381.734375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_21">
+    <path d="M 50.610298 316.6 
+L 50.610298 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 572.4 316.6 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 50.610298 316.6 
+L 572.4 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 50.610298 25.8 
+L 572.4 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- BerlinMOD streaming throughput — windowed form (216,075-instant real corpus) -->
+    <g transform="translate(66.250461 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(616.064453 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(655.273438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(694.136719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(755.660156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(816.939453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(914.351562 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(942.134766 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1005.513672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.990234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1100.777344 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1139.986328 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1203.365234 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1242.228516 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1303.410156 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1366.789062 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1430.265625 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1493.644531 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1557.121094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1620.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1659.708984 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1691.496094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1791.496094 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(1823.283203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1905.070312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1932.853516 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1996.232422 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2059.708984 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(2120.890625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2202.677734 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2264.201172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2327.677734 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2359.464844 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2394.669922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2455.851562 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2495.214844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2592.626953 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2624.414062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(2663.427734 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2727.050781 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2790.673828 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2854.296875 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2886.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2949.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3013.330078 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3076.953125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3113.037109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3140.820312 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3204.199219 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3256.298828 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3295.507812 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3356.787109 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3420.166016 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3459.375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3491.162109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3530.025391 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3591.548828 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3652.828125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3680.611328 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3712.398438 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3767.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3828.560547 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3869.673828 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(3933.150391 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3996.529297 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4048.628906 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_25">
+     <path d="M 442.08 59.420625 
+L 566.1 59.420625 
+Q 567.9 59.420625 567.9 57.620625 
+L 567.9 32.1 
+Q 567.9 30.3 566.1 30.3 
+L 442.08 30.3 
+Q 440.28 30.3 440.28 32.1 
+L 440.28 57.620625 
+Q 440.28 59.420625 442.08 59.420625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_26">
+     <path d="M 443.88 40.738594 
+L 461.88 40.738594 
+L 461.88 34.438594 
+L 443.88 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_16">
+     <!-- Flink (MobilityFlink) -->
+     <g transform="translate(469.08 40.738594) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(57.519531 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(85.302734 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(113.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(176.464844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(234.375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(266.162109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(305.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(391.455078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(452.636719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(516.113281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(543.896484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(571.679688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(599.462891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(638.671875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(697.851562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(755.371094 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(783.154297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(810.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(874.316406 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(932.226562 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 443.88 53.948906 
+L 461.88 53.948906 
+L 461.88 47.648906 
+L 443.88 47.648906 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_17">
+     <!-- Kafka (MobilityKafka) -->
+     <g transform="translate(469.08 53.948906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4b"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.826172 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(125.105469 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(160.310547 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(216.470703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(277.75 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(309.537109 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(348.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(434.830078 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(496.011719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(559.488281 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(587.271484 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(615.054688 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(642.837891 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(682.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(741.226562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(805.052734 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(866.332031 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(901.537109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(957.697266 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1018.976562 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5805b37f3c">
+   <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
The streaming sibling of the cross-platform BerlinMOD benchmark, under BerlinMOD/benchmarks/streaming/. It defines the streaming query set (a 9-query subset of the BerlinMOD intents in continuous, windowed, and snapshot forms across Flink, Kafka, and NebulaStream), records the snapshot-equals-batch bridge to the 3-DB benchmark, and specifies the engine-agnostic result schema the three harnesses emit. The cross-platform timing table is seeded with the measured MobilityFlink figures; the Nebula and Kafka columns are not yet measured.