### PR TITLE
Describe Q5 via the set-set minDistance kernel in the benchmark docs

### DIFF
--- a/BerlinMOD/benchmarks/CrossPlatform_rqueries_readiness_2026-05-11.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_rqueries_readiness_2026-05-11.md
@@ -36,8 +36,7 @@ requires a portable harness to replace the PL/pgSQL driver.
 |---|---|---|---|
 | `ST_Intersects(geom, geom)` | Q4, Q7, Q13, Q15, Q16, Q17 | DuckDB `spatial` extension | sedona / fallback UDF |
 | `ST_Contains(geom, geom)` | Q14 | DuckDB `spatial` extension | sedona / fallback UDF |
-| `ST_Distance(geom, geom)` | Q5 | DuckDB `spatial` extension | sedona / fallback UDF |
-| `ST_Collect(geom)` | Q5 (agg) | available | sedona / fallback UDF |
+| `minDistance(tgeompoint[], tgeompoint[])` | Q5 | MobilityDuck native | MobilitySpark native |
 
 ### PG operators
 
@@ -45,7 +44,7 @@ requires a portable harness to replace the PL/pgSQL driver.
 |---|---|---|
 | `t.Trip && stbox(…)` (bbox overlap) | Q11–Q15 | `eIntersects(t.Trip, stbox)` or `overlaps_stbox(stbox(t.Trip), …)` |
 | `t.Trip @> point` (contains) | Q3, Q11, Q12 | `eContains(t.Trip, point)` or `valueAtTimestamp` check |
-| `length(t.Trip) <-> point` (distance) | Q5 indirectly via min | function-call form available |
+| `length(t.Trip) <-> point` (distance) | distance ordering | function-call form available |
 
 ### PG harness (not portable as-is)
 

--- a/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings_2026-05-12.md
@@ -27,7 +27,7 @@ table that matters for you.
 | **Trip × static** | Q4, Q7, Q11, Q12, Q15, Q17 | a trip against a query point or polygon |
 | **Trip × trip** | Q6, Q10 | a trip against another trip (cross-join) |
 | **Trip × region** | Q13, Q14, Q16 | a trip against query regions over time periods |
-| **Aggregated cross-join** | Q5 | minimum distance over the full vehicle cross-join |
+| **Aggregated cross-join** | Q5 | minimum distance over the full vehicle cross-join, via the set-set `minDistance(tgeompoint[], tgeompoint[])` kernel |
 
 The shared spatial accelerator is `th3index` — a temporal H3-cell index of each
 trip, available on all three engines. The cross-join shapes (Q4–Q7, Q10) are
@@ -109,8 +109,11 @@ a penalty elsewhere.
 | Q16 | trip × trip × region | 16.35 | 14.59 | neutral |
 
 \*On region queries the H3 cell-set covers most of the city at this scale, so the
-prefilter adds work without pruning. Q5 (aggregated cross-join) has no
-answer-preserving prefilter — its th3index cell is a throughput diagnostic only.
+prefilter adds work without pruning. Q5 (aggregated cross-join) aggregates each
+vehicle group's trips into a `tgeompoint[]` and calls the set-set
+`minDistance(tgeompoint[], tgeompoint[])` kernel, which already carries its own
+per-trip STBox lower-bound prefilter; a th3index cell adds no answer-preserving
+pruning on top, so the th3index cell is a throughput diagnostic only.
 
 ![th3index accelerator](cross_platform_th3index.svg)
 


### PR DESCRIPTION
The benchmark timings and readiness docs describe Q5 as the set-set minDistance(tgeompoint[], tgeompoint[]) cross-join, whose kernel carries its own per-trip STBox lower-bound prefilter, so a th3index cell adds no answer-preserving pruning. The readiness function inventory lists minDistance as Q5's spatial function.