### PR TITLE
Run the documentation deploy job only on the canonical repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
     name: Deploy documentation
     runs-on: ubuntu-latest
     needs: build
+    # The gh-pages branch and Pages deployment exist only on the canonical
+    # repository; skip this job on forks, which have no gh-pages branch.
+    if: github.repository == 'MobilityDB/MobilityDB-BerlinMOD'
 
     steps:
       # checkout the gh-pages branch


### PR DESCRIPTION
The Deploy documentation job checks out the gh-pages branch, which exists only on MobilityDB/MobilityDB-BerlinMOD; gating the job to that repository skips it on forks, where the gh-pages checkout has nothing to resolve.