### PR TITLE
bench: add MobilitySpark Q1–Q3 timings to the batch benchmark

### DIFF
--- a/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/batch/CrossPlatform_timings.md
@@ -77,6 +77,26 @@ MobilityDuck and MobilitySpark run the same dataset and portable SQL via
 [`bench/bench_mspark.sh`](bench/bench_mspark.sh) and fill their columns when
 they report.
 
+| Query | Shape | MobilityDB | MobilityDuck | MobilitySpark |
+|---|---|---:|---:|---:|
+| Q1  | Relational              |  0.78 | — |    0.67 |
+| Q2  | Relational              |  0.15 | — | 1109.81 |
+| Q3  | Relational              |  5.70 | — |  168.13 |
+| Q4  | Trip × static           | 15.19 | — |   >cap |
+| Q5  | Aggregated cross-join   |  9.50 | — |   >cap |
+| Q6  | Trip × trip             |  4.23 | — |   >cap |
+| Q7  | Trip × static           |  9.24 | — |   >cap |
+| Q8  | Relational              |  1.18 | — |   >cap |
+| Q9  | Relational              |  9.81 | — |   >cap |
+| Q10 | Trip × trip             |  6.46 | — |   >cap |
+| Q11 | Trip × static           |  2.31 | — |   >cap |
+| Q12 | Trip × static           |  2.37 | — |   >cap |
+| Q13 | Trip × region           |  4.55 | — |   >cap |
+| Q14 | Trip × region           |  0.44 | — |   >cap |
+| Q15 | Trip × static           |  4.13 | — |   >cap |
+| Q16 | Trip × trip × region    | 16.35 | — |   >cap |
+| Q17 | Trip × static           |  9.74 | — |   >cap |
+
 ### th3index accelerator effect
 
 ![th3index accelerator (log scale, lower is better)](cross_platform_th3index.svg)

--- a/BerlinMOD/benchmarks/batch/cross_platform_standard.svg
+++ b/BerlinMOD/benchmarks/batch/cross_platform_standard.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="864pt" height="360pt" viewBox="0 0 864 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1101.6pt" height="360pt" viewBox="0 0 1101.6 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-01T18:56:18.836583</dc:date>
+    <dc:date>2026-06-07T17:42:28.275193</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,36 +22,444 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 360 
-L 864 360 
-L 864 0 
+L 1101.6 360 
+L 1101.6 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 55.772054 332.12 
-L 853.2 332.12 
-L 853.2 25.44 
-L 55.772054 25.44 
+    <path d="M 56.338994 316.6 
+L 1090.8 316.6 
+L 1090.8 25.8 
+L 56.338994 25.8 
 z
 " style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 103.359949 44848.601475 
+L 117.110514 44848.601475 
+L 117.110514 187.421704 
+L 103.359949 187.421704 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 159.408449 44848.601475 
+L 173.159014 44848.601475 
+L 173.159014 219.402709 
+L 159.408449 219.402709 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 215.456949 44848.601475 
+L 229.207514 44848.601475 
+L 229.207514 148.840096 
+L 215.456949 148.840096 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 271.505449 44848.601475 
+L 285.256014 44848.601475 
+L 285.256014 129.826543 
+L 271.505449 129.826543 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 327.553948 44848.601475 
+L 341.304514 44848.601475 
+L 341.304514 138.931 
+L 327.553948 138.931 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 383.602448 44848.601475 
+L 397.353014 44848.601475 
+L 397.353014 154.625883 
+L 383.602448 154.625883 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 439.650948 44848.601475 
+L 453.401513 44848.601475 
+L 453.401513 139.469298 
+L 439.650948 139.469298 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 495.699448 44848.601475 
+L 509.450013 44848.601475 
+L 509.450013 179.39132 
+L 495.699448 179.39132 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 551.747948 44848.601475 
+L 565.498513 44848.601475 
+L 565.498513 138.308114 
+L 551.747948 138.308114 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 607.796448 44848.601475 
+L 621.547013 44848.601475 
+L 621.547013 146.412156 
+L 607.796448 146.412156 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 663.844948 44848.601475 
+L 677.595513 44848.601475 
+L 677.595513 166.360909 
+L 663.844948 166.360909 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 719.893447 44848.601475 
+L 733.644013 44848.601475 
+L 733.644013 165.863492 
+L 719.893447 165.863492 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 775.941947 44848.601475 
+L 789.692513 44848.601475 
+L 789.692513 153.211265 
+L 775.941947 153.211265 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 831.990447 44848.601475 
+L 845.741012 44848.601475 
+L 845.741012 198.527544 
+L 831.990447 198.527544 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 888.038947 44848.601475 
+L 901.789512 44848.601475 
+L 901.789512 155.089977 
+L 888.038947 155.089977 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 944.087447 44848.601475 
+L 957.838012 44848.601475 
+L 957.838012 128.399018 
+L 944.087447 128.399018 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 1000.135947 44848.601475 
+L 1013.886512 44848.601475 
+L 1013.886512 138.447028 
+L 1000.135947 138.447028 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 118.306216 44848.601475 
+L 132.056781 44848.601475 
+L 132.056781 271.934001 
+L 118.306216 271.934001 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 174.354715 44848.601475 
+L 188.105281 44848.601475 
+L 188.105281 285.379806 
+L 174.354715 285.379806 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 230.403215 44848.601475 
+L 244.153781 44848.601475 
+L 244.153781 199.897398 
+L 230.403215 199.897398 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 286.451715 44848.601475 
+L 300.20228 44848.601475 
+L 300.20228 187.17459 
+L 286.451715 187.17459 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 342.500215 44848.601475 
+L 356.25078 44848.601475 
+L 356.25078 97.276357 
+L 342.500215 97.276357 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 398.548715 44848.601475 
+L 412.29928 44848.601475 
+L 412.29928 205.32084 
+L 398.548715 205.32084 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 454.597215 44848.601475 
+L 468.34778 44848.601475 
+L 468.34778 190.083158 
+L 454.597215 190.083158 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 510.645715 44848.601475 
+L 524.39628 44848.601475 
+L 524.39628 220.741046 
+L 510.645715 220.741046 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 566.694214 44848.601475 
+L 580.44478 44848.601475 
+L 580.44478 147.240347 
+L 566.694214 147.240347 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 622.742714 44848.601475 
+L 636.49328 44848.601475 
+L 636.49328 147.084287 
+L 622.742714 147.084287 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 678.791214 44848.601475 
+L 692.541779 44848.601475 
+L 692.541779 191.875034 
+L 678.791214 191.875034 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 734.839714 44848.601475 
+L 748.590279 44848.601475 
+L 748.590279 190.958413 
+L 734.839714 190.958413 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 790.888214 44848.601475 
+L 804.638779 44848.601475 
+L 804.638779 143.413334 
+L 790.888214 143.413334 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 846.936714 44848.601475 
+L 860.687279 44848.601475 
+L 860.687279 194.554902 
+L 846.936714 194.554902 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 902.985214 44848.601475 
+L 916.735779 44848.601475 
+L 916.735779 143.542397 
+L 902.985214 143.542397 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 959.033713 44848.601475 
+L 972.784279 44848.601475 
+L 972.784279 159.559981 
+L 959.033713 159.559981 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 1015.082213 44848.601475 
+L 1028.832779 44848.601475 
+L 1028.832779 189.520852 
+L 1015.082213 189.520852 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 133.252482 44848.601475 
+L 147.003048 44848.601475 
+L 147.003048 190.370544 
+L 133.252482 190.370544 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 189.300982 44848.601475 
+L 203.051547 44848.601475 
+L 203.051547 46.582928 
+L 189.300982 46.582928 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 245.349482 44848.601475 
+L 259.100047 44848.601475 
+L 259.100047 83.191334 
+L 245.349482 83.191334 
+z
+" clip-path="url(#p951353d1b5)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 301.397982 44848.601475 
+L 315.148547 44848.601475 
+L 315.148547 37.202002 
+L 301.397982 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 357.446482 44848.601475 
+L 371.197047 44848.601475 
+L 371.197047 37.202002 
+L 357.446482 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 413.494981 44848.601475 
+L 427.245547 44848.601475 
+L 427.245547 37.202002 
+L 413.494981 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 469.543481 44848.601475 
+L 483.294047 44848.601475 
+L 483.294047 37.202002 
+L 469.543481 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 525.591981 44848.601475 
+L 539.342546 44848.601475 
+L 539.342546 37.202002 
+L 525.591981 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 581.640481 44848.601475 
+L 595.391046 44848.601475 
+L 595.391046 37.202002 
+L 581.640481 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 637.688981 44848.601475 
+L 651.439546 44848.601475 
+L 651.439546 37.202002 
+L 637.688981 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 693.737481 44848.601475 
+L 707.488046 44848.601475 
+L 707.488046 37.202002 
+L 693.737481 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 749.785981 44848.601475 
+L 763.536546 44848.601475 
+L 763.536546 37.202002 
+L 749.785981 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 805.83448 44848.601475 
+L 819.585046 44848.601475 
+L 819.585046 37.202002 
+L 805.83448 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 861.88298 44848.601475 
+L 875.633546 44848.601475 
+L 875.633546 37.202002 
+L 861.88298 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 917.93148 44848.601475 
+L 931.682045 44848.601475 
+L 931.682045 37.202002 
+L 917.93148 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 973.97998 44848.601475 
+L 987.730545 44848.601475 
+L 987.730545 37.202002 
+L 973.97998 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 1030.02848 44848.601475 
+L 1043.779045 44848.601475 
+L 1043.779045 37.202002 
+L 1030.02848 37.202002 
+z
+" clip-path="url(#p951353d1b5)" style="fill: url(#hbc887773d0); stroke: #333333; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mdc8e2c314d" d="M 0 0 
+       <path id="mafabe9ba45" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdc8e2c314d" x="109.562312" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="125.181498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q1 -->
-      <g transform="translate(102.445125 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(118.064311 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -102,12 +510,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="154.164517" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="181.229998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Q2 -->
-      <g transform="translate(147.047329 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(174.112811 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -142,12 +550,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="198.766721" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="237.278498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Q3 -->
-      <g transform="translate(191.649534 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(230.16131 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -190,12 +598,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="243.368926" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="293.326998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Q4 -->
-      <g transform="translate(236.251738 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(286.20981 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -225,12 +633,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="287.97113" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="349.375498" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Q5 -->
-      <g transform="translate(280.853943 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(342.25831 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -266,12 +674,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="332.573335" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="405.423998" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Q6 -->
-      <g transform="translate(325.456147 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(398.30681 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -312,12 +720,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="377.175539" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="461.472497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- Q7 -->
-      <g transform="translate(370.058352 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(454.35531 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -338,12 +746,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="421.777744" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="517.520997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- Q8 -->
-      <g transform="translate(414.660556 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(510.40381 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -393,12 +801,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="466.379948" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="573.569497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- Q9 -->
-      <g transform="translate(459.262761 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(566.45231 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -439,12 +847,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="510.982153" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="629.617997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- Q10 -->
-      <g transform="translate(500.683715 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(619.319559 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -477,12 +885,12 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="555.584357" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="685.666497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- Q11 -->
-      <g transform="translate(545.28592 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(675.368059 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(142.333984 0)"/>
@@ -492,12 +900,12 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="600.186562" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="741.714997" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- Q12 -->
-      <g transform="translate(589.888124 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(731.416559 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(142.333984 0)"/>
@@ -507,12 +915,12 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="644.788766" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="797.763496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- Q13 -->
-      <g transform="translate(634.490328 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(787.465059 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(142.333984 0)"/>
@@ -522,12 +930,12 @@ z
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="689.39097" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="853.811996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- Q14 -->
-      <g transform="translate(679.092533 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(843.513559 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(142.333984 0)"/>
@@ -537,12 +945,12 @@ z
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="733.993175" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="909.860496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- Q15 -->
-      <g transform="translate(723.694737 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(899.562059 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(142.333984 0)"/>
@@ -552,12 +960,12 @@ z
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="778.595379" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="965.908996" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- Q16 -->
-      <g transform="translate(768.296942 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(955.610559 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-36" transform="translate(142.333984 0)"/>
@@ -567,476 +975,52 @@ z
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdc8e2c314d" x="823.197584" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mafabe9ba45" x="1021.957496" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- Q17 -->
-      <g transform="translate(812.899146 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(1011.659058 331.198438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-51"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
        <use xlink:href="#DejaVuSans-37" transform="translate(142.333984 0)"/>
       </g>
      </g>
     </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_18">
-      <path d="M 55.772054 314.595429 
-L 853.2 314.595429 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_19">
+    <g id="text_18">
+     <!-- BerlinMOD R-query -->
+     <g transform="translate(525.85856 344.876563) scale(0.1 -0.1)">
       <defs>
-       <path id="m843a85f1ab" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#m843a85f1ab" x="55.772054" y="314.595429" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_18">
-      <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.272054 318.394647) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-2212" d="M 678 2272 
-L 4684 2272 
-L 4684 1741 
-L 678 1741 
-L 678 2272 
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
 z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_20">
-      <path d="M 55.772054 226.972571 
-L 853.2 226.972571 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#m843a85f1ab" x="55.772054" y="226.972571" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_19">
-      <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.172054 230.77179) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_22">
-      <path d="M 55.772054 139.349714 
-L 853.2 139.349714 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m843a85f1ab" x="55.772054" y="139.349714" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_20">
-      <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.172054 143.148933) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_24">
-      <path d="M 55.772054 51.726857 
-L 853.2 51.726857 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m843a85f1ab" x="55.772054" y="51.726857" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_21">
-      <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.172054 55.526076) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_26">
-      <path d="M 55.772054 328.168381 
-L 853.2 328.168381 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_27">
-      <defs>
-       <path id="m315af5f9bc" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="328.168381" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_28">
-      <path d="M 55.772054 323.086961 
-L 853.2 323.086961 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="323.086961" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_30">
-      <path d="M 55.772054 318.604831 
-L 853.2 318.604831 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="318.604831" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_8">
-     <g id="line2d_32">
-      <path d="M 55.772054 288.21832 
-L 853.2 288.21832 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="288.21832" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_34">
-      <path d="M 55.772054 272.788701 
-L 853.2 272.788701 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="272.788701" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_36">
-      <path d="M 55.772054 261.841212 
-L 853.2 261.841212 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="261.841212" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_11">
-     <g id="line2d_38">
-      <path d="M 55.772054 253.34968 
-L 853.2 253.34968 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="253.34968" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_40">
-      <path d="M 55.772054 246.411593 
-L 853.2 246.411593 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="246.411593" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_13">
-     <g id="line2d_42">
-      <path d="M 55.772054 240.545524 
-L 853.2 240.545524 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="240.545524" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_44">
-      <path d="M 55.772054 235.464104 
-L 853.2 235.464104 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="235.464104" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_46">
-      <path d="M 55.772054 230.981973 
-L 853.2 230.981973 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="230.981973" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_48">
-      <path d="M 55.772054 200.595463 
-L 853.2 200.595463 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="200.595463" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_17">
-     <g id="line2d_50">
-      <path d="M 55.772054 185.165844 
-L 853.2 185.165844 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="185.165844" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_18">
-     <g id="line2d_52">
-      <path d="M 55.772054 174.218355 
-L 853.2 174.218355 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="174.218355" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_19">
-     <g id="line2d_54">
-      <path d="M 55.772054 165.726823 
-L 853.2 165.726823 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_55">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="165.726823" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_20">
-     <g id="line2d_56">
-      <path d="M 55.772054 158.788736 
-L 853.2 158.788736 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_57">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="158.788736" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_21">
-     <g id="line2d_58">
-      <path d="M 55.772054 152.922667 
-L 853.2 152.922667 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_59">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="152.922667" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_22">
-     <g id="line2d_60">
-      <path d="M 55.772054 147.841247 
-L 853.2 147.841247 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_61">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="147.841247" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_23">
-     <g id="line2d_62">
-      <path d="M 55.772054 143.359116 
-L 853.2 143.359116 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_63">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="143.359116" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_24">
-     <g id="line2d_64">
-      <path d="M 55.772054 112.972606 
-L 853.2 112.972606 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_65">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="112.972606" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_25">
-     <g id="line2d_66">
-      <path d="M 55.772054 97.542987 
-L 853.2 97.542987 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_67">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="97.542987" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_26">
-     <g id="line2d_68">
-      <path d="M 55.772054 86.595498 
-L 853.2 86.595498 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_69">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="86.595498" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_27">
-     <g id="line2d_70">
-      <path d="M 55.772054 78.103965 
-L 853.2 78.103965 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_71">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="78.103965" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_28">
-     <g id="line2d_72">
-      <path d="M 55.772054 71.165878 
-L 853.2 71.165878 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_73">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="71.165878" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_29">
-     <g id="line2d_74">
-      <path d="M 55.772054 65.299809 
-L 853.2 65.299809 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_75">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="65.299809" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_30">
-     <g id="line2d_76">
-      <path d="M 55.772054 60.218389 
-L 853.2 60.218389 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_77">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="60.218389" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_31">
-     <g id="line2d_78">
-      <path d="M 55.772054 55.736259 
-L 853.2 55.736259 
-" clip-path="url(#p6739aaa24c)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_79">
-      <g>
-       <use xlink:href="#m315af5f9bc" x="55.772054" y="55.736259" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- Execution time (s) -->
-     <g transform="translate(19.192366 224.294844) rotate(-90) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-45" d="M 628 4666 
-L 3578 4666 
-L 3578 4134 
-L 1259 4134 
-L 1259 2753 
-L 3481 2753 
-L 3481 2222 
-L 1259 2222 
-L 1259 531 
-L 3634 531 
-L 3634 0 
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
 L 628 0 
 L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-65" d="M 3597 1894 
@@ -1064,25 +1048,178 @@ Q 1016 2553 972 2059
 L 3022 2063 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-75" d="M 544 1381 
@@ -1107,38 +1244,879 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(895.023438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_18">
+      <path d="M 56.338994 316.6 
+L 1090.8 316.6 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <defs>
+       <path id="m848d8af72f" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g transform="translate(25.838994 320.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
 z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_20">
+      <path d="M 56.338994 271.934001 
+L 1090.8 271.934001 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="271.934001" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(25.838994 275.733219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_22">
+      <path d="M 56.338994 227.268001 
+L 1090.8 227.268001 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="227.268001" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(25.838994 231.06722) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_24">
+      <path d="M 56.338994 182.602002 
+L 1090.8 182.602002 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="182.602002" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(31.738994 186.40122) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_26">
+      <path d="M 56.338994 137.936002 
+L 1090.8 137.936002 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="137.936002" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(31.738994 141.735221) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_28">
+      <path d="M 56.338994 93.270003 
+L 1090.8 93.270003 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="93.270003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(31.738994 97.069221) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_30">
+      <path d="M 56.338994 48.604003 
+L 1090.8 48.604003 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m848d8af72f" x="56.338994" y="48.604003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(31.738994 52.403222) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_32">
+      <path d="M 56.338994 303.154194 
+L 1090.8 303.154194 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <defs>
+       <path id="me4bfb18c2c" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="303.154194" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_34">
+      <path d="M 56.338994 295.288902 
+L 1090.8 295.288902 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="295.288902" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_36">
+      <path d="M 56.338994 289.708389 
+L 1090.8 289.708389 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="289.708389" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_38">
+      <path d="M 56.338994 285.379806 
+L 1090.8 285.379806 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="285.379806" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_40">
+      <path d="M 56.338994 281.843097 
+L 1090.8 281.843097 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="281.843097" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_42">
+      <path d="M 56.338994 278.852851 
+L 1090.8 278.852851 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="278.852851" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_44">
+      <path d="M 56.338994 276.262583 
+L 1090.8 276.262583 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="276.262583" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_46">
+      <path d="M 56.338994 273.977805 
+L 1090.8 273.977805 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="273.977805" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_48">
+      <path d="M 56.338994 258.488195 
+L 1090.8 258.488195 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="258.488195" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_50">
+      <path d="M 56.338994 250.622903 
+L 1090.8 250.622903 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="250.622903" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_52">
+      <path d="M 56.338994 245.042389 
+L 1090.8 245.042389 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="245.042389" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_54">
+      <path d="M 56.338994 240.713807 
+L 1090.8 240.713807 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="240.713807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_56">
+      <path d="M 56.338994 237.177097 
+L 1090.8 237.177097 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="237.177097" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_58">
+      <path d="M 56.338994 234.186852 
+L 1090.8 234.186852 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="234.186852" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_60">
+      <path d="M 56.338994 231.596584 
+L 1090.8 231.596584 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="231.596584" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_62">
+      <path d="M 56.338994 229.311805 
+L 1090.8 229.311805 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="229.311805" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_64">
+      <path d="M 56.338994 213.822195 
+L 1090.8 213.822195 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="213.822195" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_66">
+      <path d="M 56.338994 205.956903 
+L 1090.8 205.956903 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="205.956903" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_68">
+      <path d="M 56.338994 200.37639 
+L 1090.8 200.37639 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="200.37639" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_70">
+      <path d="M 56.338994 196.047807 
+L 1090.8 196.047807 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="196.047807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_72">
+      <path d="M 56.338994 192.511098 
+L 1090.8 192.511098 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="192.511098" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_74">
+      <path d="M 56.338994 189.520852 
+L 1090.8 189.520852 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="189.520852" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_76">
+      <path d="M 56.338994 186.930584 
+L 1090.8 186.930584 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="186.930584" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_78">
+      <path d="M 56.338994 184.645806 
+L 1090.8 184.645806 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="184.645806" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_80">
+      <path d="M 56.338994 169.156196 
+L 1090.8 169.156196 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="169.156196" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_82">
+      <path d="M 56.338994 161.290904 
+L 1090.8 161.290904 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="161.290904" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_84">
+      <path d="M 56.338994 155.71039 
+L 1090.8 155.71039 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="155.71039" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_86">
+      <path d="M 56.338994 151.381808 
+L 1090.8 151.381808 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="151.381808" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_88">
+      <path d="M 56.338994 147.845098 
+L 1090.8 147.845098 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="147.845098" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_90">
+      <path d="M 56.338994 144.854853 
+L 1090.8 144.854853 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="144.854853" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_92">
+      <path d="M 56.338994 142.264585 
+L 1090.8 142.264585 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="142.264585" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_94">
+      <path d="M 56.338994 139.979806 
+L 1090.8 139.979806 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="139.979806" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_96">
+      <path d="M 56.338994 124.490196 
+L 1090.8 124.490196 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="124.490196" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_98">
+      <path d="M 56.338994 116.624904 
+L 1090.8 116.624904 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="116.624904" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_100">
+      <path d="M 56.338994 111.044391 
+L 1090.8 111.044391 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="111.044391" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_102">
+      <path d="M 56.338994 106.715808 
+L 1090.8 106.715808 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="106.715808" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_104">
+      <path d="M 56.338994 103.179099 
+L 1090.8 103.179099 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="103.179099" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_106">
+      <path d="M 56.338994 100.188853 
+L 1090.8 100.188853 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="100.188853" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_108">
+      <path d="M 56.338994 97.598585 
+L 1090.8 97.598585 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="97.598585" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_110">
+      <path d="M 56.338994 95.313807 
+L 1090.8 95.313807 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="95.313807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_112">
+      <path d="M 56.338994 79.824197 
+L 1090.8 79.824197 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="79.824197" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_114">
+      <path d="M 56.338994 71.958905 
+L 1090.8 71.958905 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="71.958905" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_116">
+      <path d="M 56.338994 66.378391 
+L 1090.8 66.378391 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="66.378391" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_118">
+      <path d="M 56.338994 62.049809 
+L 1090.8 62.049809 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="62.049809" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_120">
+      <path d="M 56.338994 58.513099 
+L 1090.8 58.513099 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="58.513099" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_122">
+      <path d="M 56.338994 55.522854 
+L 1090.8 55.522854 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="55.522854" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_124">
+      <path d="M 56.338994 52.932586 
+L 1090.8 52.932586 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="52.932586" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_126">
+      <path d="M 56.338994 50.647807 
+L 1090.8 50.647807 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="50.647807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_128">
+      <path d="M 56.338994 35.158198 
+L 1090.8 35.158198 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="35.158198" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_130">
+      <path d="M 56.338994 27.292905 
+L 1090.8 27.292905 
+" clip-path="url(#p951353d1b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#me4bfb18c2c" x="56.338994" y="27.292905" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_26">
+     <!-- Wall-clock seconds (log scale) -->
+     <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-6f" d="M 1959 3097 
@@ -1162,67 +2140,18 @@ Q 353 2609 779 3096
 Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
 L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
+L 1159 1709 
 L 1159 0 
 L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
+L 581 4863 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-73" d="M 2834 3397 
@@ -1256,1114 +2185,7 @@ Q 2034 3584 2315 3537
 Q 2597 3491 2834 3397 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(119.238281 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(180.761719 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(235.742188 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(299.121094 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(338.330078 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(366.113281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(427.294922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(490.673828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(522.460938 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(561.669922 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(589.453125 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(686.865234 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(748.388672 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(780.175781 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(819.189453 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(871.289062 0)"/>
-     </g>
-    </g>
-   </g>
-   <g id="patch_3">
-    <path d="M 92.018779 87849.829714 
-L 103.318004 87849.829714 
-L 103.318004 236.427551 
-L 92.018779 236.427551 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 136.620983 87849.829714 
-L 147.920208 87849.829714 
-L 147.920208 299.165809 
-L 136.620983 299.165809 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 181.223188 87849.829714 
-L 192.522413 87849.829714 
-L 192.522413 160.740657 
-L 181.223188 160.740657 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 225.825392 87849.829714 
-L 237.124617 87849.829714 
-L 237.124617 123.441103 
-L 225.825392 123.441103 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 270.427597 87849.829714 
-L 281.726822 87849.829714 
-L 281.726822 141.301636 
-L 270.427597 141.301636 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 315.029801 87849.829714 
-L 326.329026 87849.829714 
-L 326.329026 172.090839 
-L 315.029801 172.090839 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 359.632005 87849.829714 
-L 370.931231 87849.829714 
-L 370.931231 142.357634 
-L 359.632005 142.357634 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 404.23421 87849.829714 
-L 415.533435 87849.829714 
-L 415.533435 220.674065 
-L 404.23421 220.674065 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 448.836414 87849.829714 
-L 460.13564 87849.829714 
-L 460.13564 140.0797 
-L 448.836414 140.0797 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 493.438619 87849.829714 
-L 504.737844 87849.829714 
-L 504.737844 155.977683 
-L 493.438619 155.977683 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 538.040823 87849.829714 
-L 549.340048 87849.829714 
-L 549.340048 195.111851 
-L 538.040823 195.111851 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 582.643028 87849.829714 
-L 593.942253 87849.829714 
-L 593.942253 194.136051 
-L 582.643028 194.136051 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 627.245232 87849.829714 
-L 638.544457 87849.829714 
-L 638.544457 169.315733 
-L 627.245232 169.315733 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 671.847437 87849.829714 
-L 683.146662 87849.829714 
-L 683.146662 258.214267 
-L 671.847437 258.214267 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 716.449641 87849.829714 
-L 727.748866 87849.829714 
-L 727.748866 173.001268 
-L 716.449641 173.001268 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 761.051846 87849.829714 
-L 772.351071 87849.829714 
-L 772.351071 120.640678 
-L 761.051846 120.640678 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 805.65405 87849.829714 
-L 816.953275 87849.829714 
-L 816.953275 140.352211 
-L 805.65405 140.352211 
-z
-" clip-path="url(#p6739aaa24c)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 55.772054 332.12 
-L 55.772054 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 853.2 332.12 
-L 853.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 55.772054 332.12 
-L 853.2 332.12 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 55.772054 25.44 
-L 853.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="text_23">
-    <!-- 780m -->
-    <g transform="translate(99.324016 234.210178) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 150m -->
-    <g transform="translate(143.926221 296.948437) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 5.70 -->
-    <g transform="translate(188.528425 158.523285) rotate(-90) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 15.19 -->
-    <g transform="translate(233.13063 121.223731) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 9.50 -->
-    <g transform="translate(277.732834 139.084263) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 4.23 -->
-    <g transform="translate(322.335039 169.873467) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 9.24 -->
-    <g transform="translate(366.937243 140.140262) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 1.18 -->
-    <g transform="translate(411.539447 218.456692) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 9.81 -->
-    <g transform="translate(456.141652 137.862327) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 6.46 -->
-    <g transform="translate(500.743856 153.760311) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 2.31 -->
-    <g transform="translate(545.346061 192.894479) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 2.37 -->
-    <g transform="translate(589.948265 191.918678) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 4.55 -->
-    <g transform="translate(634.55047 167.098361) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 440m -->
-    <g transform="translate(679.152674 255.996894) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 4.13 -->
-    <g transform="translate(723.754879 170.783896) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 16.35 -->
-    <g transform="translate(768.357083 118.423306) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 9.74 -->
-    <g transform="translate(812.959288 138.134839) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- pending: MobilityDuck, MobilitySpark -->
-    <g style="fill: #999999" transform="translate(370.720636 319.8528) scale(0.09 -0.09)">
-     <defs>
-      <path id="DejaVuSans-Oblique-70" d="M 3175 2156 
-Q 3175 2616 2975 2859 
-Q 2775 3103 2400 3103 
-Q 2144 3103 1911 2972 
-Q 1678 2841 1497 2591 
-Q 1319 2344 1212 1994 
-Q 1106 1644 1106 1300 
-Q 1106 863 1306 627 
-Q 1506 391 1875 391 
-Q 2147 391 2380 519 
-Q 2613 647 2778 891 
-Q 2956 1147 3065 1494 
-Q 3175 1841 3175 2156 
-z
-M 1394 2969 
-Q 1625 3272 1939 3428 
-Q 2253 3584 2638 3584 
-Q 3175 3584 3472 3232 
-Q 3769 2881 3769 2247 
-Q 3769 1728 3584 1258 
-Q 3400 788 3053 416 
-Q 2822 169 2531 39 
-Q 2241 -91 1919 -91 
-Q 1547 -91 1294 64 
-Q 1041 219 916 525 
-L 556 -1331 
-L -19 -1331 
-L 922 3500 
-L 1497 3500 
-L 1394 2969 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-65" d="M 3078 2063 
-Q 3088 2113 3092 2166 
-Q 3097 2219 3097 2272 
-Q 3097 2653 2873 2875 
-Q 2650 3097 2266 3097 
-Q 1838 3097 1509 2826 
-Q 1181 2556 1013 2059 
-L 3078 2063 
-z
-M 3578 1613 
-L 903 1613 
-Q 884 1494 878 1425 
-Q 872 1356 872 1306 
-Q 872 872 1139 634 
-Q 1406 397 1894 397 
-Q 2269 397 2603 481 
-Q 2938 566 3225 728 
-L 3116 159 
-Q 2806 34 2476 -28 
-Q 2147 -91 1806 -91 
-Q 1078 -91 686 257 
-Q 294 606 294 1247 
-Q 294 1794 489 2264 
-Q 684 2734 1063 3103 
-Q 1306 3334 1642 3459 
-Q 1978 3584 2356 3584 
-Q 2950 3584 3301 3228 
-Q 3653 2872 3653 2272 
-Q 3653 2128 3634 1964 
-Q 3616 1800 3578 1613 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113 
-L 3156 0 
-L 2578 0 
-L 2988 2091 
-Q 3016 2238 3031 2350 
-Q 3047 2463 3047 2528 
-Q 3047 2791 2881 2937 
-Q 2716 3084 2419 3084 
-Q 1956 3084 1622 2776 
-Q 1288 2469 1184 1941 
-L 800 0 
-L 225 0 
-L 903 3500 
-L 1478 3500 
-L 1363 2950 
-Q 1603 3253 1940 3418 
-Q 2278 3584 2650 3584 
-Q 3113 3584 3367 3334 
-Q 3622 3084 3622 2631 
-Q 3622 2519 3608 2391 
-Q 3594 2263 3566 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-64" d="M 2675 525 
-Q 2444 222 2128 65 
-Q 1813 -91 1428 -91 
-Q 903 -91 598 267 
-Q 294 625 294 1247 
-Q 294 1766 478 2236 
-Q 663 2706 1013 3078 
-Q 1244 3325 1534 3454 
-Q 1825 3584 2144 3584 
-Q 2481 3584 2739 3421 
-Q 2997 3259 3138 2956 
-L 3513 4863 
-L 4091 4863 
-L 3144 0 
-L 2566 0 
-L 2675 525 
-z
-M 891 1350 
-Q 891 897 1095 644 
-Q 1300 391 1663 391 
-Q 1931 391 2161 520 
-Q 2391 650 2566 903 
-Q 2750 1166 2856 1509 
-Q 2963 1853 2963 2188 
-Q 2963 2622 2758 2865 
-Q 2553 3109 2194 3109 
-Q 1922 3109 1687 2981 
-Q 1453 2853 1288 2613 
-Q 1106 2353 998 2009 
-Q 891 1666 891 1350 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-69" d="M 1172 4863 
-L 1747 4863 
-L 1606 4134 
-L 1031 4134 
-L 1172 4863 
-z
-M 909 3500 
-L 1484 3500 
-L 800 0 
-L 225 0 
-L 909 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
-L 3219 434 
-Q 3047 -456 2561 -893 
-Q 2075 -1331 1253 -1331 
-Q 950 -1331 690 -1286 
-Q 431 -1241 206 -1147 
-L 313 -588 
-Q 525 -725 762 -790 
-Q 1000 -856 1269 -856 
-Q 1816 -856 2167 -557 
-Q 2519 -259 2631 300 
-L 2681 563 
-Q 2441 288 2122 144 
-Q 1803 0 1434 0 
-Q 903 0 598 351 
-Q 294 703 294 1319 
-Q 294 1803 478 2267 
-Q 663 2731 997 3091 
-Q 1219 3328 1514 3456 
-Q 1809 3584 2131 3584 
-Q 2484 3584 2746 3420 
-Q 3009 3256 3138 2956 
-L 3238 3500 
-L 3816 3500 
-z
-M 2950 2216 
-Q 2950 2641 2750 2872 
-Q 2550 3103 2181 3103 
-Q 1953 3103 1747 3012 
-Q 1541 2922 1394 2759 
-Q 1156 2491 1023 2127 
-Q 891 1763 891 1375 
-Q 891 944 1092 712 
-Q 1294 481 1672 481 
-Q 2219 481 2584 976 
-Q 2950 1472 2950 2216 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-3a" d="M 978 3309 
-L 1638 3309 
-L 1484 2516 
-L 825 2516 
-L 978 3309 
-z
-M 488 794 
-L 1147 794 
-L 991 0 
-L 331 0 
-L 488 794 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-4d" d="M 1081 4666 
-L 2028 4666 
-L 2572 1522 
-L 4378 4666 
-L 5350 4666 
-L 4441 0 
-L 3828 0 
-L 4622 4091 
-L 2791 897 
-L 2175 897 
-L 1581 4103 
-L 788 0 
-L 172 0 
-L 1081 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-6f" d="M 1625 -91 
-Q 1009 -91 651 289 
-Q 294 669 294 1325 
-Q 294 1706 417 2101 
-Q 541 2497 738 2766 
-Q 1047 3184 1428 3384 
-Q 1809 3584 2291 3584 
-Q 2888 3584 3255 3212 
-Q 3622 2841 3622 2241 
-Q 3622 1825 3500 1412 
-Q 3378 1000 3181 728 
-Q 2875 309 2494 109 
-Q 2113 -91 1625 -91 
-z
-M 891 1344 
-Q 891 869 1089 633 
-Q 1288 397 1691 397 
-Q 2269 397 2648 901 
-Q 3028 1406 3028 2181 
-Q 3028 2634 2825 2865 
-Q 2622 3097 2228 3097 
-Q 1903 3097 1650 2945 
-Q 1397 2794 1197 2484 
-Q 1050 2253 970 1956 
-Q 891 1659 891 1344 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-62" d="M 3169 2138 
-Q 3169 2591 2961 2847 
-Q 2753 3103 2388 3103 
-Q 2122 3103 1889 2973 
-Q 1656 2844 1484 2597 
-Q 1303 2338 1198 1995 
-Q 1094 1653 1094 1313 
-Q 1094 881 1298 636 
-Q 1503 391 1863 391 
-Q 2134 391 2365 517 
-Q 2597 644 2772 891 
-Q 2950 1147 3059 1487 
-Q 3169 1828 3169 2138 
-z
-M 1381 2969 
-Q 1594 3256 1914 3420 
-Q 2234 3584 2584 3584 
-Q 3122 3584 3439 3221 
-Q 3756 2859 3756 2241 
-Q 3756 1734 3570 1259 
-Q 3384 784 3041 416 
-Q 2816 172 2522 40 
-Q 2228 -91 1906 -91 
-Q 1566 -91 1316 65 
-Q 1066 222 909 531 
-L 806 0 
-L 231 0 
-L 1178 4863 
-L 1753 4863 
-L 1381 2969 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-6c" d="M 1172 4863 
-L 1747 4863 
-L 800 0 
-L 225 0 
-L 1172 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-74" d="M 2706 3500 
-L 2619 3053 
-L 1472 3053 
-L 1100 1153 
-Q 1081 1047 1072 975 
-Q 1063 903 1063 863 
-Q 1063 663 1183 572 
-Q 1303 481 1569 481 
-L 2150 481 
-L 2053 0 
-L 1503 0 
-Q 991 0 739 200 
-Q 488 400 488 806 
-Q 488 878 497 964 
-Q 506 1050 525 1153 
-L 897 3053 
-L 409 3053 
-L 500 3500 
-L 978 3500 
-L 1172 4494 
-L 1747 4494 
-L 1556 3500 
-L 2706 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-79" d="M 1588 -325 
-Q 1188 -997 936 -1164 
-Q 684 -1331 294 -1331 
-L -159 -1331 
-L -63 -850 
-L 269 -850 
-Q 509 -850 678 -719 
-Q 847 -588 1056 -206 
-L 1234 128 
-L 459 3500 
-L 1069 3500 
-L 1650 819 
-L 3256 3500 
-L 3859 3500 
-L 1588 -325 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-44" d="M 1081 4666 
-L 2438 4666 
-Q 3519 4666 4070 4208 
-Q 4622 3750 4622 2847 
-Q 4622 2250 4412 1698 
-Q 4203 1147 3834 769 
-Q 3463 381 2891 190 
-Q 2319 0 1538 0 
-L 172 0 
-L 1081 4666 
-z
-M 1613 4147 
-L 909 519 
-L 1734 519 
-Q 2794 519 3375 1128 
-Q 3956 1738 3956 2847 
-Q 3956 3519 3581 3833 
-Q 3206 4147 2406 4147 
-L 1613 4147 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-75" d="M 428 1388 
-L 838 3500 
-L 1416 3500 
-L 1006 1409 
-Q 975 1256 961 1147 
-Q 947 1038 947 966 
-Q 947 700 1109 554 
-Q 1272 409 1569 409 
-Q 2031 409 2368 721 
-Q 2706 1034 2809 1563 
-L 3194 3500 
-L 3769 3500 
-L 3091 0 
-L 2516 0 
-L 2631 550 
-Q 2388 244 2052 76 
-Q 1716 -91 1338 -91 
-Q 878 -91 622 161 
-Q 366 413 366 863 
-Q 366 956 381 1097 
-Q 397 1238 428 1388 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-63" d="M 3431 3366 
-L 3316 2797 
-Q 3109 2947 2876 3022 
-Q 2644 3097 2394 3097 
-Q 2119 3097 1870 3000 
-Q 1622 2903 1453 2725 
-Q 1184 2453 1037 2087 
-Q 891 1722 891 1331 
-Q 891 859 1127 628 
-Q 1363 397 1844 397 
-Q 2081 397 2348 469 
-Q 2616 541 2906 684 
-L 2797 116 
-Q 2547 13 2283 -39 
-Q 2019 -91 1741 -91 
-Q 1044 -91 669 257 
-Q 294 606 294 1253 
-Q 294 1797 489 2255 
-Q 684 2713 1069 3078 
-Q 1331 3328 1684 3456 
-Q 2038 3584 2456 3584 
-Q 2700 3584 2940 3529 
-Q 3181 3475 3431 3366 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
-L 1747 4863 
-L 1197 2028 
-L 3169 3500 
-L 3916 3500 
-L 1716 1825 
-L 3322 0 
-L 2625 0 
-L 1131 1709 
-L 800 0 
-L 225 0 
-L 1172 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-2c" d="M 575 794 
-L 1234 794 
-L 1131 256 
-L 422 -744 
-L 19 -744 
-L 469 256 
-L 575 794 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-53" d="M 3859 4513 
-L 3738 3897 
-Q 3422 4066 3111 4152 
-Q 2800 4238 2509 4238 
-Q 1944 4238 1609 3991 
-Q 1275 3744 1275 3334 
-Q 1275 3109 1398 2989 
-Q 1522 2869 2034 2731 
-L 2413 2638 
-Q 3053 2472 3303 2217 
-Q 3553 1963 3553 1503 
-Q 3553 797 2998 353 
-Q 2444 -91 1538 -91 
-Q 1166 -91 791 -17 
-Q 416 56 38 206 
-L 166 856 
-Q 513 641 861 531 
-Q 1209 422 1556 422 
-Q 2147 422 2503 684 
-Q 2859 947 2859 1369 
-Q 2859 1650 2717 1795 
-Q 2575 1941 2106 2059 
-L 1728 2156 
-Q 1081 2325 845 2545 
-Q 609 2766 609 3163 
-Q 609 3859 1145 4304 
-Q 1681 4750 2541 4750 
-Q 2875 4750 3203 4690 
-Q 3531 4631 3859 4513 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
-L 3047 0 
-L 2472 0 
-L 2578 531 
-Q 2325 219 2001 64 
-Q 1678 -91 1281 -91 
-Q 834 -91 548 182 
-Q 263 456 263 884 
-Q 263 1497 752 1853 
-Q 1241 2209 2100 2209 
-L 2900 2209 
-L 2931 2363 
-Q 2938 2388 2941 2417 
-Q 2944 2447 2944 2509 
-Q 2944 2788 2717 2942 
-Q 2491 3097 2081 3097 
-Q 1800 3097 1504 3025 
-Q 1209 2953 897 2809 
-L 997 3341 
-Q 1322 3463 1633 3523 
-Q 1944 3584 2234 3584 
-Q 2853 3584 3176 3315 
-Q 3500 3047 3500 2534 
-Q 3500 2431 3484 2292 
-Q 3469 2153 3438 1997 
-z
-M 2816 1759 
-L 2241 1759 
-Q 1534 1759 1195 1570 
-Q 856 1381 856 984 
-Q 856 709 1029 553 
-Q 1203 397 1509 397 
-Q 1978 397 2328 733 
-Q 2678 1069 2791 1631 
-L 2816 1759 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Oblique-72" d="M 2853 2969 
-Q 2766 3016 2653 3041 
-Q 2541 3066 2413 3066 
-Q 1953 3066 1609 2717 
-Q 1266 2369 1153 1784 
-L 800 0 
-L 225 0 
-L 909 3500 
-L 1484 3500 
-L 1375 2956 
-Q 1603 3259 1920 3421 
-Q 2238 3584 2597 3584 
-Q 2691 3584 2781 3573 
-Q 2872 3563 2963 3538 
-L 2853 2969 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Oblique-70"/>
-     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(125 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(188.378906 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(251.855469 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(279.638672 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(343.017578 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-3a" transform="translate(406.494141 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(440.185547 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-4d" transform="translate(471.972656 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(558.251953 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(619.433594 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(682.910156 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(710.693359 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(738.476562 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(766.259766 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(805.46875 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(864.648438 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(941.650391 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1005.029297 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(1060.009766 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(1117.919922 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1149.707031 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-4d" transform="translate(1181.494141 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1267.773438 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1328.955078 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(1392.431641 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1420.214844 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(1447.998047 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1475.78125 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(1514.990234 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(1574.169922 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1637.646484 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(1701.123047 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1762.402344 0)"/>
-     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(1803.515625 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- BerlinMOD DB benchmark — baseline, default config (log scale, lower is better) -->
-    <g transform="translate(235.606652 19.44) scale(0.11 -0.11)">
-     <defs>
-      <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-44" d="M 1259 4147 
-L 1259 519 
-L 2022 519 
-Q 2988 519 3436 956 
-Q 3884 1394 3884 2338 
-Q 3884 3275 3436 3711 
-Q 2988 4147 2022 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 1925 4666 
-Q 3281 4666 3915 4102 
-Q 4550 3538 4550 2338 
-Q 4550 1131 3912 565 
-Q 3275 0 1925 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2014" d="M 313 1978 
-L 6088 1978 
-L 6088 1528 
-L 313 1528 
-L 313 1978 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2c" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
+       <path id="DejaVuSans-64" d="M 2906 2969 
 L 2906 4863 
 L 3481 4863 
 L 3481 0 
@@ -2389,28 +2211,20 @@ Q 1469 3103 1208 2742
 Q 947 2381 947 1747 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791 
+       <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
 Q 2391 3103 1925 3103 
 Q 1463 3103 1205 2759 
@@ -2444,122 +2258,88 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-42"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
-     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(563.964844 0)"/>
-     <use xlink:href="#DejaVuSans-42" transform="translate(640.966797 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(709.570312 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(741.357422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(804.833984 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(866.357422 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(929.736328 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(984.716797 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1048.095703 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1145.507812 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1206.787109 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(1247.900391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1305.810547 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1337.597656 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1437.597656 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(1469.384766 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1532.861328 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1594.140625 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1646.240234 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(1707.763672 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1735.546875 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1763.330078 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1826.708984 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(1888.232422 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1920.019531 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(1951.806641 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2015.283203 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2076.806641 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2112.011719 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(2173.291016 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2236.669922 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2264.453125 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2303.662109 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2335.449219 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2390.429688 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2451.611328 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2514.990234 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2550.195312 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(2577.978516 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2641.455078 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(2673.242188 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2712.255859 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2740.039062 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(2801.220703 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2864.697266 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2896.484375 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2948.583984 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3003.564453 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3064.84375 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3092.626953 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(3154.150391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3185.9375 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3217.724609 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3245.507812 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(3306.689453 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3388.476562 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3450 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3491.113281 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3522.900391 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3550.683594 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3602.783203 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(3634.570312 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3698.046875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3759.570312 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3798.779297 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3837.988281 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3899.511719 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(3940.625 0)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-57"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(92.501953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(153.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(181.564453 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(209.347656 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(245.431641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(300.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(328.195312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(389.376953 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(444.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(502.267578 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(534.054688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(586.154297 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(647.677734 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(702.658203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(763.839844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(827.21875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(890.695312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(942.794922 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(974.582031 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1013.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1041.378906 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1102.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1166.037109 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1197.824219 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1249.923828 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1304.904297 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1366.183594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1393.966797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1455.490234 0)"/>
+     </g>
     </g>
    </g>
-   <g id="legend_1">
-    <g id="patch_24">
-     <path d="M 756.904219 86.449062 
-L 846.9 86.449062 
-Q 848.7 86.449062 848.7 84.649062 
-L 848.7 31.74 
-Q 848.7 29.94 846.9 29.94 
-L 756.904219 29.94 
-Q 755.104219 29.94 755.104219 31.74 
-L 755.104219 84.649062 
-Q 755.104219 86.449062 756.904219 86.449062 
+   <g id="patch_54">
+    <path d="M 56.338994 316.6 
+L 56.338994 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 1090.8 316.6 
+L 1090.8 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 56.338994 316.6 
+L 1090.8 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 56.338994 25.8 
+L 1090.8 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_27">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(310.204827 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-3e" d="M 678 3150 
+L 678 3719 
+L 4684 2266 
+L 4684 1747 
+L 678 294 
+L 678 863 
+L 3897 2003 
+L 678 3150 
 z
-" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_42">
-     <!-- platforms -->
-     <g transform="translate(778.052109 41.138437) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-70" d="M 1159 525 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
 L 581 3500 
@@ -2585,45 +2365,355 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-70"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(91.259766 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(152.539062 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(191.748047 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(226.953125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(288.134766 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(327.498047 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(424.910156 0)"/>
-     </g>
+     </defs>
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
     </g>
-    <g id="patch_25">
-     <path d="M 758.704219 54.556719 
-L 776.704219 54.556719 
-L 776.704219 48.256719 
-L 758.704219 48.256719 
+   </g>
+   <g id="text_28">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(366.253327 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(422.301827 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(478.350326 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(534.398826 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(590.447326 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(646.495826 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(702.544326 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(758.592826 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(814.641326 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(870.689825 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(926.738325 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(982.786825 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- &gt;cap -->
+    <g style="fill: #333333" transform="translate(1038.835325 36.25556) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-3e"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(138.769531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(200.048828 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- BerlinMOD R-queries Q1-Q17 — standard index per platform (sf 0.005) -->
+    <g transform="translate(361.25856 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
 z
-" style="fill: #3a7bd5; stroke: #3a7bd5; stroke-linejoin: miter"/>
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(895.023438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(922.806641 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(984.330078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1036.429688 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1068.216797 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1146.927734 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1210.550781 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1250.259766 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1328.970703 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(1392.59375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1456.216797 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1488.003906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1588.003906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1619.791016 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1671.890625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1711.099609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1772.378906 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1835.757812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1899.234375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1960.513672 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1999.876953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2063.353516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2095.140625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2122.923828 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2186.302734 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2249.779297 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(2309.552734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2368.732422 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2400.519531 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2463.996094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2525.519531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2566.632812 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2598.419922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2661.896484 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2689.679688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2750.958984 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2790.167969 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2825.373047 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2886.554688 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2925.917969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3023.330078 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3055.117188 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3094.130859 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(3146.230469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3181.435547 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3213.222656 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3276.845703 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3308.632812 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3372.255859 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3435.878906 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3499.501953 0)"/>
     </g>
-    <g id="text_43">
-     <!-- MobilityDB -->
-     <g transform="translate(783.904219 54.556719) scale(0.09 -0.09)">
+   </g>
+   <g id="legend_1">
+    <g id="patch_58">
+     <path d="M 62.638994 59.420625 
+L 339.130244 59.420625 
+Q 340.930244 59.420625 340.930244 57.620625 
+L 340.930244 32.1 
+Q 340.930244 30.3 339.130244 30.3 
+L 62.638994 30.3 
+Q 60.838994 30.3 60.838994 32.1 
+L 60.838994 57.620625 
+Q 60.838994 59.420625 62.638994 59.420625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_59">
+     <path d="M 64.438994 40.738594 
+L 82.438994 40.738594 
+L 82.438994 34.438594 
+L 64.438994 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_42">
+     <!-- MobilityDB R-tree -->
+     <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <defs>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
 " transform="scale(0.015625)"/>
       </defs>
@@ -2637,19 +2727,26 @@ z
       <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
       <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
       <use xlink:href="#DejaVuSans-42" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.28125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(570.068359 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(635.550781 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(671.634766 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(710.84375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(749.707031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(811.230469 0)"/>
      </g>
     </g>
-    <g id="patch_26">
-     <path d="M 758.704219 67.767031 
-L 776.704219 67.767031 
-L 776.704219 61.467031 
-L 758.704219 61.467031 
+    <g id="patch_60">
+     <path d="M 64.438994 53.948906 
+L 82.438994 53.948906 
+L 82.438994 47.648906 
+L 64.438994 47.648906 
 z
-" style="fill: #e07b39; stroke: #e07b39; stroke-linejoin: miter"/>
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
-     <!-- MobilityDuck -->
-     <g transform="translate(783.904219 67.767031) scale(0.09 -0.09)">
+    <g id="text_43">
+     <!-- MobilityDuck (no index) -->
+     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2662,19 +2759,30 @@ z
       <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
       <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
       <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(716.748047 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(780.126953 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(841.308594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(873.095703 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(900.878906 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(964.257812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1027.734375 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1087.507812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1146.6875 0)"/>
      </g>
     </g>
-    <g id="patch_27">
-     <path d="M 758.704219 80.977344 
-L 776.704219 80.977344 
-L 776.704219 74.677344 
-L 758.704219 74.677344 
+    <g id="patch_61">
+     <path d="M 214.353682 40.738594 
+L 232.353682 40.738594 
+L 232.353682 34.438594 
+L 214.353682 34.438594 
 z
-" style="fill: #1f9e6e; stroke: #1f9e6e; stroke-linejoin: miter"/>
+" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
-     <!-- MobilitySpark -->
-     <g transform="translate(783.904219 80.977344) scale(0.09 -0.09)">
+    <g id="text_44">
+     <!-- MobilitySpark local[2] -->
+     <g transform="translate(239.553682 40.738594) scale(0.09 -0.09)">
       <defs>
        <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -2707,6 +2815,28 @@ Q 2388 4750 2728 4690
 Q 3069 4631 3425 4513 
 z
 " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
@@ -2721,14 +2851,67 @@ z
       <use xlink:href="#DejaVuSans-61" transform="translate(519.628906 0)"/>
       <use xlink:href="#DejaVuSans-72" transform="translate(580.908203 0)"/>
       <use xlink:href="#DejaVuSans-6b" transform="translate(622.021484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(679.931641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(711.71875 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(739.501953 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(800.683594 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(855.664062 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(916.943359 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(944.726562 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(983.740234 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(1047.363281 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6739aaa24c">
-   <rect x="55.772054" y="25.44" width="797.427946" height="306.68"/>
+  <clipPath id="p951353d1b5">
+   <rect x="56.338994" y="25.8" width="1034.461006" height="290.8"/>
   </clipPath>
+ </defs>
+ <defs>
+  <pattern id="hbc887773d0" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#2ca02c"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #333333; stroke: #333333; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/batch/cross_platform_th3index.svg
+++ b/BerlinMOD/benchmarks/batch/cross_platform_th3index.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="864pt" height="360pt" viewBox="0 0 864 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="360pt" viewBox="0 0 576 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-01T18:56:19.919792</dc:date>
+    <dc:date>2026-06-07T17:42:28.588975</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,36 +22,236 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 360 
-L 864 360 
-L 864 0 
+L 576 360 
+L 576 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 55.772054 332.12 
-L 853.2 332.12 
-L 853.2 25.44 
-L 55.772054 25.44 
+    <path d="M 56.338994 316.6 
+L 565.2 316.6 
+L 565.2 25.8 
+L 56.338994 25.8 
 z
 " style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 79.46904 59565.759687 
+L 93.6934 59565.759687 
+L 93.6934 68.100718 
+L 79.46904 68.100718 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 176.101918 59565.759687 
+L 190.326278 59565.759687 
+L 190.326278 316.6 
+L 176.101918 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 272.734796 59565.759687 
+L 286.959156 59565.759687 
+L 286.959156 121.081659 
+L 272.734796 121.081659 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 369.367674 59565.759687 
+L 383.592034 59565.759687 
+L 383.592034 80.930259 
+L 369.367674 80.930259 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 466.000553 59565.759687 
+L 480.224912 59565.759687 
+L 480.224912 40.970192 
+L 466.000553 40.970192 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 94.9303 59565.759687 
+L 109.15466 59565.759687 
+L 109.15466 93.762763 
+L 94.9303 93.762763 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 191.563179 59565.759687 
+L 205.787538 59565.759687 
+L 205.787538 80.214061 
+L 191.563179 80.214061 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 288.196057 59565.759687 
+L 302.420416 59565.759687 
+L 302.420416 215.634559 
+L 288.196057 215.634559 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 384.828935 59565.759687 
+L 399.053295 59565.759687 
+L 399.053295 96.625283 
+L 384.828935 96.625283 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 481.461813 59565.759687 
+L 495.686173 59565.759687 
+L 495.686173 122.720877 
+L 481.461813 122.720877 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 110.391561 59565.759687 
+L 124.615921 59565.759687 
+L 124.615921 144.401434 
+L 110.391561 144.401434 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 207.024439 59565.759687 
+L 221.248799 59565.759687 
+L 221.248799 316.6 
+L 207.024439 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 303.657317 59565.759687 
+L 317.881677 59565.759687 
+L 317.881677 168.544747 
+L 303.657317 168.544747 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 400.290195 59565.759687 
+L 414.514555 59565.759687 
+L 414.514555 148.271241 
+L 400.290195 148.271241 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 496.923074 59565.759687 
+L 511.147433 59565.759687 
+L 511.147433 91.061888 
+L 496.923074 91.061888 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 125.852821 59565.759687 
+L 140.077181 59565.759687 
+L 140.077181 316.6 
+L 125.852821 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 222.4857 59565.759687 
+L 236.710059 59565.759687 
+L 236.710059 316.6 
+L 222.4857 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 319.118578 59565.759687 
+L 333.342937 59565.759687 
+L 333.342937 210.92902 
+L 319.118578 210.92902 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 415.751456 59565.759687 
+L 429.975816 59565.759687 
+L 429.975816 203.50423 
+L 415.751456 203.50423 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 512.384334 59565.759687 
+L 526.608694 59565.759687 
+L 526.608694 124.171203 
+L 512.384334 124.171203 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 141.314082 59565.759687 
+L 155.538442 59565.759687 
+L 155.538442 316.6 
+L 141.314082 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 237.94696 59565.759687 
+L 252.17132 59565.759687 
+L 252.17132 79.943807 
+L 237.94696 79.943807 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 334.579838 59565.759687 
+L 348.804198 59565.759687 
+L 348.804198 316.6 
+L 334.579838 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 431.212716 59565.759687 
+L 445.437076 59565.759687 
+L 445.437076 316.6 
+L 431.212716 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 527.845595 59565.759687 
+L 542.069954 59565.759687 
+L 542.069954 316.6 
+L 527.845595 316.6 
+z
+" clip-path="url(#pdddc84ef6e)" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m1f6bb84808" d="M 0 0 
+       <path id="md021966ecb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1f6bb84808" x="140.933044" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md021966ecb" x="117.503741" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Q4 -->
-      <g transform="translate(133.815857 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(110.386553 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-51" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -107,12 +307,53 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m1f6bb84808" x="266.354237" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md021966ecb" x="214.136619" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
+      <!-- Q5 -->
+      <g transform="translate(207.019431 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md021966ecb" x="310.769497" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
       <!-- Q6 -->
-      <g transform="translate(259.23705 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(303.65231 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -150,15 +391,41 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
+    <g id="xtick_4">
+     <g id="line2d_4">
       <g>
-       <use xlink:href="#m1f6bb84808" x="391.77543" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md021966ecb" x="407.402375" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_3">
+     <g id="text_4">
+      <!-- Q7 -->
+      <g transform="translate(400.285188 331.198438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(78.710938 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#md021966ecb" x="504.035253" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
       <!-- Q10 -->
-      <g transform="translate(381.476993 346.718437) scale(0.1 -0.1)">
+      <g transform="translate(493.736816 331.198438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -202,16 +469,329 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_4">
-     <g id="line2d_4">
+    <g id="text_6">
+     <!-- BerlinMOD R-query -->
+     <g transform="translate(263.05856 344.876563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(563.964844 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(629.447266 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(665.53125 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(729.007812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(792.386719 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(853.910156 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(895.023438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <path d="M 56.338994 316.6 
+L 565.2 316.6 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <defs>
+       <path id="m42983da2c3" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
       <g>
-       <use xlink:href="#m1f6bb84808" x="517.196624" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42983da2c3" x="56.338994" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_4">
-      <!-- Q13 -->
-      <g transform="translate(506.898186 346.718437) scale(0.1 -0.1)">
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g transform="translate(25.838994 320.399219) scale(0.1 -0.1)">
        <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -245,71 +825,28 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-51"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(142.333984 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m1f6bb84808" x="642.617817" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- Q14 -->
-      <g transform="translate(632.319379 346.718437) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-51"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(142.333984 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m1f6bb84808" x="768.03901" y="332.12" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- Q16 -->
-      <g transform="translate(757.740572 346.718437) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-51"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(78.710938 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(142.333984 0)"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_7">
-      <path d="M 55.772054 318.489778 
-L 853.2 318.489778 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
+    <g id="ytick_2">
      <g id="line2d_8">
-      <defs>
-       <path id="mea849c697d" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
+      <path d="M 56.338994 257.172558 
+L 565.2 257.172558 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
       <g>
-       <use xlink:href="#mea849c697d" x="55.772054" y="318.489778" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42983da2c3" x="56.338994" y="257.172558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_7">
+     <g id="text_8">
       <!-- $\mathdefault{10^{-2}}$ -->
-      <g transform="translate(25.272054 322.288997) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 260.971777) scale(0.1 -0.1)">
        <defs>
-        <path id="DejaVuSans-2212" d="M 678 2272 
-L 4684 2272 
-L 4684 1741 
-L 678 1741 
-L 678 2272 
-z
-" transform="scale(0.015625)"/>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -342,20 +879,20 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_2">
-     <g id="line2d_9">
-      <path d="M 55.772054 250.338667 
-L 853.2 250.338667 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
+    <g id="ytick_3">
      <g id="line2d_10">
+      <path d="M 56.338994 197.745116 
+L 565.2 197.745116 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <g>
-       <use xlink:href="#mea849c697d" x="55.772054" y="250.338667" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42983da2c3" x="56.338994" y="197.745116" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_8">
+     <g id="text_9">
       <!-- $\mathdefault{10^{-1}}$ -->
-      <g transform="translate(25.272054 254.137885) scale(0.1 -0.1)">
+      <g transform="translate(25.838994 201.544335) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -363,548 +900,558 @@ L 853.2 250.338667
       </g>
      </g>
     </g>
-    <g id="ytick_3">
-     <g id="line2d_11">
-      <path d="M 55.772054 182.187556 
-L 853.2 182.187556 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
+    <g id="ytick_4">
      <g id="line2d_12">
+      <path d="M 56.338994 138.317674 
+L 565.2 138.317674 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
       <g>
-       <use xlink:href="#mea849c697d" x="55.772054" y="182.187556" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42983da2c3" x="56.338994" y="138.317674" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
+     <g id="text_10">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(31.172054 185.986774) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 142.116893) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <path d="M 55.772054 114.036444 
-L 853.2 114.036444 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
+    <g id="ytick_5">
      <g id="line2d_14">
+      <path d="M 56.338994 78.890232 
+L 565.2 78.890232 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
       <g>
-       <use xlink:href="#mea849c697d" x="55.772054" y="114.036444" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42983da2c3" x="56.338994" y="78.890232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_10">
+     <g id="text_11">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(31.172054 117.835663) scale(0.1 -0.1)">
+      <g transform="translate(31.738994 82.689451) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_5">
-     <g id="line2d_15">
-      <path d="M 55.772054 45.885333 
-L 853.2 45.885333 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#mea849c697d" x="55.772054" y="45.885333" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(31.172054 49.684552) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
     <g id="ytick_6">
-     <g id="line2d_17">
-      <path d="M 55.772054 329.046518 
-L 853.2 329.046518 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_16">
+      <path d="M 56.338994 298.710557 
+L 565.2 298.710557 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_18">
+     <g id="line2d_17">
       <defs>
-       <path id="mcd6b2412da" d="M 0 0 
+       <path id="ma2db599401" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="329.046518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="298.710557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_19">
-      <path d="M 55.772054 325.094303 
-L 853.2 325.094303 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_18">
+      <path d="M 56.338994 288.245904 
+L 565.2 288.245904 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_20">
+     <g id="line2d_19">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="325.094303" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="288.245904" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_21">
-      <path d="M 55.772054 321.608202 
-L 853.2 321.608202 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_20">
+      <path d="M 56.338994 280.821115 
+L 565.2 280.821115 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_22">
+     <g id="line2d_21">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="321.608202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="280.821115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 55.772054 297.974249 
-L 853.2 297.974249 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_22">
+      <path d="M 56.338994 275.062001 
+L 565.2 275.062001 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_24">
+     <g id="line2d_23">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="297.974249" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="275.062001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_25">
-      <path d="M 55.772054 285.973434 
-L 853.2 285.973434 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_24">
+      <path d="M 56.338994 270.356462 
+L 565.2 270.356462 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_26">
+     <g id="line2d_25">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="285.973434" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="270.356462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_27">
-      <path d="M 55.772054 277.45872 
-L 853.2 277.45872 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_26">
+      <path d="M 56.338994 266.377985 
+L 565.2 266.377985 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_28">
+     <g id="line2d_27">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="277.45872" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="266.377985" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_29">
-      <path d="M 55.772054 270.854195 
-L 853.2 270.854195 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_28">
+      <path d="M 56.338994 262.931672 
+L 565.2 262.931672 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_30">
+     <g id="line2d_29">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="270.854195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="262.931672" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_31">
-      <path d="M 55.772054 265.457905 
-L 853.2 265.457905 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_30">
+      <path d="M 56.338994 259.891809 
+L 565.2 259.891809 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_32">
+     <g id="line2d_31">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="265.457905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="259.891809" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_33">
-      <path d="M 55.772054 260.895407 
-L 853.2 260.895407 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_32">
+      <path d="M 56.338994 239.283115 
+L 565.2 239.283115 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_34">
+     <g id="line2d_33">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="260.895407" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="239.283115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
-     <g id="line2d_35">
-      <path d="M 55.772054 256.943192 
-L 853.2 256.943192 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_34">
+      <path d="M 56.338994 228.818462 
+L 565.2 228.818462 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_36">
+     <g id="line2d_35">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="256.943192" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="228.818462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_37">
-      <path d="M 55.772054 253.45709 
-L 853.2 253.45709 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_36">
+      <path d="M 56.338994 221.393673 
+L 565.2 221.393673 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_38">
+     <g id="line2d_37">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="253.45709" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="221.393673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
-     <g id="line2d_39">
-      <path d="M 55.772054 229.823138 
-L 853.2 229.823138 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_38">
+      <path d="M 56.338994 215.634559 
+L 565.2 215.634559 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_40">
+     <g id="line2d_39">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="229.823138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="215.634559" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
-     <g id="line2d_41">
-      <path d="M 55.772054 217.822323 
-L 853.2 217.822323 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_40">
+      <path d="M 56.338994 210.92902 
+L 565.2 210.92902 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_42">
+     <g id="line2d_41">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="217.822323" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="210.92902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
-     <g id="line2d_43">
-      <path d="M 55.772054 209.307609 
-L 853.2 209.307609 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_42">
+      <path d="M 56.338994 206.950543 
+L 565.2 206.950543 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_44">
+     <g id="line2d_43">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="209.307609" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="206.950543" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
-     <g id="line2d_45">
-      <path d="M 55.772054 202.703084 
-L 853.2 202.703084 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_44">
+      <path d="M 56.338994 203.50423 
+L 565.2 203.50423 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_46">
+     <g id="line2d_45">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="202.703084" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="203.50423" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
-     <g id="line2d_47">
-      <path d="M 55.772054 197.306794 
-L 853.2 197.306794 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_46">
+      <path d="M 56.338994 200.464367 
+L 565.2 200.464367 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_48">
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="197.306794" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="200.464367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
-     <g id="line2d_49">
-      <path d="M 55.772054 192.744296 
-L 853.2 192.744296 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_48">
+      <path d="M 56.338994 179.855673 
+L 565.2 179.855673 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_50">
+     <g id="line2d_49">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="192.744296" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="179.855673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
-     <g id="line2d_51">
-      <path d="M 55.772054 188.792081 
-L 853.2 188.792081 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_50">
+      <path d="M 56.338994 169.39102 
+L 565.2 169.39102 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_52">
+     <g id="line2d_51">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="188.792081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="169.39102" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
-     <g id="line2d_53">
-      <path d="M 55.772054 185.305979 
-L 853.2 185.305979 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_52">
+      <path d="M 56.338994 161.966231 
+L 565.2 161.966231 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_54">
+     <g id="line2d_53">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="185.305979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="161.966231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
-     <g id="line2d_55">
-      <path d="M 55.772054 161.672027 
-L 853.2 161.672027 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_54">
+      <path d="M 56.338994 156.207117 
+L 565.2 156.207117 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_56">
+     <g id="line2d_55">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="161.672027" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="156.207117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
-     <g id="line2d_57">
-      <path d="M 55.772054 149.671212 
-L 853.2 149.671212 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_56">
+      <path d="M 56.338994 151.501578 
+L 565.2 151.501578 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_58">
+     <g id="line2d_57">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="149.671212" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="151.501578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
-     <g id="line2d_59">
-      <path d="M 55.772054 141.156498 
-L 853.2 141.156498 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_58">
+      <path d="M 56.338994 147.523101 
+L 565.2 147.523101 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_60">
+     <g id="line2d_59">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="141.156498" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="147.523101" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
-     <g id="line2d_61">
-      <path d="M 55.772054 134.551973 
-L 853.2 134.551973 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_60">
+      <path d="M 56.338994 144.076788 
+L 565.2 144.076788 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_62">
+     <g id="line2d_61">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="134.551973" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="144.076788" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
-     <g id="line2d_63">
-      <path d="M 55.772054 129.155683 
-L 853.2 129.155683 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_62">
+      <path d="M 56.338994 141.036925 
+L 565.2 141.036925 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_64">
+     <g id="line2d_63">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="129.155683" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="141.036925" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
-     <g id="line2d_65">
-      <path d="M 55.772054 124.593185 
-L 853.2 124.593185 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_64">
+      <path d="M 56.338994 120.428231 
+L 565.2 120.428231 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_66">
+     <g id="line2d_65">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="124.593185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="120.428231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
-     <g id="line2d_67">
-      <path d="M 55.772054 120.64097 
-L 853.2 120.64097 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_66">
+      <path d="M 56.338994 109.963578 
+L 565.2 109.963578 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_68">
+     <g id="line2d_67">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="120.64097" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="109.963578" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
-     <g id="line2d_69">
-      <path d="M 55.772054 117.154868 
-L 853.2 117.154868 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_68">
+      <path d="M 56.338994 102.538789 
+L 565.2 102.538789 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_70">
+     <g id="line2d_69">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="117.154868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="102.538789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
-     <g id="line2d_71">
-      <path d="M 55.772054 93.520916 
-L 853.2 93.520916 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_70">
+      <path d="M 56.338994 96.779675 
+L 565.2 96.779675 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_72">
+     <g id="line2d_71">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="93.520916" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="96.779675" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
-     <g id="line2d_73">
-      <path d="M 55.772054 81.520101 
-L 853.2 81.520101 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_72">
+      <path d="M 56.338994 92.074136 
+L 565.2 92.074136 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_74">
+     <g id="line2d_73">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="81.520101" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="92.074136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
-     <g id="line2d_75">
-      <path d="M 55.772054 73.005387 
-L 853.2 73.005387 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_74">
+      <path d="M 56.338994 88.095659 
+L 565.2 88.095659 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_76">
+     <g id="line2d_75">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="73.005387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="88.095659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
-     <g id="line2d_77">
-      <path d="M 55.772054 66.400862 
-L 853.2 66.400862 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_76">
+      <path d="M 56.338994 84.649346 
+L 565.2 84.649346 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_78">
+     <g id="line2d_77">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="66.400862" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="84.649346" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
-     <g id="line2d_79">
-      <path d="M 55.772054 61.004572 
-L 853.2 61.004572 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_78">
+      <path d="M 56.338994 81.609483 
+L 565.2 81.609483 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_80">
+     <g id="line2d_79">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="61.004572" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="81.609483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
-     <g id="line2d_81">
-      <path d="M 55.772054 56.442074 
-L 853.2 56.442074 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_80">
+      <path d="M 56.338994 61.000789 
+L 565.2 61.000789 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_82">
+     <g id="line2d_81">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="56.442074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="61.000789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
-     <g id="line2d_83">
-      <path d="M 55.772054 52.489858 
-L 853.2 52.489858 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_82">
+      <path d="M 56.338994 50.536136 
+L 565.2 50.536136 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_84">
+     <g id="line2d_83">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="52.489858" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="50.536136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
-     <g id="line2d_85">
-      <path d="M 55.772054 49.003757 
-L 853.2 49.003757 
-" clip-path="url(#p0145a965ce)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.6; stroke-linecap: square"/>
+     <g id="line2d_84">
+      <path d="M 56.338994 43.111347 
+L 565.2 43.111347 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_86">
+     <g id="line2d_85">
       <g>
-       <use xlink:href="#mcd6b2412da" x="55.772054" y="49.003757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma2db599401" x="56.338994" y="43.111347" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_86">
+      <path d="M 56.338994 37.352233 
+L 565.2 37.352233 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#ma2db599401" x="56.338994" y="37.352233" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_88">
+      <path d="M 56.338994 32.646694 
+L 565.2 32.646694 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#ma2db599401" x="56.338994" y="32.646694" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_90">
+      <path d="M 56.338994 28.668217 
+L 565.2 28.668217 
+" clip-path="url(#pdddc84ef6e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#ma2db599401" x="56.338994" y="28.668217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_12">
-     <!-- Execution time (s) -->
-     <g transform="translate(19.192366 224.294844) rotate(-90) scale(0.1 -0.1)">
+     <!-- Wall-clock seconds (log scale) -->
+     <g transform="translate(19.759307 245.925781) rotate(-90) scale(0.1 -0.1)">
       <defs>
-       <path id="DejaVuSans-45" d="M 628 4666 
-L 3578 4666 
-L 3578 4134 
-L 1259 4134 
-L 1259 2753 
-L 3481 2753 
-L 3481 2222 
-L 1259 2222 
-L 1259 531 
-L 3634 531 
-L 3634 0 
-L 628 0 
-L 628 4666 
+       <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
 z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-65" d="M 3597 1894 
-L 3597 1613 
-L 953 1613 
-Q 991 1019 1311 708 
-Q 1631 397 2203 397 
-Q 2534 397 2845 478 
-Q 3156 559 3463 722 
-L 3463 178 
-Q 3153 47 2828 -22 
-Q 2503 -91 2169 -91 
-Q 1331 -91 842 396 
-Q 353 884 353 1716 
-Q 353 2575 817 3079 
-Q 1281 3584 2069 3584 
-Q 2775 3584 3186 3129 
-Q 3597 2675 3597 1894 
-z
-M 3022 2063 
-Q 3016 2534 2758 2815 
-Q 2500 3097 2075 3097 
-Q 1594 3097 1305 2825 
-Q 1016 2553 972 2059 
-L 3022 2063 
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-63" d="M 3122 3366 
@@ -928,62 +1475,6 @@ Q 2378 3584 2631 3529
 Q 2884 3475 3122 3366 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
        <path id="DejaVuSans-6f" d="M 1959 3097 
 Q 1497 3097 1228 2736 
 Q 959 2375 959 1747 
@@ -1005,67 +1496,18 @@ Q 353 2609 779 3096
 Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
 L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
+L 1159 1709 
 L 1159 0 
 L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6d" d="M 3328 2828 
-Q 3544 3216 3844 3400 
-Q 4144 3584 4550 3584 
-Q 5097 3584 5394 3201 
-Q 5691 2819 5691 2113 
-L 5691 0 
-L 5113 0 
-L 5113 2094 
-Q 5113 2597 4934 2840 
-Q 4756 3084 4391 3084 
-Q 3944 3084 3684 2787 
-Q 3425 2491 3425 1978 
-L 3425 0 
-L 2847 0 
-L 2847 2094 
-Q 2847 2600 2669 2842 
-Q 2491 3084 2119 3084 
-Q 1678 3084 1418 2786 
-Q 1159 2488 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1356 3278 1631 3431 
-Q 1906 3584 2284 3584 
-Q 2666 3584 2933 3390 
-Q 3200 3197 3328 2828 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
+L 581 4863 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-73" d="M 2834 3397 
@@ -1099,602 +1541,7 @@ Q 2034 3584 2315 3537
 Q 2597 3491 2834 3397 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-45"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(63.183594 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(119.238281 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(180.761719 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(235.742188 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(299.121094 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(338.330078 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(366.113281 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(427.294922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(490.673828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(522.460938 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(561.669922 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(589.453125 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(686.865234 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(748.388672 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(780.175781 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(819.189453 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(871.289062 0)"/>
-     </g>
-    </g>
-   </g>
-   <g id="patch_3">
-    <path d="M 92.018779 68333.298667 
-L 139.678832 68333.298667 
-L 139.678832 134.14048 
-L 92.018779 134.14048 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 217.439972 68333.298667 
-L 265.100025 68333.298667 
-L 265.100025 162.421375 
-L 217.439972 162.421375 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 342.861165 68333.298667 
-L 390.521218 68333.298667 
-L 390.521218 70.549921 
-L 342.861165 70.549921 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_6">
-    <path d="M 468.282358 68333.298667 
-L 515.942412 68333.298667 
-L 515.942412 137.343348 
-L 468.282358 137.343348 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 593.703551 68333.298667 
-L 641.363605 68333.298667 
-L 641.363605 206.486652 
-L 593.703551 206.486652 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 719.124745 68333.298667 
-L 766.784798 68333.298667 
-L 766.784798 99.484972 
-L 719.124745 99.484972 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #3a7bd5; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 142.187256 68333.298667 
-L 189.847309 68333.298667 
-L 189.847309 131.092193 
-L 142.187256 131.092193 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 267.608449 68333.298667 
-L 315.268503 68333.298667 
-L 315.268503 270.854195 
-L 267.608449 270.854195 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 393.029642 68333.298667 
-L 440.689696 68333.298667 
-L 440.689696 164.301222 
-L 393.029642 164.301222 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 518.450835 68333.298667 
-L 566.110889 68333.298667 
-L 566.110889 100.329627 
-L 518.450835 100.329627 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 643.872029 68333.298667 
-L 691.532082 68333.298667 
-L 691.532082 105.707297 
-L 643.872029 105.707297 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 769.293222 68333.298667 
-L 816.953275 68333.298667 
-L 816.953275 102.855894 
-L 769.293222 102.855894 
-z
-" clip-path="url(#p0145a965ce)" style="fill: #e07b39; stroke: #1a1a1a; stroke-width: 0.3; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 55.772054 332.12 
-L 55.772054 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 853.2 332.12 
-L 853.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 55.772054 332.12 
-L 853.2 332.12 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 55.772054 25.44 
-L 853.2 25.44 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="text_13">
-    <!-- 5.07 -->
-    <g transform="translate(117.50443 132.415857) rotate(-90) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_14">
-    <!-- 1.95 -->
-    <g transform="translate(242.925624 160.696752) rotate(-90) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_15">
-    <!-- 43.46 -->
-    <g transform="translate(368.346817 68.825298) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 4.55 -->
-    <g transform="translate(493.76801 135.618725) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 440m -->
-    <g transform="translate(619.189203 204.762029) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 16.35 -->
-    <g transform="translate(744.610396 97.760349) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 5.62 -->
-    <g transform="translate(167.672908 129.36757) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 50m -->
-    <g transform="translate(293.094101 269.129573) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.83 -->
-    <g transform="translate(418.515294 162.576599) rotate(-90) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 15.89 -->
-    <g transform="translate(543.936487 98.605005) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 13.25 -->
-    <g transform="translate(669.35768 103.982674) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 14.59 -->
-    <g transform="translate(794.778873 101.131271) rotate(-90) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- BerlinMOD DB benchmark — shared accelerator: th3index vs R-tree baseline (log scale, lower is better) -->
-    <g transform="translate(169.715793 19.44) scale(0.11 -0.11)">
-     <defs>
-      <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-44" d="M 1259 4147 
-L 1259 519 
-L 2022 519 
-Q 2988 519 3436 956 
-Q 3884 1394 3884 2338 
-Q 3884 3275 3436 3711 
-Q 2988 4147 2022 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 1925 4666 
-Q 3281 4666 3915 4102 
-Q 4550 3538 4550 2338 
-Q 4550 1131 3912 565 
-Q 3275 0 1925 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759 
-Q 1497 1759 1228 1600 
-Q 959 1441 959 1056 
-Q 959 750 1161 570 
-Q 1363 391 1709 391 
-Q 2188 391 2477 730 
-Q 2766 1069 2766 1631 
-L 2766 1759 
-L 2194 1759 
-z
-M 3341 1997 
-L 3341 0 
-L 2766 0 
-L 2766 531 
-Q 2569 213 2275 61 
-Q 1981 -91 1556 -91 
-Q 1019 -91 701 211 
-Q 384 513 384 1019 
-Q 384 1609 779 1909 
-Q 1175 2209 1959 2209 
-L 2766 2209 
-L 2766 2266 
-Q 2766 2663 2505 2880 
-Q 2244 3097 1772 3097 
-Q 1472 3097 1187 3025 
-Q 903 2953 641 2809 
-L 641 3341 
-Q 956 3463 1253 3523 
-Q 1550 3584 1831 3584 
-Q 2591 3584 2966 3190 
-Q 3341 2797 3341 1997 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2014" d="M 313 1978 
-L 6088 1978 
-L 6088 1528 
-L 313 1528 
-L 313 1978 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969 
+       <path id="DejaVuSans-64" d="M 2906 2969 
 L 2906 4863 
 L 3481 4863 
 L 3481 0 
@@ -1720,65 +1567,20 @@ Q 1469 3103 1208 2742
 Q 947 2381 947 1747 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-76" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791 
+       <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
 Q 2391 3103 1925 3103 
 Q 1463 3103 1205 2759 
@@ -1812,154 +1614,172 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2c" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
+      </defs>
+      <use xlink:href="#DejaVuSans-57"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(92.501953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(153.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(181.564453 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(209.347656 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(245.431641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(300.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(328.195312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(389.376953 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(444.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(502.267578 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(534.054688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(586.154297 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(647.677734 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(702.658203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(763.839844 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(827.21875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(890.695312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(942.794922 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(974.582031 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1013.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1041.378906 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1102.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1166.037109 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1197.824219 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1249.923828 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1304.904297 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1366.183594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1393.966797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1455.490234 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_28">
+    <path d="M 56.338994 316.6 
+L 56.338994 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 565.2 316.6 
+L 565.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 56.338994 316.6 
+L 565.2 316.6 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 56.338994 25.8 
+L 565.2 25.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(185.14566 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-42"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
-     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(563.964844 0)"/>
-     <use xlink:href="#DejaVuSans-42" transform="translate(640.966797 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(709.570312 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(741.357422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(804.833984 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(866.357422 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(929.736328 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(984.716797 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1048.095703 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1145.507812 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1206.787109 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(1247.900391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1305.810547 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1337.597656 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1437.597656 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1469.384766 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1521.484375 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1584.863281 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1646.142578 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1685.005859 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(1746.529297 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1810.005859 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1841.792969 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1903.072266 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1958.052734 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2013.033203 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2074.556641 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2102.339844 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2163.863281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2204.976562 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2266.255859 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2305.464844 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2366.646484 0)"/>
-     <use xlink:href="#DejaVuSans-3a" transform="translate(2406.009766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2439.701172 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2471.488281 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2510.697266 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(2574.076172 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2637.699219 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2665.482422 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2728.861328 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2792.337891 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(2852.111328 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2911.291016 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(2943.078125 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3002.257812 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3054.357422 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(3086.144531 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(3151.626953 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3187.710938 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3226.919922 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3265.783203 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3327.306641 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3388.830078 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(3420.617188 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3484.09375 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3545.373047 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3597.472656 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3658.996094 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3686.779297 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3714.5625 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3777.941406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3839.464844 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(3871.251953 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3910.265625 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3938.048828 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(3999.230469 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4062.707031 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4094.494141 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(4146.59375 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(4201.574219 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(4262.853516 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4290.636719 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(4352.160156 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4383.947266 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(4415.734375 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(4443.517578 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(4504.699219 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4586.486328 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(4648.009766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4689.123047 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(4720.910156 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4748.693359 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4800.792969 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(4832.580078 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4896.056641 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4957.580078 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4996.789062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(5035.998047 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(5097.521484 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(5138.634766 0)"/>
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
    </g>
-   <g id="legend_1">
-    <g id="patch_19">
-     <path d="M 727.209844 73.23875 
-L 846.9 73.23875 
-Q 848.7 73.23875 848.7 71.43875 
-L 848.7 31.74 
-Q 848.7 29.94 846.9 29.94 
-L 727.209844 29.94 
-Q 725.409844 29.94 725.409844 31.74 
-L 725.409844 71.43875 
-Q 725.409844 73.23875 727.209844 73.23875 
-z
-" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
+   <g id="text_14">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(216.068181 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
     </g>
-    <g id="text_26">
-     <!-- platforms -->
-     <g transform="translate(763.204922 41.138438) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-70" d="M 1159 525 
+   </g>
+   <g id="text_15">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(134.896564 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(231.529442 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(150.357824 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(343.623581 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(440.256459 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- n/a -->
+    <g style="fill: #666666" transform="translate(536.889337 307.915985) rotate(-90) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-6e"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(97.070312 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- BerlinMOD trip-side cross-join queries — th3index prefilter vs baseline (sf 0.005) -->
+    <g transform="translate(69.154185 19.8) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
 L 581 3500 
@@ -1985,7 +1805,67 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-66" d="M 2375 4863 
+      <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
 L 1825 4384 
 Q 1516 4384 1395 4259 
@@ -2006,48 +1886,159 @@ Q 1241 4863 1831 4863
 L 2375 4863 
 z
 " transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-70"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(91.259766 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(152.539062 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(191.748047 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(226.953125 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(288.134766 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(327.498047 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(424.910156 0)"/>
-     </g>
-    </g>
-    <g id="patch_20">
-     <path d="M 729.009844 54.556719 
-L 747.009844 54.556719 
-L 747.009844 48.256719 
-L 729.009844 48.256719 
-z
-" style="fill: #3a7bd5; stroke: #3a7bd5; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_27">
-     <!-- MobilityDB R-tree -->
-     <g transform="translate(754.209844 54.556719) scale(0.09 -0.09)">
-      <defs>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
+      <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
-L 1894 763 
+L 1894 563 
 L 2988 3500 
 L 3597 3500 
-L 2059 -325 
+L 2284 0 
+L 1503 0 
+L 191 3500 
 z
 " transform="scale(0.015625)"/>
-      </defs>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(130.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(171.240234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(199.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(226.806641 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(290.185547 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(455.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(532.177734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(563.964844 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(603.173828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(644.287109 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(672.070312 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(735.546875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(771.630859 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(823.730469 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(851.513672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(914.990234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(976.513672 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1008.300781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1063.28125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1102.144531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1163.326172 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1215.425781 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1267.525391 0)"/>
+     <use xlink:href="#DejaVuSans-6a" transform="translate(1303.609375 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1331.392578 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1392.574219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1420.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1483.736328 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(1515.523438 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1579 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1642.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1703.902344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1745.015625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1772.798828 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1834.322266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1886.421875 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1918.208984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2018.208984 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2049.996094 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2089.205078 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2152.583984 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2216.207031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2243.990234 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2307.369141 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2370.845703 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(2430.619141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2489.798828 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2521.585938 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2585.0625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2623.925781 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2685.449219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2720.654297 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2748.4375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2776.220703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2815.429688 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2876.953125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2918.066406 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2949.853516 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3009.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3061.132812 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3092.919922 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3156.396484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3217.675781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3269.775391 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3331.298828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3359.082031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3386.865234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3450.244141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3511.767578 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3543.554688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3582.568359 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(3634.667969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3669.873047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3701.660156 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3765.283203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3797.070312 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3860.693359 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3924.316406 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3987.939453 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_32">
+     <path d="M 62.638994 72.630938 
+L 388.410869 72.630938 
+Q 390.210869 72.630938 390.210869 70.830938 
+L 390.210869 32.1 
+Q 390.210869 30.3 388.410869 30.3 
+L 62.638994 30.3 
+Q 60.838994 30.3 60.838994 32.1 
+L 60.838994 70.830938 
+Q 60.838994 72.630938 62.638994 72.630938 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_33">
+     <path d="M 64.438994 40.738594 
+L 82.438994 40.738594 
+L 82.438994 34.438594 
+L 64.438994 34.438594 
+z
+" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <!-- MobilityDB R-tree (baseline) -->
+     <g transform="translate(89.638994 40.738594) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2065,19 +2056,30 @@ z
       <use xlink:href="#DejaVuSans-72" transform="translate(710.84375 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(749.707031 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(811.230469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(872.753906 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(904.541016 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(943.554688 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1007.03125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1068.310547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1120.410156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1181.933594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1209.716797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1237.5 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1300.878906 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1362.402344 0)"/>
      </g>
     </g>
-    <g id="patch_21">
-     <path d="M 729.009844 67.767031 
-L 747.009844 67.767031 
-L 747.009844 61.467031 
-L 729.009844 61.467031 
+    <g id="patch_34">
+     <path d="M 64.438994 53.948906 
+L 82.438994 53.948906 
+L 82.438994 47.648906 
+L 64.438994 47.648906 
 z
-" style="fill: #e07b39; stroke: #e07b39; stroke-linejoin: miter"/>
+" style="fill: #aec7e8; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_28">
+    <g id="text_23">
      <!-- MobilityDB th3index -->
-     <g transform="translate(754.209844 67.767031) scale(0.09 -0.09)">
+     <g transform="translate(89.638994 53.948906) scale(0.09 -0.09)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
@@ -2099,12 +2101,171 @@ z
       <use xlink:href="#DejaVuSans-78" transform="translate(950.691406 0)"/>
      </g>
     </g>
+    <g id="patch_35">
+     <path d="M 64.438994 67.159219 
+L 82.438994 67.159219 
+L 82.438994 60.859219 
+L 64.438994 60.859219 
+z
+" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_24">
+     <!-- MobilityDuck (baseline, no index) -->
+     <g transform="translate(89.638994 67.159219) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(716.748047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(780.224609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(841.503906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(893.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(955.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(982.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1010.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1074.072266 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1135.595703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1167.382812 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1199.169922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1262.548828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1323.730469 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1355.517578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1383.300781 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1446.679688 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1510.15625 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1569.929688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1629.109375 0)"/>
+     </g>
+    </g>
+    <g id="patch_36">
+     <path d="M 257.77165 40.738594 
+L 275.77165 40.738594 
+L 275.77165 34.438594 
+L 257.77165 34.438594 
+z
+" style="fill: #ffbb78; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_25">
+     <!-- MobilityDuck th3index -->
+     <g transform="translate(282.97165 40.738594) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(469.677734 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(533.056641 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(588.037109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(645.947266 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(677.734375 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(716.943359 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(780.322266 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(843.945312 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(871.728516 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(935.107422 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(998.583984 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1058.357422 0)"/>
+     </g>
+    </g>
+    <g id="patch_37">
+     <path d="M 257.77165 53.948906 
+L 275.77165 53.948906 
+L 275.77165 47.648906 
+L 257.77165 47.648906 
+z
+" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_26">
+     <!-- MobilitySpark th3index -->
+     <g transform="translate(282.97165 53.948906) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4d"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(86.279297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(147.460938 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(210.9375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.720703 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(294.287109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(333.496094 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(392.675781 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(456.152344 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(519.628906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(580.908203 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(622.021484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(679.931641 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(711.71875 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(750.927734 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(814.306641 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(877.929688 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(905.712891 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(969.091797 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1032.568359 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1092.341797 0)"/>
+     </g>
+    </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0145a965ce">
-   <rect x="55.772054" y="25.44" width="797.427946" height="306.68"/>
+  <clipPath id="pdddc84ef6e">
+   <rect x="56.338994" y="25.8" width="508.861006" height="290.8"/>
   </clipPath>
  </defs>
 </svg>

--- a/BerlinMOD/benchmarks/batch/scripts/render_chart.py
+++ b/BerlinMOD/benchmarks/batch/scripts/render_chart.py
@@ -45,7 +45,7 @@ class Series:
 # Standard matrix — all three platforms with their default index.
 # MobilityDB: R-tree on `trip` + R-tree on `trajectory` (GiST opclass)
 # MobilityDuck: no spatial index (DuckDB columnar full scan)
-# MobilitySpark: local[4], no spatial index
+# MobilitySpark: local[2], 6 g driver, no spatial index
 STANDARD: list[Series] = [
     Series("MobilityDB R-tree", "#1f77b4", {
         "Q1": 0.78, "Q2": 0.15, "Q3": 5.70, "Q4": 15.19, "Q5": 9.50,
@@ -59,11 +59,11 @@ STANDARD: list[Series] = [
         "Q11": 0.62, "Q12": 0.65, "Q13": 7.54, "Q14": 0.54, "Q15": 7.49,
         "Q16": 3.28, "Q17": 0.70,
     }),
-    Series("MobilitySpark local[4]", "#2ca02c", {
-        "Q1": 0.46, "Q2": 49.92, "Q3": 41.08, "Q4": 47.65, "Q5": 9.60,
-        "Q6": 3.87, "Q7": 48.36, "Q8": 0.10, "Q9": 44.05, "Q10": 1156.49,
-        "Q11": ">cap", "Q12": ">cap", "Q13": 110.57, "Q14": ">cap",
-        "Q15": 261.90, "Q16": 69.65, "Q17": 99.26,
+    Series("MobilitySpark local[2]", "#2ca02c", {
+        "Q1": 0.67, "Q2": 1109.81, "Q3": 168.13, "Q4": ">cap", "Q5": ">cap",
+        "Q6": ">cap", "Q7": ">cap", "Q8": ">cap", "Q9": ">cap", "Q10": ">cap",
+        "Q11": ">cap", "Q12": ">cap", "Q13": ">cap", "Q14": ">cap",
+        "Q15": ">cap", "Q16": ">cap", "Q17": ">cap",
     }),
 ]
 


### PR DESCRIPTION
BerlinMOD sf 0.005 (1620 trips, 141 vehicles), Spark 3.5.4 local[2], 6 g driver, 1 run per query. Q1=0.67 s, Q2=1109.81 s, Q3=168.13 s; Q4–Q17 exceed the run cap on this configuration. MobilityDuck column stays — (not yet measured). render_chart.py and the two standard/th3index SVGs regenerated.