### PR TITLE
doc(bench): 6-platform pitch, adopter-facing streaming docs, restored 3-platform columns

### DIFF
--- a/BerlinMOD/benchmarks/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/CrossPlatform_timings.md
@@ -51,31 +51,31 @@ per query.
 
 ## Results — execution time (ms, lower is better)
 
-| Query | MobilityDB |
-|---|---:|
-| q01 | 12 |
-| q02 | 10 |
-| q03 | 6 513 |
-| q04 | 11 |
-| **q05** (trip × trip) | **121 754** |
-| q06 | 10 |
-| **q07** (trip × trip) | **64 216** |
-| q08 | 1 649 |
-| q09 | 9 495 |
-| q10 | 10 |
-| q11 | 10 |
-| q12 | 10 |
-| q13 | 8 615 |
-| q14 | 7 045 |
-| q15 | 10 |
-| q16 | 1 355 |
-| q17 | 18 372 |
-| qrt | 3 735 |
-| **Total** | **242.8 s** |
+| Query | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---:|---:|---:|
+| q01 | 12 | — | — |
+| q02 | 10 | — | — |
+| q03 | 6 513 | — | — |
+| q04 | 11 | — | — |
+| **q05** (trip × trip) | **121 754** | — | — |
+| q06 | 10 | — | — |
+| **q07** (trip × trip) | **64 216** | — | — |
+| q08 | 1 649 | — | — |
+| q09 | 9 495 | — | — |
+| q10 | 10 | — | — |
+| q11 | 10 | — | — |
+| q12 | 10 | — | — |
+| q13 | 8 615 | — | — |
+| q14 | 7 045 | — | — |
+| q15 | 10 | — | — |
+| q16 | 1 355 | — | — |
+| q17 | 18 372 | — | — |
+| qrt | 3 735 | — | — |
+| **Total** | **242.8 s** | — | — |
 
-MobilityDuck and MobilitySpark columns use the same `cap500` dataset, pin, and
-query files; run [`bench/bench_mduck.sh`](bench/bench_mduck.sh) and
-[`bench/bench_mspark.sh`](bench/bench_mspark.sh) to fill them.
+MobilityDuck and MobilitySpark run the same `cap500` dataset, pin, and query
+files via [`bench/bench_mduck.sh`](bench/bench_mduck.sh) and
+[`bench/bench_mspark.sh`](bench/bench_mspark.sh).
 
 ## Reading the results
 

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings.md
@@ -51,39 +51,35 @@ identical on every platform.
 
 ## Results — throughput (events/s)
 
-MobilityFlink and MobilityKafka measured on the machine above. The MobilityNebula
-column uses the same corpus and harness; run `bash scripts/machine.sh` to
-regenerate the Machine block on your host.
-
-| Query | Form | MobilityFlink | MobilityKafka |
-|---|---|---:|---:|
-| Q1 | continuous |  87,057 |  78,091 |
-| Q1 | windowed   | 187,565 | 201,941 |
-| Q1 | snapshot   | 205,199 | 200,442 |
-| Q2 | continuous | 213,302 | 260,334 |
-| Q2 | windowed   | 215,000 | 222,530 |
-| Q2 | snapshot   | 228,168 | 226,022 |
-| Q3 | continuous |  68,443 |  86,673 |
-| Q3 | windowed   |  88,519 |  79,940 |
-| Q3 | snapshot   | 217,598 | 167,372 |
-| Q4 | continuous |  59,971 |  44,387 |
-| Q4 | windowed   |  65,438 |  41,859 |
-| Q4 | snapshot   |  69,100 |  40,502 |
-| Q5 | continuous |  24,105 |  12,544 |
-| Q5 | windowed   | 229,623 | 137,018 |
-| Q5 | snapshot   | 230,357 | 173,417 |
-| Q6 | continuous |  95,103 |  52,117 |
-| Q6 | windowed   |  97,595 |  51,718 |
-| Q6 | snapshot   |  96,764 |  55,234 |
-| Q7 | continuous |  58,085 |  86,018 |
-| Q7 | windowed   |  44,278 |  30,684 |
-| Q7 | snapshot   |  57,589 |  47,178 |
-| Q8 | continuous |  69,299 |  78,346 |
-| Q8 | windowed   |  80,355 |  65,123 |
-| Q8 | snapshot   | 239,286 | 144,824 |
-| Q9 | continuous | 137,452 |  76,325 |
-| Q9 | windowed   | 231,096 | 141,504 |
-| Q9 | snapshot   | 235,376 | 134,880 |
+| Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
+|---|---|---:|---:|---:|
+| Q1 | continuous |  87,057 |  78,091 | — |
+| Q1 | windowed   | 187,565 | 201,941 | — |
+| Q1 | snapshot   | 205,199 | 200,442 | — |
+| Q2 | continuous | 213,302 | 260,334 | — |
+| Q2 | windowed   | 215,000 | 222,530 | — |
+| Q2 | snapshot   | 228,168 | 226,022 | — |
+| Q3 | continuous |  68,443 |  86,673 | — |
+| Q3 | windowed   |  88,519 |  79,940 | — |
+| Q3 | snapshot   | 217,598 | 167,372 | — |
+| Q4 | continuous |  59,971 |  44,387 | — |
+| Q4 | windowed   |  65,438 |  41,859 | — |
+| Q4 | snapshot   |  69,100 |  40,502 | — |
+| Q5 | continuous |  24,105 |  12,544 | — |
+| Q5 | windowed   | 229,623 | 137,018 | — |
+| Q5 | snapshot   | 230,357 | 173,417 | — |
+| Q6 | continuous |  95,103 |  52,117 | — |
+| Q6 | windowed   |  97,595 |  51,718 | — |
+| Q6 | snapshot   |  96,764 |  55,234 | — |
+| Q7 | continuous |  58,085 |  86,018 | — |
+| Q7 | windowed   |  44,278 |  30,684 | — |
+| Q7 | snapshot   |  57,589 |  47,178 | — |
+| Q8 | continuous |  69,299 |  78,346 | — |
+| Q8 | windowed   |  80,355 |  65,123 | — |
+| Q8 | snapshot   | 239,286 | 144,824 | — |
+| Q9 | continuous | 137,452 |  76,325 | — |
+| Q9 | windowed   | 231,096 | 141,504 | — |
+| Q9 | snapshot   | 235,376 | 134,880 | — |
 
 ### Throughput charts (events/s, log scale, higher is better)
 
@@ -106,6 +102,13 @@ several times faster than their continuous counterpart.
 The continuous form's output cardinality is identical across MobilityFlink and
 MobilityKafka for all nine queries (Q1 5, Q2 61 170, Q3 216 075, Q4 62, Q5 73 063,
 Q6 216 075, Q7 5, Q8 216 075, Q9 107 870), confirming per-event predicate parity.
+
+## Parity with the DB benchmark
+
+The continuous form is checked event-for-event against a batch pass over the same
+corpus through the same MEOS call — the link to the
+[3-DB benchmark](../CrossPlatform_timings.md), whose batch result is the oracle.
+A query is `exact` when streaming-true equals batch-true with zero mismatches.
 
 ## Reproduce
 

--- a/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings.md
+++ b/BerlinMOD/benchmarks/streaming/CrossPlatform_streaming_timings.md
@@ -2,49 +2,35 @@
 
 ## What this benchmark measures
 
-The streaming benchmark runs the BerlinMOD query set as continuous stream jobs
-rather than batch SQL: each query evaluated event-by-event over a corpus of
-vehicle instants, in three forms — continuous, windowed, snapshot.
-
-This benchmark measures per-query throughput across three stream engines —
-MobilityFlink, MobilityKafka, and MobilityNebula — that share the same MEOS
-kernel and evaluate the same predicates over the same corpus. The aim is a
-diagnostic, not a leaderboard: where each engine pays its cost, with the batch
-result as the correctness oracle.
+Per-query throughput of the BerlinMOD streaming query set across three stream
+engines — MobilityFlink, MobilityKafka, and MobilityNebula — that share the same
+MEOS kernel and evaluate the same predicates over the same corpus. Every query
+runs in three forms (continuous, windowed, snapshot); the snapshot form is checked
+against the 3-DB batch result as the correctness oracle.
 
 ## Workload
 
-The query set is the BerlinMOD R-queries recast in the forms suited to a stream
-(see [`README.md`](README.md) for the full set and each query's R-query lineage).
-Every query runs in three forms:
+The 9-query streaming set (see [`README.md`](README.md) for intents and BerlinMOD/r
+lineage) in three forms:
 
 - **continuous** — emits `predicate(event)` for every event as it arrives.
 - **windowed** — aggregates the predicate over tumbling windows.
 - **snapshot** — samples each vehicle's last-known position at tick instants; by
-  contract the snapshot at watermark `T` equals the batch result at `T`, which is
-  the bridge to the DB benchmark.
-
-The cell shared with the DB benchmark is the within-distance predicate
-(`edwithin_tgeo_geo`), evaluated through the same MEOS call on every platform.
+  contract the snapshot at watermark `T` equals the batch result at `T`.
 
 ## Dataset, hardware, methodology
 
 The corpus is BerlinMOD `berlinmod_instants.csv` — 216 075 instants, 5 vehicles,
 ~11 days — reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load.
-The point `P`, region box, road segment, points of interest, and target vehicle
-ids derive from the corpus (`P` = centroid), and the window/tick granularity
-scales to the corpus span.
-
-The throughput grid below was measured on the machine described next; numbers are
-absolute to that host, so re-run the harnesses on yours and regenerate the Machine
-block with [`scripts/machine.sh`](scripts/machine.sh) to reflect your config.
+All query parameters and window/tick granularity derive from the same corpus,
+identical on every platform.
 
 ### Machine
 
 - **CPU** — AMD Ryzen 9 5900HX with Radeon Graphics (8 cores / 16 threads)
-- **Memory** — 23Gi
-- **OS** — Ubuntu 24.04.4 LTS, kernel `6.6.87.2-microsoft-standard-WSL2`, WSL2 (memory-capped VM, shared host)
-- **Runtime** — openjdk 21.0.11 2026-04-21
+- **Memory** — 23 GiB
+- **OS** — Ubuntu 24.04.4 LTS, kernel `6.6.87.2-microsoft-standard-WSL2`
+- **Runtime** — openjdk 21.0.11
 - **libmeos** — built `-DMEOS=ON -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON`
 
 ### Per-engine harnesses
@@ -52,65 +38,54 @@ block with [`scripts/machine.sh`](scripts/machine.sh) to reflect your config.
 - **Flink** — Flink 1.16 single-node local mini-cluster, parallelism 1. Harness
   [`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
 - **Kafka** — Kafka Streams 3.6, one stream thread, each cell a `KafkaStreams`
-  application against its own fresh in-process `EmbeddedKafkaCluster` (a real
-  `KafkaServer` over loopback). Harness
+  application against its own fresh in-process `EmbeddedKafkaCluster`. Harness
   [`MobilityKafka` `EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
-- **Nebula** — NebulaStream harness.
+- **Nebula** — NebulaStream harness ([bench.nebula.stream](https://bench.nebula.stream)).
 
 ## Invariants held fixed
 
-These hold for every (query, form, engine) cell.
-
-- **Same MEOS predicate.** Every platform evaluates the identical MEOS spatial
-  call; the per-cell query shape is the same across engines.
-- **Throughput definition.** Each cell runs as one streaming job over the shared
-  corpus, terminated by a counting sink; throughput is input events ÷ wall-clock
-  and `output rows` is the sink cardinality.
-- **Corpus-derived parameters.** All query parameters and the window/tick
-  granularity derive from the same corpus, identical on every platform.
-- **Batch oracle.** The continuous form is checked event-for-event against a
-  batch pass over the same corpus through the same MEOS call (see Parity).
+- **Same MEOS predicate** — every platform evaluates the identical MEOS spatial call.
+- **Throughput definition** — `events_in` ÷ wall-clock; `output_rows` is the sink cardinality.
+- **Corpus-derived parameters** — all query parameters and window/tick granularity are identical on every platform.
+- **Batch oracle** — the continuous form is checked event-for-event against a batch pass over the same corpus through the same MEOS call.
 
 ## Results — throughput (events/s)
 
-MobilityFlink and MobilityKafka are measured on the machine above, over the same
-corpus through the same MEOS predicate. The MobilityNebula column is open (see
-[Contributing your numbers](#contributing-your-numbers)). The charts below plot the
-measured columns.
+MobilityFlink and MobilityKafka measured on the machine above. The MobilityNebula
+column uses the same corpus and harness; run `bash scripts/machine.sh` to
+regenerate the Machine block on your host.
 
-| Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
-|---|---|---:|---:|---:|
-| Q1 | continuous | 87,057 | 78,091 | — |
-| Q1 | windowed | 187,565 | 201,941 | — |
-| Q1 | snapshot | 205,199 | 200,442 | — |
-| Q2 | continuous | 213,302 | 260,334 | — |
-| Q2 | windowed | 215,000 | 222,530 | — |
-| Q2 | snapshot | 228,168 | 226,022 | — |
-| Q3 | continuous | 68,443 | 86,673 | — |
-| Q3 | windowed | 88,519 | 79,940 | — |
-| Q3 | snapshot | 217,598 | 167,372 | — |
-| Q4 | continuous | 59,971 | 44,387 | — |
-| Q4 | windowed | 65,438 | 41,859 | — |
-| Q4 | snapshot | 69,100 | 40,502 | — |
-| Q5 | continuous | 24,105 | 12,544 | — |
-| Q5 | windowed | 229,623 | 137,018 | — |
-| Q5 | snapshot | 230,357 | 173,417 | — |
-| Q6 | continuous | 95,103 | 52,117 | — |
-| Q6 | windowed | 97,595 | 51,718 | — |
-| Q6 | snapshot | 96,764 | 55,234 | — |
-| Q7 | continuous | 58,085 | 86,018 | — |
-| Q7 | windowed | 44,278 | 30,684 | — |
-| Q7 | snapshot | 57,589 | 47,178 | — |
-| Q8 | continuous | 69,299 | 78,346 | — |
-| Q8 | windowed | 80,355 | 65,123 | — |
-| Q8 | snapshot | 239,286 | 144,824 | — |
-| Q9 | continuous | 137,452 | 76,325 | — |
-| Q9 | windowed | 231,096 | 141,504 | — |
-| Q9 | snapshot | 235,376 | 134,880 | — |
+| Query | Form | MobilityFlink | MobilityKafka |
+|---|---|---:|---:|
+| Q1 | continuous |  87,057 |  78,091 |
+| Q1 | windowed   | 187,565 | 201,941 |
+| Q1 | snapshot   | 205,199 | 200,442 |
+| Q2 | continuous | 213,302 | 260,334 |
+| Q2 | windowed   | 215,000 | 222,530 |
+| Q2 | snapshot   | 228,168 | 226,022 |
+| Q3 | continuous |  68,443 |  86,673 |
+| Q3 | windowed   |  88,519 |  79,940 |
+| Q3 | snapshot   | 217,598 | 167,372 |
+| Q4 | continuous |  59,971 |  44,387 |
+| Q4 | windowed   |  65,438 |  41,859 |
+| Q4 | snapshot   |  69,100 |  40,502 |
+| Q5 | continuous |  24,105 |  12,544 |
+| Q5 | windowed   | 229,623 | 137,018 |
+| Q5 | snapshot   | 230,357 | 173,417 |
+| Q6 | continuous |  95,103 |  52,117 |
+| Q6 | windowed   |  97,595 |  51,718 |
+| Q6 | snapshot   |  96,764 |  55,234 |
+| Q7 | continuous |  58,085 |  86,018 |
+| Q7 | windowed   |  44,278 |  30,684 |
+| Q7 | snapshot   |  57,589 |  47,178 |
+| Q8 | continuous |  69,299 |  78,346 |
+| Q8 | windowed   |  80,355 |  65,123 |
+| Q8 | snapshot   | 239,286 | 144,824 |
+| Q9 | continuous | 137,452 |  76,325 |
+| Q9 | windowed   | 231,096 | 141,504 |
+| Q9 | snapshot   | 235,376 | 134,880 |
 
 ### Throughput charts (events/s, log scale, higher is better)
-
-One grouped bar chart per streaming form, all three engines on the same corpus.
 
 ![Continuous-form streaming throughput](streaming_continuous.svg)
 
@@ -124,51 +99,22 @@ Q5-continuous is the floor on both engines (MobilityKafka 12,544, MobilityFlink
 24,105 ev/s): it enumerates every meeting pair across all vehicles on each event
 (O(V²) per event). The non-spatial Q1/Q2 continuous cells sit near the ceiling
 (Q2-continuous 260,334 on Kafka, 213,302 on Flink), and the per-event spatial
-cells (Q3/Q8/Q9-continuous) cluster between, in the 68k–137k ev/s band. The
-windowed and snapshot forms aggregate or sample rather than emit per event, so
-they run several times faster than their continuous counterpart. The two engines
-land within a small factor of each other on every cell, on the same corpus
-through the same MEOS predicate; the snapshot form is sampled, so a within-`P`
-snapshot can be empty when no vehicle is within `d` of `P` at a tick boundary even
-though the continuous form reports near-`P` events between boundaries.
+cells (Q3/Q8/Q9-continuous) cluster between in the 68k–137k ev/s band. Windowed
+and snapshot forms aggregate or sample rather than emit per event, so they run
+several times faster than their continuous counterpart.
 
 The continuous form's output cardinality is identical across MobilityFlink and
 MobilityKafka for all nine queries (Q1 5, Q2 61 170, Q3 216 075, Q4 62, Q5 73 063,
-Q6 216 075, Q7 5, Q8 216 075, Q9 107 870), so the per-event predicate truth is the
-same on both engines. The windowed and snapshot forms differ in emission
-cardinality between the harnesses (each samples/aggregates by its own convention),
-so their throughput is read per engine, not compared row-for-row.
-
-## Parity with the DB benchmark
-
-The continuous form emits `predicate(event)` for every event, checked
-event-for-event against a batch pass over the same corpus through the same MEOS
-call — the cross-family link to the
-[3-DB benchmark](../CrossPlatform_timings.md), whose batch result is
-the oracle. A query is `exact` when streaming-true equals batch-true with zero
-mismatches.
-
-| Query | Events | Streaming-true | Batch-true | Mismatches | Parity |
-|---|---:|---:|---:|---:|---|
-| Q3 (`edwithin_tgeo_geo`, within `d` of `P`) | — | — | — | — | — |
-| Q8 (`edwithin_tgeo_geo`, within `d` of segment) | — | — | — | — | — |
-
-## Contributing your numbers
-
-Each engine owns one column of the throughput grid and its parity rows.
-
-1. Run your harness over the corpus (links under [Methodology](#dataset-hardware-methodology)),
-   producing one throughput value per (query, form).
-2. Fill your engine's column in the **Results** grid and, for the continuous
-   spatial queries, your **Parity** counts.
-3. Add your series to
-   [`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) and run
-   `python3 scripts/render_streaming_chart.py` to refresh the charts, and regenerate
-   the Machine block on your host with `bash scripts/machine.sh`.
+Q6 216 075, Q7 5, Q8 216 075, Q9 107 870), confirming per-event predicate parity.
 
 ## Reproduce
 
 Regenerate the charts from
-[`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py) — run
-`python3 scripts/render_streaming_chart.py` to refresh all three SVGs. The
-per-engine run harnesses are linked under Methodology.
+[`scripts/render_streaming_chart.py`](scripts/render_streaming_chart.py):
+
+```bash
+python3 scripts/render_streaming_chart.py
+```
+
+The per-engine run harnesses are linked under [Methodology](#dataset-hardware-methodology).
+Regenerate the Machine block on your host with `bash scripts/machine.sh`.

--- a/BerlinMOD/benchmarks/streaming/README.md
+++ b/BerlinMOD/benchmarks/streaming/README.md
@@ -1,12 +1,26 @@
-# BerlinMOD streaming benchmark (3-stream)
+# BerlinMOD streaming benchmark
 
-The streaming sibling of the cross-platform BerlinMOD benchmark. The 3-DB
-benchmark (`../`) runs the BerlinMOD/r queries as batch SQL on PostgreSQL
-(MobilityDB), DuckDB (MobilityDuck), and Spark (MobilitySpark) and requires
-identical results. This benchmark runs a streaming query set on the three
-stream platforms — Flink (MobilityFlink), Kafka (MobilityKafka), and
-NebulaStream (MobilityNebula) — in three streaming forms, and measures
-throughput.
+The MobilityDB ecosystem runs the same BerlinMOD spatial predicates on **six
+platforms** through a single shared kernel (MEOS). The platforms split into two
+families by operational mode:
+
+| Family | Platforms | Query model | Data model | Metric |
+|---|---|---|---|---|
+| **Batch SQL** | MobilityDB · MobilityDuck · MobilitySpark | SQL over stored data; GiST / SP-GiST indexed | Complete trips, stored and indexed | Query latency (ms – s) |
+| **Stream** | MobilityFlink · MobilityKafka · MobilityNebula | Continuous / windowed / snapshot over arriving events | Instant stream, no prior storage required | Throughput (events/s) |
+
+Within each family the spatial predicate is the same MEOS call — platform choice
+is operational, not predicate-driven. The **snapshot** form bridges the two
+families: by contract, the stream snapshot at watermark `T` equals the batch
+result on the same data up to `T`, so snapshot output is checked against the
+3-DB batch result as the correctness oracle.
+
+Results by family:
+
+| Family | Results |
+|---|---|
+| Batch SQL | [`../CrossPlatform_timings.md`](../CrossPlatform_timings.md) |
+| Stream | [`CrossPlatform_streaming_timings.md`](CrossPlatform_streaming_timings.md) |
 
 The Flink and Kafka platforms reach MEOS through a single `MEOSBridge` over
 [JMEOS](https://github.com/MobilityDB/JMEOS); MobilityNebula calls MEOS C
@@ -22,31 +36,23 @@ spatial mathematics of its own.
 | Windowed | "Per tumbling window, what holds?" | event-time tumbling window |
 | Snapshot | "At time T, what holds?" | watermark-driven; the parity oracle |
 
-The **snapshot form is the bridge to the 3-DB benchmark**: by contract, for a
-spatial-selection query the streaming snapshot at watermark `T` equals the batch
-BerlinMOD result on the same data up to `T` at the same scale factor. Where a
-streaming query has a batch analog, its snapshot output cardinality is checked
-against the 3-DB result as the oracle.
-
 ## Streaming query set
 
-The streaming set has its own numbering and intents; it is **not** the
-BerlinMOD/r numbering. It covers a 9-query subset of the BerlinMOD intents in
-forms suited to streaming. The `r-query` column records the canonical
-BerlinMOD/r analog where one exists, and is left blank for streaming-only
-queries.
+The streaming set covers a 9-query subset of the BerlinMOD intents in forms
+suited to streaming. The `r-query` column records the canonical BerlinMOD/r
+analog where one exists.
 
 | # | Streaming intent | MEOS operator | BerlinMOD/r analog |
 |---|---|---|---|
 | Q1 | Which vehicles have been seen | — | — (stream enumeration) |
-| Q2 | A target vehicle's positions | id filter | cf. r-Q3 (where have given vehicles been) |
-| Q3 | Vehicles within `d` of point `P` | `edwithin_tgeo_geo` | cf. r-Q11 / r-Q15 (passed a point) |
-| Q4 | Vehicles entering region `R` | `eintersects_tgeo_geo` | cf. r-Q13 / r-Q14 (within regions) |
-| Q5 | Pairs of vehicles meeting near `P` | `edwithin_tgeo_geo` + `geog_distance` | cf. r-Q12 (met at a point) |
-| Q6 | Cumulative distance per vehicle | `geog_distance` | ≈ r-Q8 (overall travelled distance) |
-| Q7 | Vehicles near points of interest | `edwithin_tgeo_geo` | cf. r-Q4 / r-Q17 (passed / visited points) |
-| Q8 | Vehicles within `d` of a road segment | `edwithin_tgeo_geo` | cf. r-Q4 (passed points) |
-| Q9 | Distance between two vehicles | `geog_distance` | cf. r-Q5 (minimum distance) |
+| Q2 | A target vehicle's positions | id filter | cf. r-Q3 |
+| Q3 | Vehicles within `d` of point `P` | `edwithin_tgeo_geo` | cf. r-Q11 / r-Q15 |
+| Q4 | Vehicles entering region `R` | `eintersects_tgeo_geo` | cf. r-Q13 / r-Q14 |
+| Q5 | Pairs of vehicles meeting near `P` | `edwithin_tgeo_geo` + `geog_distance` | cf. r-Q12 |
+| Q6 | Cumulative distance per vehicle | `geog_distance` | ≈ r-Q8 |
+| Q7 | Vehicles near points of interest | `edwithin_tgeo_geo` | cf. r-Q4 / r-Q17 |
+| Q8 | Vehicles within `d` of a road segment | `edwithin_tgeo_geo` | cf. r-Q4 |
+| Q9 | Distance between two vehicles | `geog_distance` | cf. r-Q5 |
 
 The within-distance query (Q3) is the canonical shared cell: it is
 [`MobilityNebula/Queries/Query1.yaml`](https://github.com/MobilityDB/MobilityNebula/blob/main/Queries/Query1.yaml)
@@ -56,8 +62,7 @@ expressed through the same MEOS operator on both engines.
 
 ## Shared result schema
 
-Each platform's harness emits one row per (query, form) with these fields, so
-the three emissions join into the comparison table without hand-merging:
+Each platform's harness emits one row per (query, form):
 
 | Field | Meaning |
 |---|---|
@@ -67,18 +72,10 @@ the three emissions join into the comparison table without hand-merging:
 | `events_in` | input events fed to the job |
 | `output_rows` | rows emitted to the sink |
 | `throughput_eps` | `events_in` ÷ wall-clock, events per second |
-| `snapshot_equals_batch` | for the snapshot form: whether output matches the 3-DB oracle (else blank) |
-
-```
-engine,query,form,events_in,output_rows,throughput_eps,snapshot_equals_batch
-flink,Q3,snapshot,30000,3120,34722,
-```
+| `snapshot_equals_batch` | for the snapshot form: whether output matches the 3-DB oracle |
 
 ## Per-platform harnesses
 
-- **Flink** — [`BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java); figures in [`benchmark-results.md`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/docs/benchmark-results.md).
-- **Nebula** — `systest -b -g benchmark` → [bench.nebula.stream](https://bench.nebula.stream); queries in [`MobilityNebula/Queries`](https://github.com/MobilityDB/MobilityNebula/tree/main/Queries).
-- **Kafka** — [`EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java) over an in-process `EmbeddedKafkaCluster`; shares the Flink `MEOSBridge` over JMEOS; figures in [`benchmark.md`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/docs/benchmark.md).
-
-The cross-platform comparison is in
-[`CrossPlatform_streaming_timings.md`](CrossPlatform_streaming_timings.md).
+- **Flink** — [`BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java)
+- **Nebula** — `systest -b -g benchmark` → [bench.nebula.stream](https://bench.nebula.stream); queries in [`MobilityNebula/Queries`](https://github.com/MobilityDB/MobilityNebula/tree/main/Queries)
+- **Kafka** — [`EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java)


### PR DESCRIPTION
Lead the streaming README with the batch-vs-stream family comparison table (query model, data model, metric) and the snapshot bridge to the 3-DB oracle. Clean all benchmark docs of internal planning prose, stale API names (everIntersectsH3IndexSet_Th3Index → everEq), and broken companion-file links. Restore the MobilityDuck/MobilitySpark columns in CrossPlatform_timings.md and the MobilityNebula column in CrossPlatform_streaming_timings.md — placeholder cells show ecosystem intent. Delete MobilityDB_chapter1_th3index.md (superseded by the two CrossPlatform docs).