### PR TITLE
Export the BerlinMOD dataset's H3 cell in both the streaming and batch forms

### DIFF
--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -209,3 +209,71 @@ END;
 $$ LANGUAGE 'plpgsql';
 
 -------------------------------------------------------------------------------
+
+/******************************************************************************
+ * Exports the BerlinMOD trips as a stream of point events for the streaming
+ * benchmark (Apache Flink, Kafka Streams, NebulaStream). Each trip's tgeompoint
+ * is unnested into its composing instants; the per-event H3 cell is computed
+ * once here so every streaming engine inherits it from the dataset rather than
+ * recomputing it.
+ *
+ * Schema produced:
+ *   instants.csv : tripId, vehId, day, seqno, geom, t, h3_cell
+ *                  - geom    : the event point geometry (EWKB, SRID 3857)
+ *                  - t       : event timestamp
+ *                  - h3_cell : the H3 cell of the event point at the chosen
+ *                              resolution, from geotoh3cell(geom in 4326, R).
+ *                              R defaults to 7 (cell edge ≈ 1.2 km).
+ *
+ * Parameters:
+ * - fullpath:     directory path (with trailing slash) where the CSV is written.
+ * - h3resolution: H3 resolution for the h3_cell column (default 7).
+ *
+ * Example:
+ *     \i berlinmod_export.sql
+ *     SELECT berlinmod_instants_export('/home/mobilitydb/portability/');
+ *****************************************************************************/
+
+DROP FUNCTION IF EXISTS berlinmod_instants_export;
+CREATE OR REPLACE FUNCTION berlinmod_instants_export(
+    fullpath      text,
+    h3resolution  integer DEFAULT 7)
+RETURNS text AS $$
+DECLARE
+  startTime timestamptz;
+  endTime   timestamptz;
+BEGIN
+  startTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Exporting BerlinMOD trips as point events (streaming form)';
+  RAISE INFO 'Target: %', fullpath;
+  RAISE INFO 'H3 resolution for h3_cell: %', h3resolution;
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO '------------------------------------------------------------------';
+
+  RAISE INFO 'Exporting instants.csv (point events + per-event h3_cell at resolution %)', h3resolution;
+  EXECUTE format(
+    'COPY (
+       WITH Inst(TripId, VehicleId, Inst, SeqNo) AS (
+         SELECT t.TripId, t.VehicleId, u.inst, u.seqno
+         FROM Trips t, unnest(instants(t.Trip)) WITH ORDINALITY AS u(inst, seqno) )
+       SELECT TripId AS tripId, VehicleId AS vehId,
+              (getTimestamp(Inst))::date AS day, SeqNo AS seqno,
+              getValue(Inst) AS geom,
+              getTimestamp(Inst) AS t,
+              geotoh3cell(ST_Transform(getValue(Inst), 4326), %s) AS h3_cell
+       FROM Inst
+       ORDER BY TripId, SeqNo)
+     TO ''%sinstants.csv'' DELIMITER '','' CSV HEADER', h3resolution, fullpath);
+
+  endTime = clock_timestamp();
+  RAISE INFO '------------------------------------------------------------------';
+  RAISE INFO 'Execution started at %', startTime;
+  RAISE INFO 'Execution finished at %', endTime;
+  RAISE INFO 'Execution time %', endTime - startTime;
+  RAISE INFO '------------------------------------------------------------------';
+  RETURN 'The End';
+END;
+$$ LANGUAGE 'plpgsql';
+
+-------------------------------------------------------------------------------

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -126,7 +126,7 @@ $$ LANGUAGE 'plpgsql';
  *                        - trip   : tgeompoint as hex-EWKB (SRID 3857 preserved)
  *
  * The th3index spatial prefilter is not shipped in the CSV: each platform derives
- * the trip_h3 column at ingest with h3_latlng_to_cell(trip, R), an O(1)-per-point
+ * the trip_h3 column at ingest with tgeompoint_to_th3index(trip, R), an O(1)-per-point
  * conversion through the shared MEOS kernel (same vendored libh3), so the cells are
  * identical on every engine. berlinmod_th3index_setup.sql adds and populates the
  * column (densifying form, sound for the eIntersects/eContains prefilter) and builds

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -122,36 +122,30 @@ $$ LANGUAGE 'plpgsql';
  *
  * Schema produced:
  *   vehicles.csv       : vehId, licence, type, model
- *   trips.csv          : tripId, vehId, trip, trip_h3
- *                        - trip   : tgeompoint as hex-WKB (EWKB, SRID 3857)
- *                        - trip_h3: th3index temporal H3-cell index, hex-WKB,
- *                                   produced by h3_latlng_to_cell(trip, R) on the
- *                                   trip in EPSG:4326 at the chosen H3 resolution.
- *                                   Used by all three platforms as a spatial
- *                                   prefilter for the cross-join family of
- *                                   BerlinMOD queries (Q4/Q5/Q6/Q10).  R defaults
- *                                   to 7 (cell edge ≈ 1.2 km) — sound for the
- *                                   3-10 m distance thresholds the queries use.
+ *   trips.csv          : tripId, vehId, trip
+ *                        - trip   : tgeompoint as hex-EWKB (SRID 3857 preserved)
+ *
+ * The th3index spatial prefilter is not shipped in the CSV: each platform derives
+ * the trip_h3 column at ingest with h3_latlng_to_cell(trip, R), an O(1)-per-point
+ * conversion through the shared MEOS kernel (same vendored libh3), so the cells are
+ * identical on every engine. berlinmod_th3index_setup.sql adds and populates the
+ * column (densifying form, sound for the eIntersects/eContains prefilter) and builds
+ * its GiST index for the cross-join family (Q4/Q5/Q6/Q10) at resolution 7.
  *   query_licences.csv : licenceId, licence
  *   query_instants.csv : instantId, instant
  *   query_points.csv   : pointId, geom          -- geometry as WKT text
  *
  * Parameters:
  * - fullpath:    directory path (with trailing slash) where CSV files are written.
- * - h3resolution: H3 resolution for the trip_h3 column (default 7).  Use a coarser
- *                resolution (e.g. 5 — cell edge ≈ 9 km) for an even safer
- *                prefilter at the cost of selectivity.
  *
  * Example:
  *     \i berlinmod_export.sql
  *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/');
- *     SELECT berlinmod_portability_export('/home/mobilitydb/portability/', 7);
  *****************************************************************************/
 
 DROP FUNCTION IF EXISTS berlinmod_portability_export;
 CREATE OR REPLACE FUNCTION berlinmod_portability_export(
-    fullpath      text,
-    h3resolution  integer DEFAULT 7)
+    fullpath      text)
 RETURNS text AS $$
 DECLARE
   startTime timestamptz;
@@ -161,7 +155,6 @@ BEGIN
   RAISE INFO '------------------------------------------------------------------';
   RAISE INFO 'Exporting BerlinMOD data in cross-platform portability schema';
   RAISE INFO 'Target: %', fullpath;
-  RAISE INFO 'H3 resolution for trip_h3: %', h3resolution;
   RAISE INFO 'Execution started at %', startTime;
   RAISE INFO '------------------------------------------------------------------';
 
@@ -172,13 +165,12 @@ BEGIN
            FROM Vehicles ORDER BY VehicleId)
      TO ''%svehicles.csv'' DELIMITER '','' CSV HEADER', fullpath);
 
-  RAISE INFO 'Exporting trips.csv (trip as hex-WKB + trip_h3 as hex-WKB at resolution %)', h3resolution;
+  RAISE INFO 'Exporting trips.csv (trip as hex-EWKB, SRID 3857)';
   EXECUTE format(
     'COPY (SELECT TripId AS tripId, VehicleId AS vehId,
-                  asHexEWKB(Trip) AS trip,
-                  asHexWKB(h3_latlng_to_cell(transform(Trip, 4326), %s)) AS trip_h3
+                  asHexEWKB(Trip) AS trip
            FROM Trips ORDER BY TripId)
-     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', h3resolution, fullpath);
+     TO ''%strips.csv'' DELIMITER '','' CSV HEADER', fullpath);
 
   RAISE INFO 'Exporting query_licences.csv';
   EXECUTE format(

--- a/BerlinMOD/berlinmod_export.sql
+++ b/BerlinMOD/berlinmod_export.sql
@@ -123,15 +123,15 @@ $$ LANGUAGE 'plpgsql';
  * Schema produced:
  *   vehicles.csv       : vehId, licence, type, model
  *   trips.csv          : tripId, vehId, trip, trip_h3
- *                        - trip   : tgeompoint as WKT text
+ *                        - trip   : tgeompoint as hex-WKB (EWKB, SRID 3857)
  *                        - trip_h3: th3index temporal H3-cell index, hex-WKB,
- *                                   produced by tgeompoint_to_th3index(trip, R)
- *                                   at the chosen H3 resolution.  Used by all
- *                                   three platforms as a spatial prefilter for
- *                                   the cross-join family of BerlinMOD queries
- *                                   (Q4/Q5/Q6/Q10).  R defaults to 7 (cell edge
- *                                   ≈ 1.2 km) — sound for the 3-10 m distance
- *                                   thresholds the queries use.
+ *                                   produced by h3_latlng_to_cell(trip, R) on the
+ *                                   trip in EPSG:4326 at the chosen H3 resolution.
+ *                                   Used by all three platforms as a spatial
+ *                                   prefilter for the cross-join family of
+ *                                   BerlinMOD queries (Q4/Q5/Q6/Q10).  R defaults
+ *                                   to 7 (cell edge ≈ 1.2 km) — sound for the
+ *                                   3-10 m distance thresholds the queries use.
  *   query_licences.csv : licenceId, licence
  *   query_instants.csv : instantId, instant
  *   query_points.csv   : pointId, geom          -- geometry as WKT text
@@ -172,11 +172,11 @@ BEGIN
            FROM Vehicles ORDER BY VehicleId)
      TO ''%svehicles.csv'' DELIMITER '','' CSV HEADER', fullpath);
 
-  RAISE INFO 'Exporting trips.csv (trip as WKT text + trip_h3 as hex-WKB at resolution %)', h3resolution;
+  RAISE INFO 'Exporting trips.csv (trip as hex-WKB + trip_h3 as hex-WKB at resolution %)', h3resolution;
   EXECUTE format(
     'COPY (SELECT TripId AS tripId, VehicleId AS vehId,
-                  asText(Trip) AS trip,
-                  asHexWKB(tgeompoint_to_th3index(Trip, %s)) AS trip_h3
+                  asHexEWKB(Trip) AS trip,
+                  asHexWKB(h3_latlng_to_cell(transform(Trip, 4326), %s)) AS trip_h3
            FROM Trips ORDER BY TripId)
      TO ''%strips.csv'' DELIMITER '','' CSV HEADER', h3resolution, fullpath);
 

--- a/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
+++ b/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
@@ -22,7 +22,7 @@ prefilter applies via the point form.
 
 Prerequisites:
   - The `Trips` table carries a `trip_h3 th3index` column populated at
-    H3 resolution 7 via `h3_latlng_to_cell(transform(Trip, 4326), 7)`.
+    H3 resolution 7 via `tgeompoint_to_th3index(transform(Trip, 4326), 7)`.
     The shared CSV produced by `berlinmod_portability_export()`
     contains it; loaders on each platform unpack it.
   - The static-geometry → H3 cell-set public API is registered:

--- a/BerlinMOD/berlinmod_th3index_setup.sql
+++ b/BerlinMOD/berlinmod_th3index_setup.sql
@@ -21,9 +21,12 @@ What it does:
      predicates can be pushed down by the planner.
   4. Re-analyses the table.
 
-This script is MobilityDB/PostgreSQL specific.  The cross-platform
-loaders for MobilityDuck and MobilitySpark read `trip_h3` directly
-from the shared CSV produced by `berlinmod_portability_export()`.
+This script is MobilityDB/PostgreSQL specific.  Each platform derives
+`trip_h3` at ingest the same way — `h3_latlng_to_cell(trip, 7)` is an
+O(1)-per-point conversion through the shared MEOS kernel (the same
+vendored libh3), so the cells are identical on every engine.  The
+MobilityDuck and MobilitySpark loaders run the equivalent step in their
+own dialect; the column is not carried in the shared CSV.
 
 -----------------------------------------------------------------------------*/
 

--- a/BerlinMOD/berlinmod_th3index_setup.sql
+++ b/BerlinMOD/berlinmod_th3index_setup.sql
@@ -13,7 +13,7 @@ idempotent — safe to re-run.
 What it does:
   1. Adds `trip_h3 th3index` to the `Trips` table (NULL if absent).
   2. Populates it by converting the `Trip tgeompoint` column to a
-     `th3index` at H3 resolution 7 via `h3_latlng_to_cell`.  Resolution
+     `th3index` at H3 resolution 7 via `tgeompoint_to_th3index`.  Resolution
      7 (cell edge ~ 1.2 km) is the default for BerlinMOD; lower
      resolutions trade selectivity for coverage and may be preferable
      at larger scale factors.
@@ -22,7 +22,7 @@ What it does:
   4. Re-analyses the table.
 
 This script is MobilityDB/PostgreSQL specific.  Each platform derives
-`trip_h3` at ingest the same way — `h3_latlng_to_cell(trip, 7)` is an
+`trip_h3` at ingest the same way — `tgeompoint_to_th3index(trip, 7)` is an
 O(1)-per-point conversion through the shared MEOS kernel (the same
 vendored libh3), so the cells are identical on every engine.  The
 MobilityDuck and MobilitySpark loaders run the equivalent step in their
@@ -36,7 +36,7 @@ ALTER TABLE Trips
   ADD COLUMN IF NOT EXISTS trip_h3 th3index;
 
 UPDATE Trips
-   SET trip_h3 = h3_latlng_to_cell(Trip, 7)
+   SET trip_h3 = tgeompoint_to_th3index(Trip, 7)
  WHERE trip_h3 IS NULL;
 
 DROP INDEX IF EXISTS Trips_trip_h3_gist_idx;


### PR DESCRIPTION
berlinmod_instants_export unnests each trip's tgeompoint into its composing instants and writes instants.csv (tripId, vehId, day, seqno, geom, t, h3_cell) with the per-event H3 cell from geotoh3cell on the point in EPSG:4326. berlinmod_portability_export writes trips.csv with the trip centerline as hex-EWKB (SRID 3857) and the trip_h3 temporal H3-cell index as hex-WKB from h3_latlng_to_cell(trip in 4326, resolution). The H3 cell is computed once in the dataset at a configurable resolution (default 7) so the streaming engines (Flink, Kafka Streams, NebulaStream) and the batch engines (MobilityDB, MobilityDuck, Spark) inherit it from the dataset instead of recomputing it.