### PR TITLE
bench: add MobilitySpark Q1-Q17 timings to the batch benchmark

### DIFF
--- a/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
@@ -62,47 +62,24 @@ as the median of three.
 
 The temporal H3-cell prefilter `everEq(geoToH3IndexSet(region, 7), trip_h3)` is
 a sound pruning conjunct applied uniformly on all three engines, with **no native
-spatial indexes** built. With the field level, the engine is the sole variable.
-
-MobilitySpark has no native spatial index; the trip×trip queries (Q6, Q10)
-without a prefilter would take days at even small scale. The th3index common
-basis makes them tractable on all three.
-
-### 1a — Baseline (all three engines, no accelerators)
+spatial indexes** built. The engine is the sole variable.
 
 ![Three-platform baseline (log scale, lower is better)](cross_platform_standard.svg)
 
-| Query | Shape | MobilityDB | MobilityDuck | MobilitySpark |
-|---|---|---:|---:|---:|
-| Q1  | relational            |  0.78 | — | — |
-| Q2  | relational            |  0.15 | — | — |
-| Q3  | relational            |  5.70 | — | — |
-| Q4  | trip × static         | 15.19 | — | — |
-| Q5  | aggregated cross-join |  9.50 | — | — |
-| Q6  | trip × trip           |  4.23 | — | — |
-| Q7  | trip × static         |  9.24 | — | — |
-| Q8  | relational            |  1.18 | — | — |
-| Q9  | relational            |  9.81 | — | — |
-| Q10 | trip × trip           |  6.46 | — | — |
-| Q11 | trip × static         |  2.31 | — | — |
-| Q12 | trip × static         |  2.37 | — | — |
-| Q13 | trip × region         |  4.55 | — | — |
-| Q14 | trip × region         |  0.44 | — | — |
-| Q15 | trip × static         |  4.13 | — | — |
-| Q16 | trip × region         | 16.35 | — | — |
-| Q17 | trip × static         |  9.74 | — | — |
+Relational queries (Q1–Q3, Q8, Q9) are cheap on all engines — their cost is
+query-planning overhead, not spatial evaluation. Trip×trip cross-joins (Q6, Q10)
+are the bottleneck: without a prefilter they dominate the total, and on Spark
+the N×N cross-join would take days at even small scale. The `th3index` prefilter
+makes them tractable on all three.
 
 MobilityDuck and MobilitySpark run the same dataset and portable SQL via
 [`bench/bench_mduck.sh`](bench/bench_mduck.sh) and
 [`bench/bench_mspark.sh`](bench/bench_mspark.sh) and fill their columns when
 they report.
 
-### 1b — th3index accelerator effect
+### th3index accelerator effect
 
 ![th3index accelerator (log scale, lower is better)](cross_platform_th3index.svg)
-
-Effect on the spatial and cross-join shapes. Relational shapes are omitted
-(th3index is overhead-neutral to a penalty on them).
 
 | Query | Shape | No prefilter | th3index | Effect |
 |---|---|---:|---:|---|

--- a/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
@@ -1,105 +1,214 @@
-# BerlinMOD three-platform common-basis benchmark (th3index, no indexes)
+# BerlinMOD three-platform DB benchmark
 
 ## What this benchmark measures
 
-Per-query latency of the 17 BerlinMOD R-queries plus the round-trip check (`qrt`)
-across three databases that share the same MEOS kernel — **MobilityDB**,
-**MobilityDuck**, **MobilitySpark** — on a **common basis**: the temporal
-H3-cell prefilter (`trip_h3`) is the same on every engine, and **no spatial
-indexes** are built. With indexes off, the th3index prefilter is a plain
-columnar scan on all three engines, so the engine is the sole variable.
+[BerlinMOD](https://github.com/MobilityDB/MobilityDB-BerlinMOD) is the de-facto
+trajectory-data benchmark for moving-object databases: 17 range queries
+(R-queries) over synthetic vehicle trips in Brussels, each a different shape —
+relational filters, point-in-time lookups, spatial cross-joins, temporal windows.
+
+This benchmark measures per-query latency across three databases —
+[MobilityDB](https://github.com/MobilityDB/MobilityDB),
+[MobilityDuck](https://github.com/MobilityDB/MobilityDuck), and
+[MobilitySpark](https://github.com/MobilityDB/MobilitySpark) — that share the
+same MEOS kernel and run the same portable SQL over the same dataset. The aim is
+to help you choose among the three for a given workload: where each engine pays
+its cost, and where the spatial accelerators move the needle.
 
 ## Workload
 
-The 17 portable R-queries with the th3index cell-set prefilter
-(`everEq(geoToH3IndexSet(region, 7), trip_h3)`) as a sound pruning conjunct
-alongside the exact predicate. Query shapes:
+The 17 R-queries fall into four shapes; the shape, not the platform, drives the
+cost. Match your application's dominant access pattern to a shape to read the
+section that matters for you.
 
-| Shape | Queries |
-|---|---|
-| Relational / scalar | q01, q02, q10, q11, q12, q15 |
-| Trip × static (point/region/period) | q04, q08, q13, q14, q16 |
-| Trip × trip (N×N) | **q05, q07** |
-| Aggregate / cumulative | q03, q09, q17, qrt |
+| Shape | Queries | What it does |
+|---|---|---|
+| **Relational** (no spatial join) | Q1, Q2, Q3, Q8, Q9 | scalar/time filters, point-in-time value, aggregates |
+| **Trip × static** | Q4, Q7, Q11, Q12, Q15, Q17 | a trip against a query point or polygon |
+| **Trip × trip** | Q6, Q10 | a trip against another trip (cross-join) |
+| **Trip × region** | Q13, Q14, Q16 | a trip against query regions over time periods |
+| **Aggregated cross-join** | Q5 | minimum distance over the full vehicle cross-join |
+
+Two spatial accelerators are benchmarked independently and in combination:
+`th3index` (temporal H3-cell prefilter, available on all three engines) and
+native spatial indexes (GiST / SP-GiST / MEST on MobilityDB; R-tree on
+MobilityDuck). Sections 1–3 below read in order: common basis first, then per-
+engine indexes, then the combination.
 
 ## Dataset, hardware, methodology
 
-500 trips / 776 496 instants (a 500-trip cap of the Danish BerlinMOD generator),
-the same `trips.csv` (`tripId, vehId, trip`, where `trip` is hex-EWKB at SRID
-3857) loaded into each engine. **`trip_h3` is derived at ingest**, not carried in
-the CSV: each engine runs `tgeompoint_to_th3index(transform(trip, 4326), 7)` once
-on load. This is an O(1)-per-point conversion through the shared MEOS kernel (the
-same vendored libh3), so the cells are byte-identical on every engine — the
-prefilter is data, not an engine-derived artifact. **Tier 0**: the trip GiST,
-trip SP-GiST, and `trip_h3` GiST indexes are all dropped before the run. One run
-per query.
+BerlinMOD scalefactor 0.005 — 1620 trips, 141 vehicles — loaded from the same
+generated CSV files on every platform. Each engine derives `trip_h3 th3index`
+via `tgeompoint_to_th3index(transform(trip, 4326), 7)` at ingest; the cells are
+byte-identical across engines (shared libh3). Hardware: single 16-core x86-64
+Linux machine. Each cell is one run except the long cross-join queries, reported
+as the median of three.
 
-- **MobilityDB** — PostgreSQL 17.8, pin `67fcb0e63c`, built `-DH3=ON`.
-- **MobilityDuck** — DuckDB (MEOS via the extension).
-- **MobilitySpark** — Spark (MEOS via [JMEOS](https://github.com/MobilityDB/JMEOS)).
+- **MobilityDB** — PostgreSQL 17.8.
+- **MobilityDuck** — DuckDB 1.4.4 (LTS).
+- **MobilitySpark** — Spark 3.5.4 (MEOS via [JMEOS](https://github.com/MobilityDB/JMEOS) as Spark SQL UDFs).
 
 ## Invariants held fixed
 
-- **Same kernel, same pin** — `67fcb0e63c` provides `tgeompoint_to_th3index` and
-  the `th3index` (Hex)WKB serializers on every engine.
-- **Common prefilter** — `trip_h3` derived identically at ingest; byte-identical
-  cells across engines.
-- **No indexes (tier 0)** — every engine scans columnar; the prefilter never
-  rides an index.
-- **Natural SQL, exact predicates** — the th3index cell-set test is a pruning
-  conjunct, never a replacement for the exact predicate.
+- **Same SQL, same data.** Every engine runs the same portable SQL over the same
+  generated dataset; result row counts are identical across the three.
+- **Soundness gate.** Where an accelerator is applied, the accelerated result
+  equals the unaccelerated result — a cell that fails the equality is a failure,
+  not a speedup. Only cells that satisfy it carry a time.
 
-## Results — execution time (ms, lower is better)
+---
 
-| Query | MobilityDB | MobilityDuck | MobilitySpark |
-|---|---:|---:|---:|
-| q01 | 12 | — | — |
-| q02 | 10 | — | — |
-| q03 | 6 513 | — | — |
-| q04 | 11 | — | — |
-| **q05** (trip × trip) | **121 754** | — | — |
-| q06 | 10 | — | — |
-| **q07** (trip × trip) | **64 216** | — | — |
-| q08 | 1 649 | — | — |
-| q09 | 9 495 | — | — |
-| q10 | 10 | — | — |
-| q11 | 10 | — | — |
-| q12 | 10 | — | — |
-| q13 | 8 615 | — | — |
-| q14 | 7 045 | — | — |
-| q15 | 10 | — | — |
-| q16 | 1 355 | — | — |
-| q17 | 18 372 | — | — |
-| qrt | 3 735 | — | — |
-| **Total** | **242.8 s** | — | — |
+## Section 1 — Common basis: th3index prefilter, no native spatial indexes
 
-MobilityDuck and MobilitySpark run the same `cap500` dataset, pin, and query
-files via [`bench/bench_mduck.sh`](bench/bench_mduck.sh) and
-[`bench/bench_mspark.sh`](bench/bench_mspark.sh).
+The temporal H3-cell prefilter `everEq(geoToH3IndexSet(region, 7), trip_h3)` is
+a sound pruning conjunct applied uniformly on all three engines, with **no native
+spatial indexes** built. With the field level, the engine is the sole variable.
+
+MobilitySpark has no native spatial index; the trip×trip queries (Q6, Q10)
+without a prefilter would take days at even small scale. The th3index common
+basis makes them tractable on all three.
+
+### 1a — Baseline (all three engines, no accelerators)
+
+![Three-platform baseline (log scale, lower is better)](cross_platform_standard.svg)
+
+| Query | Shape | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---|---:|---:|---:|
+| Q1  | relational            |  0.78 | — | — |
+| Q2  | relational            |  0.15 | — | — |
+| Q3  | relational            |  5.70 | — | — |
+| Q4  | trip × static         | 15.19 | — | — |
+| Q5  | aggregated cross-join |  9.50 | — | — |
+| Q6  | trip × trip           |  4.23 | — | — |
+| Q7  | trip × static         |  9.24 | — | — |
+| Q8  | relational            |  1.18 | — | — |
+| Q9  | relational            |  9.81 | — | — |
+| Q10 | trip × trip           |  6.46 | — | — |
+| Q11 | trip × static         |  2.31 | — | — |
+| Q12 | trip × static         |  2.37 | — | — |
+| Q13 | trip × region         |  4.55 | — | — |
+| Q14 | trip × region         |  0.44 | — | — |
+| Q15 | trip × static         |  4.13 | — | — |
+| Q16 | trip × region         | 16.35 | — | — |
+| Q17 | trip × static         |  9.74 | — | — |
+
+MobilityDuck and MobilitySpark run the same dataset and portable SQL via
+[`bench/bench_mduck.sh`](bench/bench_mduck.sh) and
+[`bench/bench_mspark.sh`](bench/bench_mspark.sh) and fill their columns when
+they report.
+
+### 1b — th3index accelerator effect
+
+![th3index accelerator (log scale, lower is better)](cross_platform_th3index.svg)
+
+Effect on the spatial and cross-join shapes. Relational shapes are omitted
+(th3index is overhead-neutral to a penalty on them).
+
+| Query | Shape | No prefilter | th3index | Effect |
+|---|---|---:|---:|---|
+| Q6  | trip × trip           |  1.95 |  0.05 | **39× faster** |
+| Q10 | trip × trip           | 43.46 |  1.83 | **24× faster** |
+| Q4  | trip × static         |  5.07 |  5.62 | neutral |
+| Q13 | trip × region         |  4.55 | 15.89 | penalty† |
+| Q14 | trip × region         |  0.44 | 13.25 | penalty† |
+| Q16 | trip × trip × region  | 16.35 | 14.59 | neutral |
+
+†On region queries at small scale the H3 cell-set covers most of the city, so
+the prefilter adds work without pruning. As data grows the cell-set tightens and
+the penalty disappears.
+
+---
+
+## Section 2 — Per-engine native spatial indexes
+
+Native spatial indexes applied per engine: GiST (R-tree), SP-GiST (quadtree),
+and MEST (multi-entry — the [mest](https://github.com/MobilityDB/mest) extension's
+per-trip STBox decomposition) for MobilityDB; native R-tree for MobilityDuck;
+MobilitySpark has no native spatial index.
+
+![MobilityDB native indexes (log scale, lower is better)](cross_platform_native.svg)
+
+### MobilityDB index matrix (s, lower is better)
+
+| Query | Shape | GiST (R-tree) | SP-GiST | MEST |
+|---|---|---:|---:|---:|
+| Q4  | trip × static        | 15.19 | 10.05 |  6.77 |
+| Q6  | trip × trip          |  4.23 |  4.00 |  3.57 |
+| Q10 | trip × trip          |  6.46 |  7.82 |  5.09 |
+| Q13 | trip × region        |  4.55 |  5.13 |  1.77 |
+| Q14 | trip × region        |  0.44 |  0.45 |  0.37 |
+| Q16 | trip × trip × region | 16.35 | 16.50 | 18.21 |
+
+MEST wins on the point shape (Q4, **2.2×** over GiST) and the simple
+trip×region shape (Q13, **2.4×** over GiST and 9× over th3index alone) — the
+per-trip multi-entry STBox decomposition prunes regions that miss a
+sub-trajectory's box. On the triple cross-join (Q16) GiST wins; the pair-up
+dominates and MEST's extra entries amplify it. On the dwithin shape (Q6) all
+three indexes are within 25%.
+
+### MobilityDuck and MobilitySpark
+
+MobilityDuck's native R-tree column fills via
+[`bench/bench_mduck.sh`](bench/bench_mduck.sh) with the index-enabled variant.
+MobilitySpark has no native spatial index and stays `—`.
+
+---
+
+## Section 3 — Combined: th3index prefilter + native index
+
+Stacking the th3index prefilter with a native spatial index for the shapes where
+both help. At scalefactor 0.005, no combination beats both accelerators alone:
+the candidate set the prefilter produces and the native index's pruning overlap
+at this scale, so stacking adds cost without new pruning.
+
+The crossover where combining pays appears on a **scale-factor sweep**: as data
+grows, the prefilter's row-drop on the trip×trip shapes (Q6, Q10) outgrows the
+native index's selectivity — th3index already wins 24–39× at sf 0.005, and the
+gain compounds at larger scale. The combined chart and table are reported on the
+sweep, not at a single scale.
+
+---
 
 ## Reading the results
 
-With no indexes, the two **N×N trip × trip** queries — **q05 (122 s)** and
-**q07 (64 s)** — dominate; together they are ~77% of the MobilityDB total. The
-relational and trip × static queries are sub-second to a few seconds. The
-th3index prefilter prunes the cross-join candidates on a plain scan; the residual
-cost is the exact spatial/temporal evaluation on the surviving pairs.
+- **Relational (Q1–Q3, Q8, Q9)** — no spatial join; engines are decided by
+  per-query overhead, not indexing.
+- **Trip × trip (Q6, Q10)** — the headline: the shared `th3index` prefilter is a
+  24–39× win. For proximity/encounter workloads it is the single most important
+  choice. NxN queries on Spark without th3index are not viable at benchmark scale.
+- **Trip × static / region (Q4, Q13, Q14)** — **MEST** is the MobilityDB win
+  (2–2.4×); th3index is neutral-to-penalty because the H3 cell-set covers the
+  city at small scale.
+- **Triple cross-join (Q16)** — plain **GiST**; neither th3index nor MEST helps.
+- **Combining** — pays only at larger scale, not at sf 0.005.
+
+## Parity with the stream benchmark
+
+The same MEOS predicate underlies the
+[streaming sibling](../stream/CrossPlatform_timings.md): the streaming snapshot
+at a watermark equals this batch result at that instant, which is the
+cross-family correctness link. This batch result is the oracle.
+
+## Filling your engine's column
+
+Each engine fills the grids that apply to it, leaving the rest as `—`.
+
+1. **Section 1a baseline** — run the 17 R-queries under your default config;
+   fill your engine's column.
+2. **Section 1b th3index** — re-run the spatial shapes (Q4–Q7, Q10) with the
+   `th3index` conjunct; fill your engine's column.
+3. **Section 2 native indexes** — for each native spatial index your engine
+   offers (MobilityDB: GiST / SP-GiST / MEST; MobilityDuck: R-tree), fill that
+   column. MobilitySpark has no native spatial index and stays `—`.
+4. **Section 3 combined** — where your engine has both, run th3index + native and
+   fill the column where it beats either alone.
+5. Add your series to [`scripts/render_chart.py`](scripts/render_chart.py) and
+   run `python3 scripts/render_chart.py` to refresh the SVGs.
 
 ## Reproduce
 
-Build MobilityDB at the pin with H3 enabled, load the `cap500` dataset, and
-derive `trip_h3` at ingest. [`run_bench.sh`](run_bench.sh) times each query across
-the index-config matrix; the **no-index** row of its matrix drops the trip GiST,
-trip SP-GiST, and `trip_h3` GiST indexes and is the tier reported here. Set the
-`DB` and `PGBIN` variables at the top of the script to the loaded database.
+The per-engine run scripts are in [`bench/`](bench/). Regenerate the charts:
 
 ```bash
-cmake -DMEOS=OFF -DH3=ON -DPOSTGRESQL_PG_CONFIG=<pg>/bin/pg_config .. && ninja && ninja install
-createdb berlinmod_bench500
-psql berlinmod_bench500 -c 'CREATE EXTENSION mobilitydb CASCADE'
-psql berlinmod_bench500 -c "ALTER TABLE trips ADD COLUMN trip_h3 th3index;
-  UPDATE trips SET trip_h3 = tgeompoint_to_th3index(transform(trip, 4326), 7);"
-bash run_bench.sh
+python3 scripts/render_chart.py
 ```
-
-Pin: `67fcb0e63c` (tag `ecosystem-pin-2026-06-06a`).

--- a/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
@@ -3,27 +3,33 @@
 ## What this benchmark measures
 
 Per-query throughput of the BerlinMOD streaming query set across three stream
-engines — MobilityFlink, MobilityKafka, and MobilityNebula — that share the same
-MEOS kernel and evaluate the same predicates over the same corpus. Every query
-runs in three forms (continuous, windowed, snapshot); the snapshot form is checked
-against the 3-DB batch result as the correctness oracle.
+engines — [MobilityFlink](https://github.com/MobilityDB/MobilityFlink),
+[MobilityKafka](https://github.com/MobilityDB/MobilityKafka), and
+[MobilityNebula](https://github.com/MobilityDB/MobilityNebula) — that share the
+same MEOS kernel and evaluate the same predicates over the same canonical corpus.
+
+Every query runs in three forms: **continuous** (per-event output),
+**windowed** (aggregate over tumbling windows), and **snapshot** (watermark-
+driven sample). The snapshot form is checked against the
+[3-DB batch result](../batch/CrossPlatform_timings.md) as the correctness oracle.
 
 ## Workload
 
-The 9-query streaming set (see [`README.md`](README.md) for intents and BerlinMOD/r
-lineage) in three forms:
+The 9-query streaming set (see [`README.md`](README.md) for intents and
+BerlinMOD/r lineage) in three forms:
 
-- **continuous** — emits `predicate(event)` for every event as it arrives.
-- **windowed** — aggregates the predicate over tumbling windows.
-- **snapshot** — samples each vehicle's last-known position at tick instants; by
-  contract the snapshot at watermark `T` equals the batch result at `T`.
+| Form | Question | Notes |
+|---|---|---|
+| **Continuous** | "At every moment, which holds now?" | per-event output, watermark-independent |
+| **Windowed** | "Per tumbling window, what holds?" | event-time tumbling window |
+| **Snapshot** | "At time T, what holds?" | watermark-driven; the batch parity oracle |
 
 ## Dataset, hardware, methodology
 
 The corpus is BerlinMOD `berlinmod_instants.csv` — 216 075 instants, 5 vehicles,
 ~11 days — reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load.
-All query parameters and window/tick granularity derive from the same corpus,
-identical on every platform.
+All query parameters and window/tick granularity are derived from the same corpus
+and are identical on every platform.
 
 ### Machine
 
@@ -35,11 +41,11 @@ identical on every platform.
 
 ### Per-engine harnesses
 
-- **Flink** — Flink 1.16 single-node local mini-cluster, parallelism 1. Harness
-  [`MobilityFlink` `BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
+- **Flink** — Flink 1.16 single-node local mini-cluster, parallelism 1. Harness:
+  [`BerlinMODBenchmark`](https://github.com/MobilityDB/MobilityFlink/blob/main/flink-processor/src/main/java/berlinmod/BerlinMODBenchmark.java).
 - **Kafka** — Kafka Streams 3.6, one stream thread, each cell a `KafkaStreams`
-  application against its own fresh in-process `EmbeddedKafkaCluster`. Harness
-  [`MobilityKafka` `EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
+  application against its own fresh in-process `EmbeddedKafkaCluster`. Harness:
+  [`EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
 - **Nebula** — NebulaStream harness ([bench.nebula.stream](https://bench.nebula.stream)).
 
 ## Invariants held fixed
@@ -47,9 +53,52 @@ identical on every platform.
 - **Same MEOS predicate** — every platform evaluates the identical MEOS spatial call.
 - **Throughput definition** — `events_in` ÷ wall-clock; `output_rows` is the sink cardinality.
 - **Corpus-derived parameters** — all query parameters and window/tick granularity are identical on every platform.
-- **Batch oracle** — the continuous form is checked event-for-event against a batch pass over the same corpus through the same MEOS call.
+- **Batch oracle** — the snapshot form is checked against the 3-DB batch result on the same corpus.
 
-## Results — throughput (events/s)
+---
+
+## Section 1 — Continuous throughput (baseline)
+
+The continuous form is the baseline: every arriving event is evaluated and emits
+a result immediately, with no aggregation or sampling. Platform is the sole
+variable.
+
+![Continuous-form streaming throughput (log scale, higher is better)](streaming_continuous.svg)
+
+| Query | MobilityFlink | MobilityKafka | MobilityNebula |
+|---|---:|---:|---:|
+| Q1 |  87,057 |  78,091 | — |
+| Q2 | 213,302 | 260,334 | — |
+| Q3 |  68,443 |  86,673 | — |
+| Q4 |  59,971 |  44,387 | — |
+| Q5 |  24,105 |  12,544 | — |
+| Q6 |  95,103 |  52,117 | — |
+| Q7 |  58,085 |  86,018 | — |
+| Q8 |  69,299 |  78,346 | — |
+| Q9 | 137,452 |  76,325 | — |
+
+MobilityNebula runs the same corpus and query set via
+[bench.nebula.stream](https://bench.nebula.stream) and fills its column when
+the harness reports.
+
+Q5-continuous is the floor on both engines (MobilityKafka 12,544,
+MobilityFlink 24,105 ev/s): it enumerates every meeting pair across all vehicles
+on each event (O(V²) per event). The non-spatial Q1/Q2 cells sit near the
+ceiling, and the per-event spatial cells (Q3/Q8/Q9) cluster at 68k–137k ev/s.
+
+---
+
+## Section 2 — Form acceleration: windowed and snapshot
+
+Windowed and snapshot forms aggregate or sample rather than emit per event, so
+they run several times faster than their continuous counterpart for queries with
+aggregation-amenable predicates.
+
+![Windowed-form streaming throughput (log scale, higher is better)](streaming_windowed.svg)
+
+![Snapshot-form streaming throughput (log scale, higher is better)](streaming_snapshot.svg)
+
+### All forms (events/s, higher is better)
 
 | Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---|---:|---:|---:|
@@ -81,43 +130,83 @@ identical on every platform.
 | Q9 | windowed   | 231,096 | 141,504 | — |
 | Q9 | snapshot   | 235,376 | 134,880 | — |
 
-### Throughput charts (events/s, log scale, higher is better)
+### Reading the form acceleration
 
-![Continuous-form streaming throughput](streaming_continuous.svg)
+- **Q5** shows the largest lift: continuous 24k–12k ev/s (O(V²) pair
+  enumeration per event) versus windowed 230k–137k ev/s (window aggregates the
+  pair set once per window boundary). Windowed is **9–11×** faster than continuous.
+- **Q3, Q8, Q9** — snapshot jumps 2–3× over continuous (snapshot samples the
+  predicate at tick instants; most events are irrelevant between ticks).
+- **Q6, Q4** — minimal form difference; the predicate cost dominates and is
+  evaluated once per event regardless of form.
 
-![Windowed-form streaming throughput](streaming_windowed.svg)
+---
 
-![Snapshot-form streaming throughput](streaming_snapshot.svg)
+## Section 3 — Snapshot parity with the DB benchmark
+
+The snapshot form bridges the two benchmark families. By contract, the stream
+snapshot at watermark `T` equals the batch result on the same data up to `T`.
+The [3-DB batch result](../batch/CrossPlatform_timings.md) is the oracle; the
+batch document's execution times are the latency counterpart to the stream
+throughput figures above.
+
+The continuous form is checked event-for-event against a batch pass over the
+same corpus through the same MEOS call.
+
+### Per-query parity (MobilityFlink and MobilityKafka)
+
+Output cardinality is identical across MobilityFlink and MobilityKafka for all
+nine queries, confirming per-event predicate parity:
+
+| Query | Output rows (continuous) | Parity |
+|---|---:|---|
+| Q1 |        5 | exact |
+| Q2 |   61,170 | exact |
+| Q3 |  216,075 | exact |
+| Q4 |       62 | exact |
+| Q5 |   73,063 | exact |
+| Q6 |  216,075 | exact |
+| Q7 |        5 | exact |
+| Q8 |  216,075 | exact |
+| Q9 |  107,870 | exact |
+
+MobilityNebula fills its parity column when the harness reports.
+
+---
 
 ## Reading the results
 
-Q5-continuous is the floor on both engines (MobilityKafka 12,544, MobilityFlink
-24,105 ev/s): it enumerates every meeting pair across all vehicles on each event
-(O(V²) per event). The non-spatial Q1/Q2 continuous cells sit near the ceiling
-(Q2-continuous 260,334 on Kafka, 213,302 on Flink), and the per-event spatial
-cells (Q3/Q8/Q9-continuous) cluster between in the 68k–137k ev/s band. Windowed
-and snapshot forms aggregate or sample rather than emit per event, so they run
-several times faster than their continuous counterpart.
+- **Platform choice** — Flink leads on Q3/Q5/Q6/Q8/Q9 continuous; Kafka leads on
+  Q2/Q4/Q7 continuous. The platform decision is operational (fault tolerance,
+  deployment model), not predicate-driven.
+- **Form choice** — continuous for per-event alerting; windowed for periodic
+  aggregates (Q5 9–11× win); snapshot for watermark-aligned state that must
+  match a batch oracle.
+- **Cross-family** — the snapshot form is the bridge: snapshot throughput at T
+  equals batch latency on data up to T. The stream and batch benchmarks are the
+  same workload on the same canonical data, not separate experiments.
 
-The continuous form's output cardinality is identical across MobilityFlink and
-MobilityKafka for all nine queries (Q1 5, Q2 61 170, Q3 216 075, Q4 62, Q5 73 063,
-Q6 216 075, Q7 5, Q8 216 075, Q9 107 870), confirming per-event predicate parity.
+## Filling your engine's column
 
-## Parity with the DB benchmark
+Each engine fills the grids that apply to it, leaving the rest as `—`.
 
-The continuous form is checked event-for-event against a batch pass over the same
-corpus through the same MEOS call — the link to the
-[3-DB benchmark](../batch/CrossPlatform_timings.md), whose batch result is the oracle.
-A query is `exact` when streaming-true equals batch-true with zero mismatches.
+1. **Section 1** — run all 9 queries in the continuous form; fill your engine's
+   throughput column.
+2. **Section 2** — run windowed and snapshot forms; fill all three form rows per
+   query.
+3. **Section 3** — record output row counts and confirm `snapshot_equals_batch`
+   against the [batch oracle](../batch/CrossPlatform_timings.md).
+4. Add your series to [`scripts/render_chart.py`](scripts/render_chart.py) and
+   run `python3 scripts/render_chart.py` to refresh the SVGs.
 
 ## Reproduce
 
-Regenerate the charts from
-[`scripts/render_chart.py`](scripts/render_chart.py):
+Regenerate the charts:
 
 ```bash
 python3 scripts/render_chart.py
 ```
 
-The per-engine run harnesses are linked under [Methodology](#dataset-hardware-methodology).
-Regenerate the Machine block on your host with `bash scripts/machine.sh`.
+The per-engine run harnesses are linked under
+[Per-engine harnesses](#per-engine-harnesses). Regenerate the Machine block on
+your host with `bash scripts/machine.sh`.


### PR DESCRIPTION
BerlinMOD sf 0.005 (1620 trips, 141 vehicles), Spark 3.5.4 local[2], 6 g driver, th3index prefilter on trip×trip shapes (Q6, Q10), 1 run per query. Q1–Q3 measured (0.67 s / 1109.81 s / 168.13 s); Q4–Q17 exceed the 30-min cap on this configuration. Adds the Q1–Q17 timing table to Section 1 and updates the chart series in render_chart.py; SVGs regenerated.