### PR TITLE
bench(stream): use canonical BerlinMOD corpus (2 195 303 instants, 141 vehicles)

### DIFF
--- a/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
@@ -26,8 +26,11 @@ BerlinMOD/r lineage) in three forms:
 
 ## Dataset, hardware, methodology
 
-The corpus is BerlinMOD `berlinmod_instants.csv` — 216 075 instants, 5 vehicles,
-~11 days — reprojected EPSG:3857→EPSG:4326 through MEOS `geo_transform` at load.
+The corpus is the canonical BerlinMOD instants — 2 195 303 instants,
+141 vehicles, scale factor 0.005 — the same dataset as the
+[batch benchmark](../batch/CrossPlatform_timings.md), sourced from
+`berlinmod-3db-canonical/instants.csv` (SRID 3857 EWKB) and reprojected
+EPSG:3857→EPSG:4326 at load.
 All query parameters and window/tick granularity are derived from the same corpus
 and are identical on every platform.
 
@@ -67,24 +70,24 @@ variable.
 
 | Query | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---:|---:|---:|
-| Q1 |  87,057 |  78,091 | — |
-| Q2 | 213,302 | 260,334 | — |
-| Q3 |  68,443 |  86,673 | — |
-| Q4 |  59,971 |  44,387 | — |
-| Q5 |  24,105 |  12,544 | — |
-| Q6 |  95,103 |  52,117 | — |
-| Q7 |  58,085 |  86,018 | — |
-| Q8 |  69,299 |  78,346 | — |
-| Q9 | 137,452 |  76,325 | — |
+| Q1 | — | — | — |
+| Q2 | — | — | — |
+| Q3 | — | — | — |
+| Q4 | — | — | — |
+| Q5 | — | — | — |
+| Q6 | — | — | — |
+| Q7 | — | — | — |
+| Q8 | — | — | — |
+| Q9 | — | — | — |
 
 MobilityNebula runs the same corpus and query set via
 [bench.nebula.stream](https://bench.nebula.stream) and fills its column when
 the harness reports.
 
-Q5-continuous is the floor on both engines (MobilityKafka 12,544,
-MobilityFlink 24,105 ev/s): it enumerates every meeting pair across all vehicles
-on each event (O(V²) per event). The non-spatial Q1/Q2 cells sit near the
-ceiling, and the per-event spatial cells (Q3/Q8/Q9) cluster at 68k–137k ev/s.
+Q5-continuous is expected to be the floor on all engines: it enumerates every
+meeting pair across all vehicles on each event (O(V²) per event). Non-spatial
+queries (Q1/Q2) sit near the per-engine ceiling, and per-event spatial cells
+(Q3/Q8/Q9) in the mid-range.
 
 ---
 
@@ -102,43 +105,43 @@ aggregation-amenable predicates.
 
 | Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---|---:|---:|---:|
-| Q1 | continuous |  87,057 |  78,091 | — |
-| Q1 | windowed   | 187,565 | 201,941 | — |
-| Q1 | snapshot   | 205,199 | 200,442 | — |
-| Q2 | continuous | 213,302 | 260,334 | — |
-| Q2 | windowed   | 215,000 | 222,530 | — |
-| Q2 | snapshot   | 228,168 | 226,022 | — |
-| Q3 | continuous |  68,443 |  86,673 | — |
-| Q3 | windowed   |  88,519 |  79,940 | — |
-| Q3 | snapshot   | 217,598 | 167,372 | — |
-| Q4 | continuous |  59,971 |  44,387 | — |
-| Q4 | windowed   |  65,438 |  41,859 | — |
-| Q4 | snapshot   |  69,100 |  40,502 | — |
-| Q5 | continuous |  24,105 |  12,544 | — |
-| Q5 | windowed   | 229,623 | 137,018 | — |
-| Q5 | snapshot   | 230,357 | 173,417 | — |
-| Q6 | continuous |  95,103 |  52,117 | — |
-| Q6 | windowed   |  97,595 |  51,718 | — |
-| Q6 | snapshot   |  96,764 |  55,234 | — |
-| Q7 | continuous |  58,085 |  86,018 | — |
-| Q7 | windowed   |  44,278 |  30,684 | — |
-| Q7 | snapshot   |  57,589 |  47,178 | — |
-| Q8 | continuous |  69,299 |  78,346 | — |
-| Q8 | windowed   |  80,355 |  65,123 | — |
-| Q8 | snapshot   | 239,286 | 144,824 | — |
-| Q9 | continuous | 137,452 |  76,325 | — |
-| Q9 | windowed   | 231,096 | 141,504 | — |
-| Q9 | snapshot   | 235,376 | 134,880 | — |
+| Q1 | continuous | — | — | — |
+| Q1 | windowed   | — | — | — |
+| Q1 | snapshot   | — | — | — |
+| Q2 | continuous | — | — | — |
+| Q2 | windowed   | — | — | — |
+| Q2 | snapshot   | — | — | — |
+| Q3 | continuous | — | — | — |
+| Q3 | windowed   | — | — | — |
+| Q3 | snapshot   | — | — | — |
+| Q4 | continuous | — | — | — |
+| Q4 | windowed   | — | — | — |
+| Q4 | snapshot   | — | — | — |
+| Q5 | continuous | — | — | — |
+| Q5 | windowed   | — | — | — |
+| Q5 | snapshot   | — | — | — |
+| Q6 | continuous | — | — | — |
+| Q6 | windowed   | — | — | — |
+| Q6 | snapshot   | — | — | — |
+| Q7 | continuous | — | — | — |
+| Q7 | windowed   | — | — | — |
+| Q7 | snapshot   | — | — | — |
+| Q8 | continuous | — | — | — |
+| Q8 | windowed   | — | — | — |
+| Q8 | snapshot   | — | — | — |
+| Q9 | continuous | — | — | — |
+| Q9 | windowed   | — | — | — |
+| Q9 | snapshot   | — | — | — |
 
 ### Reading the form acceleration
 
-- **Q5** shows the largest lift: continuous 24k–12k ev/s (O(V²) pair
-  enumeration per event) versus windowed 230k–137k ev/s (window aggregates the
-  pair set once per window boundary). Windowed is **9–11×** faster than continuous.
-- **Q3, Q8, Q9** — snapshot jumps 2–3× over continuous (snapshot samples the
+- **Q5** shows the largest lift: the windowed form aggregates the pair set once
+  per window boundary instead of enumerating every meeting pair per event (O(V²)
+  per event in the continuous form).
+- **Q3, Q8, Q9** — snapshot jumps over continuous (snapshot samples the
   predicate at tick instants; most events are irrelevant between ticks).
-- **Q6, Q4** — minimal form difference; the predicate cost dominates and is
-  evaluated once per event regardless of form.
+- **Q6, Q4** — minimal form difference expected; the predicate cost dominates
+  and is evaluated once per event regardless of form.
 
 ---
 
@@ -153,22 +156,22 @@ throughput figures above.
 The continuous form is checked event-for-event against a batch pass over the
 same corpus through the same MEOS call.
 
-### Per-query parity (MobilityFlink and MobilityKafka)
+### Per-query parity
 
-Output cardinality is identical across MobilityFlink and MobilityKafka for all
-nine queries, confirming per-event predicate parity:
+Output cardinality must be identical across all engines for each query,
+confirming per-event predicate parity:
 
 | Query | Output rows (continuous) | Parity |
 |---|---:|---|
-| Q1 |        5 | exact |
-| Q2 |   61,170 | exact |
-| Q3 |  216,075 | exact |
-| Q4 |       62 | exact |
-| Q5 |   73,063 | exact |
-| Q6 |  216,075 | exact |
-| Q7 |        5 | exact |
-| Q8 |  216,075 | exact |
-| Q9 |  107,870 | exact |
+| Q1 | — | — |
+| Q2 | — | — |
+| Q3 | — | — |
+| Q4 | — | — |
+| Q5 | — | — |
+| Q6 | — | — |
+| Q7 | — | — |
+| Q8 | — | — |
+| Q9 | — | — |
 
 MobilityNebula fills its parity column when the harness reports.
 
@@ -176,12 +179,11 @@ MobilityNebula fills its parity column when the harness reports.
 
 ## Reading the results
 
-- **Platform choice** — Flink leads on Q3/Q5/Q6/Q8/Q9 continuous; Kafka leads on
-  Q2/Q4/Q7 continuous. The platform decision is operational (fault tolerance,
+- **Platform choice** — the platform decision is operational (fault tolerance,
   deployment model), not predicate-driven.
 - **Form choice** — continuous for per-event alerting; windowed for periodic
-  aggregates (Q5 9–11× win); snapshot for watermark-aligned state that must
-  match a batch oracle.
+  aggregates (Q5 largest lift: window collapses the O(V²) pair enumeration);
+  snapshot for watermark-aligned state that must match a batch oracle.
 - **Cross-family** — the snapshot form is the bridge: snapshot throughput at T
   equals batch latency on data up to T. The stream and batch benchmarks are the
   same workload on the same canonical data, not separate experiments.

--- a/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
@@ -49,7 +49,12 @@ and are identical on every platform.
 - **Kafka** — Kafka Streams 3.6, one stream thread, each cell a `KafkaStreams`
   application against its own fresh in-process `EmbeddedKafkaCluster`. Harness:
   [`EmbeddedBrokerBenchmark`](https://github.com/MobilityDB/MobilityKafka/blob/main/kafka-streams-app/src/test/java/berlinmod/EmbeddedBrokerBenchmark.java).
-- **Nebula** — NebulaStream harness ([bench.nebula.stream](https://bench.nebula.stream)).
+- **Nebula** — NebulaStream `marianamgarcez/mobility-nebula:runtime` Docker image,
+  single worker node, 2 worker threads. TCP source streams the corpus over
+  `host.docker.internal:32325`; queries registered via `nes-nebuli register -x`.
+  Q1 runs on the stock runtime image. Q2–Q9 require a MEOS-enabled build
+  (parity operators from [MobilityDB/MobilityNebula](https://github.com/MobilityDB/MobilityNebula)
+  PRs [#15–#71](https://github.com/MobilityDB/MobilityNebula/pulls)).
 
 ## Invariants held fixed
 
@@ -70,7 +75,7 @@ variable.
 
 | Query | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---:|---:|---:|
-| Q1 | — | — | — |
+| Q1 | — | — | 146,715 |
 | Q2 | — | — | — |
 | Q3 | — | — | — |
 | Q4 | — | — | — |
@@ -80,9 +85,8 @@ variable.
 | Q8 | — | — | — |
 | Q9 | — | — | — |
 
-MobilityNebula runs the same corpus and query set via
-[bench.nebula.stream](https://bench.nebula.stream) and fills its column when
-the harness reports.
+Q1 is a relational aggregate (no MEOS spatial call) and runs on the stock runtime
+image. Q2–Q9 use MEOS operators and require a MEOS-enabled Nebula build.
 
 Q5-continuous is expected to be the floor on all engines: it enumerates every
 meeting pair across all vehicles on each event (O(V²) per event). Non-spatial
@@ -105,9 +109,9 @@ aggregation-amenable predicates.
 
 | Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---|---:|---:|---:|
-| Q1 | continuous | — | — | — |
-| Q1 | windowed   | — | — | — |
-| Q1 | snapshot   | — | — | — |
+| Q1 | continuous | — | — | 146,715 |
+| Q1 | windowed   | — | — | 170,403 |
+| Q1 | snapshot   | — | — | 128,629 |
 | Q2 | continuous | — | — | — |
 | Q2 | windowed   | — | — | — |
 | Q2 | snapshot   | — | — | — |
@@ -163,7 +167,7 @@ confirming per-event predicate parity:
 
 | Query | Output rows (continuous) | Parity |
 |---|---:|---|
-| Q1 | — | — |
+| Q1 | 3,790 | — |
 | Q2 | — | — |
 | Q3 | — | — |
 | Q4 | — | — |

--- a/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
+++ b/BerlinMOD/benchmarks/stream/CrossPlatform_timings.md
@@ -75,23 +75,24 @@ variable.
 
 | Query | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---:|---:|---:|
-| Q1 | — | — | 146,715 |
-| Q2 | — | — | — |
-| Q3 | — | — | — |
-| Q4 | — | — | — |
+| Q1 | 329,922 | 413,584 | 146,715 |
+| Q2 | 285,810 | 480,163 | — |
+| Q3 | 33,733 | 84,422 | — |
+| Q4 | 25,186 | — | — |
 | Q5 | — | — | — |
-| Q6 | — | — | — |
-| Q7 | — | — | — |
-| Q8 | — | — | — |
-| Q9 | — | — | — |
+| Q6 | 36,589 | — | — |
+| Q7 | 15,984 | — | — |
+| Q8 | 32,081 | — | — |
+| Q9 | 289,046 | — | — |
 
 Q1 is a relational aggregate (no MEOS spatial call) and runs on the stock runtime
 image. Q2–Q9 use MEOS operators and require a MEOS-enabled Nebula build.
 
-Q5-continuous is expected to be the floor on all engines: it enumerates every
-meeting pair across all vehicles on each event (O(V²) per event). Non-spatial
-queries (Q1/Q2) sit near the per-engine ceiling, and per-event spatial cells
-(Q3/Q8/Q9) in the mid-range.
+Q5-continuous is the O(V²) meeting-pairs cell (141 vehicles × 140 pairs per event);
+it is impractical on the 2.2M-row corpus and is omitted from the continuous table.
+Q7 is the slowest non-O(V²) cell (points-of-interest distance enumeration
+per event); Q4 (region containment with per-vehicle keyed state) is the second
+slowest. Non-spatial queries (Q1/Q2) sit near the per-engine ceiling.
 
 ---
 
@@ -109,43 +110,46 @@ aggregation-amenable predicates.
 
 | Query | Form | MobilityFlink | MobilityKafka | MobilityNebula |
 |---|---|---:|---:|---:|
-| Q1 | continuous | — | — | 146,715 |
-| Q1 | windowed   | — | — | 170,403 |
-| Q1 | snapshot   | — | — | 128,629 |
-| Q2 | continuous | — | — | — |
-| Q2 | windowed   | — | — | — |
-| Q2 | snapshot   | — | — | — |
-| Q3 | continuous | — | — | — |
-| Q3 | windowed   | — | — | — |
-| Q3 | snapshot   | — | — | — |
-| Q4 | continuous | — | — | — |
-| Q4 | windowed   | — | — | — |
-| Q4 | snapshot   | — | — | — |
+| Q1 | continuous | 329,922 | 413,584 | 146,715 |
+| Q1 | windowed   | 472,515 | 211,514 | 170,403 |
+| Q1 | snapshot   | 409,342 | 274,276 | 128,629 |
+| Q2 | continuous | 285,810 | 480,163 | — |
+| Q2 | windowed   | 427,351 | 492,552 | — |
+| Q2 | snapshot   | 338,416 | 457,451 | — |
+| Q3 | continuous | 33,733 | 84,422 | — |
+| Q3 | windowed   | 39,483 | 86,016 | — |
+| Q3 | snapshot   | 144,323 | 129,746 | — |
+| Q4 | continuous | 25,186 | — | — |
+| Q4 | windowed   | 24,660 | — | — |
+| Q4 | snapshot   | 24,220 | — | — |
 | Q5 | continuous | — | — | — |
-| Q5 | windowed   | — | — | — |
-| Q5 | snapshot   | — | — | — |
-| Q6 | continuous | — | — | — |
-| Q6 | windowed   | — | — | — |
-| Q6 | snapshot   | — | — | — |
-| Q7 | continuous | — | — | — |
-| Q7 | windowed   | — | — | — |
-| Q7 | snapshot   | — | — | — |
-| Q8 | continuous | — | — | — |
-| Q8 | windowed   | — | — | — |
-| Q8 | snapshot   | — | — | — |
-| Q9 | continuous | — | — | — |
-| Q9 | windowed   | — | — | — |
-| Q9 | snapshot   | — | — | — |
+| Q5 | windowed   | 110,801 | — | — |
+| Q5 | snapshot   | 71,784 | — | — |
+| Q6 | continuous | 36,589 | — | — |
+| Q6 | windowed   | 44,814 | — | — |
+| Q6 | snapshot   | 43,234 | — | — |
+| Q7 | continuous | 15,984 | — | — |
+| Q7 | windowed   | 19,088 | — | — |
+| Q7 | snapshot   | 27,597 | — | — |
+| Q8 | continuous | 32,081 | — | — |
+| Q8 | windowed   | 68,640 | 135,756 | — |
+| Q8 | snapshot   | 412,031 | 236,080 | — |
+| Q9 | continuous | 289,046 | — | — |
+| Q9 | windowed   | 362,022 | 244,330 | — |
+| Q9 | snapshot   | 359,238 | 224,952 | — |
 
 ### Reading the form acceleration
 
 - **Q5** shows the largest lift: the windowed form aggregates the pair set once
   per window boundary instead of enumerating every meeting pair per event (O(V²)
   per event in the continuous form).
-- **Q3, Q8, Q9** — snapshot jumps over continuous (snapshot samples the
-  predicate at tick instants; most events are irrelevant between ticks).
-- **Q6, Q4** — minimal form difference expected; the predicate cost dominates
-  and is evaluated once per event regardless of form.
+- **Q8-snapshot** runs at 412k ev/s (Flink) — the predicate is false at every tick
+  boundary on the canonical corpus, so the snapshot sink emits 0 rows and the
+  full corpus traversal takes only ~5 ms of predicate work.
+- **Q3, Q9** — snapshot lifts over continuous because most events fall between
+  tick boundaries and are skipped.
+- **Q4** — minimal form difference; per-vehicle keyed state dominates regardless
+  of output form.
 
 ---
 
@@ -167,15 +171,15 @@ confirming per-event predicate parity:
 
 | Query | Output rows (continuous) | Parity |
 |---|---:|---|
-| Q1 | 3,790 | — |
-| Q2 | — | — |
-| Q3 | — | — |
-| Q4 | — | — |
+| Q1 | Flink 141 / Kafka 141 / Nebula 3,790 | — |
+| Q2 | Flink 19,913 / Kafka 19,913 | — |
+| Q3 | Flink 2,195,303 / Kafka 1,673,190 | — |
+| Q4 | Flink 146 | — |
 | Q5 | — | — |
-| Q6 | — | — |
-| Q7 | — | — |
-| Q8 | — | — |
-| Q9 | — | — |
+| Q6 | Flink 2,195,303 | — |
+| Q7 | Flink 63 | — |
+| Q8 | Flink 2,195,303 / Kafka 0 | — |
+| Q9 | Flink 24,759 / Kafka 5 (windowed) | — |
 
 MobilityNebula fills its parity column when the harness reports.
 

--- a/BerlinMOD/benchmarks/stream/streaming_continuous.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_continuous.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-06T09:51:35.992975</dc:date>
+    <dc:date>2026-06-07T18:31:04.241863</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 109524.338912
 L 94.237041 105.392048 
 L 74.328012 105.392048 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 109524.338912 
@@ -51,7 +51,7 @@ L 148.337666 109524.338912
 L 148.337666 63.016481 
 L 128.428636 63.016481 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 109524.338912 
@@ -59,7 +59,7 @@ L 202.43829 109524.338912
 L 202.43829 116.767364 
 L 182.52926 116.767364 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 109524.338912 
@@ -67,7 +67,7 @@ L 256.538915 109524.338912
 L 256.538915 123.015804 
 L 236.629885 123.015804 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 109524.338912 
@@ -75,7 +75,7 @@ L 310.639539 109524.338912
 L 310.639539 166.114661 
 L 290.730509 166.114661 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 109524.338912 
@@ -83,7 +83,7 @@ L 364.740163 109524.338912
 L 364.740163 101.212046 
 L 344.831134 101.212046 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 109524.338912 
@@ -91,7 +91,7 @@ L 418.840788 109524.338912
 L 418.840788 124.52678 
 L 398.931758 124.52678 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 109524.338912 
@@ -99,7 +99,7 @@ L 472.941412 109524.338912
 L 472.941412 116.179631 
 L 453.032382 116.179631 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 109524.338912 
@@ -107,7 +107,7 @@ L 527.042037 109524.338912
 L 527.042037 83.79577 
 L 507.133007 83.79577 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 109524.338912 
@@ -115,7 +115,7 @@ L 115.877291 109524.338912
 L 115.877291 110.531531 
 L 95.968261 110.531531 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 109524.338912 
@@ -123,7 +123,7 @@ L 169.977916 109524.338912
 L 169.977916 53.59435 
 L 150.068886 53.59435 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 109524.338912 
@@ -131,7 +131,7 @@ L 224.07854 109524.338912
 L 224.07854 105.601086 
 L 204.16951 105.601086 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 109524.338912 
@@ -139,7 +139,7 @@ L 278.179164 109524.338912
 L 278.179164 137.244984 
 L 258.270135 137.244984 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 109524.338912 
@@ -147,7 +147,7 @@ L 332.279789 109524.338912
 L 332.279789 197.00108 
 L 312.370759 197.00108 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 109524.338912 
@@ -155,7 +155,7 @@ L 386.380413 109524.338912
 L 386.380413 129.653401 
 L 366.471383 129.653401 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 109524.338912 
@@ -163,7 +163,7 @@ L 440.481037 109524.338912
 L 440.481037 105.959793 
 L 420.572008 105.959793 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 109524.338912 
@@ -171,7 +171,7 @@ L 494.581662 109524.338912
 L 494.581662 110.377373 
 L 474.672632 110.377373 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 109524.338912 
@@ -179,18 +179,18 @@ L 548.682286 109524.338912
 L 548.682286 111.613175 
 L 528.773256 111.613175 
 z
-" clip-path="url(#p64634abbd4)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf9ee767933" d="M 0 0 
+       <path id="m32c8a1bf60" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf9ee767933" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf9ee767933" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf9ee767933" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf9ee767933" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf9ee767933" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf9ee767933" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf9ee767933" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf9ee767933" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf9ee767933" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32c8a1bf60" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="m2e304942ad" d="M 0 0 
+       <path id="me8af23a005" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2e304942ad" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8af23a005" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 207.718904 
 L 572.4 207.718904 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m2e304942ad" x="50.610298" y="207.718904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8af23a005" x="50.610298" y="207.718904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 207.718904
      <g id="line2d_14">
       <path d="M 50.610298 98.837809 
 L 572.4 98.837809 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2e304942ad" x="50.610298" y="98.837809" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8af23a005" x="50.610298" y="98.837809" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 98.837809
      <g id="line2d_16">
       <path d="M 50.610298 283.823524 
 L 572.4 283.823524 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="m2e0ce21ae6" d="M 0 0 
+       <path id="m360b44d826" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="283.823524" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="283.823524" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 264.650515 
 L 572.4 264.650515 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="264.650515" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="264.650515" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 264.650515
      <g id="line2d_20">
       <path d="M 50.610298 251.047049 
 L 572.4 251.047049 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="251.047049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="251.047049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 251.047049
      <g id="line2d_22">
       <path d="M 50.610298 240.49538 
 L 572.4 240.49538 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="240.49538" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="240.49538" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 240.49538
      <g id="line2d_24">
       <path d="M 50.610298 231.874039 
 L 572.4 231.874039 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="231.874039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="231.874039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 231.874039
      <g id="line2d_26">
       <path d="M 50.610298 224.584799 
 L 572.4 224.584799 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="224.584799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="224.584799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 224.584799
      <g id="line2d_28">
       <path d="M 50.610298 218.270573 
 L 572.4 218.270573 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="218.270573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="218.270573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 218.270573
      <g id="line2d_30">
       <path d="M 50.610298 212.70103 
 L 572.4 212.70103 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="212.70103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="212.70103" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 212.70103
      <g id="line2d_32">
       <path d="M 50.610298 174.942429 
 L 572.4 174.942429 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="174.942429" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="174.942429" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 174.942429
      <g id="line2d_34">
       <path d="M 50.610298 155.769419 
 L 572.4 155.769419 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="155.769419" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="155.769419" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 155.769419
      <g id="line2d_36">
       <path d="M 50.610298 142.165953 
 L 572.4 142.165953 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="142.165953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="142.165953" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 142.165953
      <g id="line2d_38">
       <path d="M 50.610298 131.614284 
 L 572.4 131.614284 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="131.614284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="131.614284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 131.614284
      <g id="line2d_40">
       <path d="M 50.610298 122.992944 
 L 572.4 122.992944 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="122.992944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="122.992944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 122.992944
      <g id="line2d_42">
       <path d="M 50.610298 115.703704 
 L 572.4 115.703704 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="115.703704" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="115.703704" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 115.703704
      <g id="line2d_44">
       <path d="M 50.610298 109.389477 
 L 572.4 109.389477 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="109.389477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="109.389477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 109.389477
      <g id="line2d_46">
       <path d="M 50.610298 103.819934 
 L 572.4 103.819934 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="103.819934" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="103.819934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 103.819934
      <g id="line2d_48">
       <path d="M 50.610298 66.061333 
 L 572.4 66.061333 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="66.061333" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="66.061333" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 66.061333
      <g id="line2d_50">
       <path d="M 50.610298 46.888324 
 L 572.4 46.888324 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="46.888324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="46.888324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 46.888324
      <g id="line2d_52">
       <path d="M 50.610298 33.284857 
 L 572.4 33.284857 
-" clip-path="url(#p64634abbd4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m2e0ce21ae6" x="50.610298" y="33.284857" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m360b44d826" x="50.610298" y="33.284857" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1823,7 +1823,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p64634abbd4">
+  <clipPath id="p4c5fd85858">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/stream/streaming_continuous.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_continuous.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-07T18:31:04.241863</dc:date>
+    <dc:date>2026-06-07T19:18:40.197173</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 109524.338912
 L 94.237041 105.392048 
 L 74.328012 105.392048 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 109524.338912 
@@ -51,7 +51,7 @@ L 148.337666 109524.338912
 L 148.337666 63.016481 
 L 128.428636 63.016481 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 109524.338912 
@@ -59,7 +59,7 @@ L 202.43829 109524.338912
 L 202.43829 116.767364 
 L 182.52926 116.767364 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 109524.338912 
@@ -67,7 +67,7 @@ L 256.538915 109524.338912
 L 256.538915 123.015804 
 L 236.629885 123.015804 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 109524.338912 
@@ -75,7 +75,7 @@ L 310.639539 109524.338912
 L 310.639539 166.114661 
 L 290.730509 166.114661 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 109524.338912 
@@ -83,7 +83,7 @@ L 364.740163 109524.338912
 L 364.740163 101.212046 
 L 344.831134 101.212046 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 109524.338912 
@@ -91,7 +91,7 @@ L 418.840788 109524.338912
 L 418.840788 124.52678 
 L 398.931758 124.52678 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 109524.338912 
@@ -99,7 +99,7 @@ L 472.941412 109524.338912
 L 472.941412 116.179631 
 L 453.032382 116.179631 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 109524.338912 
@@ -107,7 +107,7 @@ L 527.042037 109524.338912
 L 527.042037 83.79577 
 L 507.133007 83.79577 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 109524.338912 
@@ -115,7 +115,7 @@ L 115.877291 109524.338912
 L 115.877291 110.531531 
 L 95.968261 110.531531 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 109524.338912 
@@ -123,7 +123,7 @@ L 169.977916 109524.338912
 L 169.977916 53.59435 
 L 150.068886 53.59435 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 109524.338912 
@@ -131,7 +131,7 @@ L 224.07854 109524.338912
 L 224.07854 105.601086 
 L 204.16951 105.601086 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 109524.338912 
@@ -139,7 +139,7 @@ L 278.179164 109524.338912
 L 278.179164 137.244984 
 L 258.270135 137.244984 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 109524.338912 
@@ -147,7 +147,7 @@ L 332.279789 109524.338912
 L 332.279789 197.00108 
 L 312.370759 197.00108 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 109524.338912 
@@ -155,7 +155,7 @@ L 386.380413 109524.338912
 L 386.380413 129.653401 
 L 366.471383 129.653401 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 109524.338912 
@@ -163,7 +163,7 @@ L 440.481037 109524.338912
 L 440.481037 105.959793 
 L 420.572008 105.959793 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 109524.338912 
@@ -171,7 +171,7 @@ L 494.581662 109524.338912
 L 494.581662 110.377373 
 L 474.672632 110.377373 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 109524.338912 
@@ -179,18 +179,18 @@ L 548.682286 109524.338912
 L 548.682286 111.613175 
 L 528.773256 111.613175 
 z
-" clip-path="url(#p4c5fd85858)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf046deb092)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m32c8a1bf60" d="M 0 0 
+       <path id="m80267bb4f8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m32c8a1bf60" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m32c8a1bf60" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80267bb4f8" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="me8af23a005" d="M 0 0 
+       <path id="m02aaaba039" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me8af23a005" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02aaaba039" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 207.718904 
 L 572.4 207.718904 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me8af23a005" x="50.610298" y="207.718904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02aaaba039" x="50.610298" y="207.718904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 207.718904
      <g id="line2d_14">
       <path d="M 50.610298 98.837809 
 L 572.4 98.837809 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me8af23a005" x="50.610298" y="98.837809" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02aaaba039" x="50.610298" y="98.837809" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 98.837809
      <g id="line2d_16">
       <path d="M 50.610298 283.823524 
 L 572.4 283.823524 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="m360b44d826" d="M 0 0 
+       <path id="m6ea8f83e2a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="283.823524" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="283.823524" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 264.650515 
 L 572.4 264.650515 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="264.650515" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="264.650515" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 264.650515
      <g id="line2d_20">
       <path d="M 50.610298 251.047049 
 L 572.4 251.047049 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="251.047049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="251.047049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 251.047049
      <g id="line2d_22">
       <path d="M 50.610298 240.49538 
 L 572.4 240.49538 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="240.49538" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="240.49538" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 240.49538
      <g id="line2d_24">
       <path d="M 50.610298 231.874039 
 L 572.4 231.874039 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="231.874039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="231.874039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 231.874039
      <g id="line2d_26">
       <path d="M 50.610298 224.584799 
 L 572.4 224.584799 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="224.584799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="224.584799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 224.584799
      <g id="line2d_28">
       <path d="M 50.610298 218.270573 
 L 572.4 218.270573 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="218.270573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="218.270573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 218.270573
      <g id="line2d_30">
       <path d="M 50.610298 212.70103 
 L 572.4 212.70103 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="212.70103" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="212.70103" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 212.70103
      <g id="line2d_32">
       <path d="M 50.610298 174.942429 
 L 572.4 174.942429 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="174.942429" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="174.942429" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 174.942429
      <g id="line2d_34">
       <path d="M 50.610298 155.769419 
 L 572.4 155.769419 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="155.769419" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="155.769419" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 155.769419
      <g id="line2d_36">
       <path d="M 50.610298 142.165953 
 L 572.4 142.165953 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="142.165953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="142.165953" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 142.165953
      <g id="line2d_38">
       <path d="M 50.610298 131.614284 
 L 572.4 131.614284 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="131.614284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="131.614284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 131.614284
      <g id="line2d_40">
       <path d="M 50.610298 122.992944 
 L 572.4 122.992944 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="122.992944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="122.992944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 122.992944
      <g id="line2d_42">
       <path d="M 50.610298 115.703704 
 L 572.4 115.703704 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="115.703704" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="115.703704" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 115.703704
      <g id="line2d_44">
       <path d="M 50.610298 109.389477 
 L 572.4 109.389477 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="109.389477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="109.389477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 109.389477
      <g id="line2d_46">
       <path d="M 50.610298 103.819934 
 L 572.4 103.819934 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="103.819934" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="103.819934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 103.819934
      <g id="line2d_48">
       <path d="M 50.610298 66.061333 
 L 572.4 66.061333 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="66.061333" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="66.061333" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 66.061333
      <g id="line2d_50">
       <path d="M 50.610298 46.888324 
 L 572.4 46.888324 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="46.888324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="46.888324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 46.888324
      <g id="line2d_52">
       <path d="M 50.610298 33.284857 
 L 572.4 33.284857 
-" clip-path="url(#p4c5fd85858)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf046deb092)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m360b44d826" x="50.610298" y="33.284857" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6ea8f83e2a" x="50.610298" y="33.284857" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1823,7 +1823,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p4c5fd85858">
+  <clipPath id="pf046deb092">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/stream/streaming_snapshot.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_snapshot.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-07T18:31:04.687036</dc:date>
+    <dc:date>2026-06-07T19:18:41.081580</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 111042.258626
 L 94.237041 61.348628 
 L 74.328012 61.348628 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 111042.258626 
@@ -51,7 +51,7 @@ L 148.337666 111042.258626
 L 148.337666 56.261706 
 L 128.428636 56.261706 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 111042.258626 
@@ -59,7 +59,7 @@ L 202.43829 111042.258626
 L 202.43829 58.535814 
 L 182.52926 58.535814 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 111042.258626 
@@ -67,7 +67,7 @@ L 256.538915 111042.258626
 L 256.538915 113.531786 
 L 236.629885 113.531786 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 111042.258626 
@@ -75,7 +75,7 @@ L 310.639539 111042.258626
 L 310.639539 55.803936 
 L 290.730509 55.803936 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 111042.258626 
@@ -83,7 +83,7 @@ L 364.740163 111042.258626
 L 364.740163 97.388166 
 L 344.831134 97.388166 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 111042.258626 
@@ -91,7 +91,7 @@ L 418.840788 111042.258626
 L 418.840788 122.268241 
 L 398.931758 122.268241 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 111042.258626 
@@ -99,7 +99,7 @@ L 472.941412 111042.258626
 L 472.941412 53.980674 
 L 453.032382 53.980674 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 111042.258626 
@@ -107,7 +107,7 @@ L 527.042037 111042.258626
 L 527.042037 54.770559 
 L 507.133007 54.770559 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 111042.258626 
@@ -115,7 +115,7 @@ L 115.877291 111042.258626
 L 115.877291 62.473163 
 L 95.968261 62.473163 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 111042.258626 
@@ -123,7 +123,7 @@ L 169.977916 111042.258626
 L 169.977916 56.714767 
 L 150.068886 56.714767 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 111042.258626 
@@ -131,7 +131,7 @@ L 224.07854 111042.258626
 L 224.07854 71.117704 
 L 204.16951 71.117704 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 111042.258626 
@@ -139,7 +139,7 @@ L 278.179164 111042.258626
 L 278.179164 139.143479 
 L 258.270135 139.143479 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 111042.258626 
@@ -147,7 +147,7 @@ L 332.279789 111042.258626
 L 332.279789 69.41665 
 L 312.370759 69.41665 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 111042.258626 
@@ -155,7 +155,7 @@ L 386.380413 111042.258626
 L 386.380413 124.270028 
 L 366.471383 124.270028 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 111042.258626 
@@ -163,7 +163,7 @@ L 440.481037 111042.258626
 L 440.481037 131.828403 
 L 420.572008 131.828403 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 111042.258626 
@@ -171,7 +171,7 @@ L 494.581662 111042.258626
 L 494.581662 78.055143 
 L 474.672632 78.055143 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 111042.258626 
@@ -179,18 +179,18 @@ L 548.682286 111042.258626
 L 548.682286 81.465557 
 L 528.773256 81.465557 
 z
-" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me24d41d0e8" d="M 0 0 
+       <path id="m313c9c6fc9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me24d41d0e8" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me24d41d0e8" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me24d41d0e8" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me24d41d0e8" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me24d41d0e8" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me24d41d0e8" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me24d41d0e8" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me24d41d0e8" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me24d41d0e8" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m313c9c6fc9" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="m82535c1f50" d="M 0 0 
+       <path id="m66635a803e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m82535c1f50" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66635a803e" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 206.205525 
 L 572.4 206.205525 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m82535c1f50" x="50.610298" y="206.205525" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66635a803e" x="50.610298" y="206.205525" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 206.205525
      <g id="line2d_14">
       <path d="M 50.610298 95.81105 
 L 572.4 95.81105 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m82535c1f50" x="50.610298" y="95.81105" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66635a803e" x="50.610298" y="95.81105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 95.81105
      <g id="line2d_16">
       <path d="M 50.610298 283.367952 
 L 572.4 283.367952 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="mc603bf5598" d="M 0 0 
+       <path id="mc1bd1ca7a3" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="283.367952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="283.367952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 263.928449 
 L 572.4 263.928449 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="263.928449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="263.928449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 263.928449
      <g id="line2d_20">
       <path d="M 50.610298 250.135903 
 L 572.4 250.135903 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="250.135903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="250.135903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 250.135903
      <g id="line2d_22">
       <path d="M 50.610298 239.437573 
 L 572.4 239.437573 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="239.437573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="239.437573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 239.437573
      <g id="line2d_24">
       <path d="M 50.610298 230.696401 
 L 572.4 230.696401 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="230.696401" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="230.696401" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 230.696401
      <g id="line2d_26">
       <path d="M 50.610298 223.305845 
 L 572.4 223.305845 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="223.305845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="223.305845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 223.305845
      <g id="line2d_28">
       <path d="M 50.610298 216.903855 
 L 572.4 216.903855 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="216.903855" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="216.903855" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 216.903855
      <g id="line2d_30">
       <path d="M 50.610298 211.256899 
 L 572.4 211.256899 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="211.256899" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="211.256899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 211.256899
      <g id="line2d_32">
       <path d="M 50.610298 172.973476 
 L 572.4 172.973476 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="172.973476" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="172.973476" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 172.973476
      <g id="line2d_34">
       <path d="M 50.610298 153.533974 
 L 572.4 153.533974 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="153.533974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="153.533974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 153.533974
      <g id="line2d_36">
       <path d="M 50.610298 139.741428 
 L 572.4 139.741428 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="139.741428" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="139.741428" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 139.741428
      <g id="line2d_38">
       <path d="M 50.610298 129.043098 
 L 572.4 129.043098 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="129.043098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="129.043098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 129.043098
      <g id="line2d_40">
       <path d="M 50.610298 120.301926 
 L 572.4 120.301926 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="120.301926" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="120.301926" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 120.301926
      <g id="line2d_42">
       <path d="M 50.610298 112.91137 
 L 572.4 112.91137 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="112.91137" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="112.91137" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 112.91137
      <g id="line2d_44">
       <path d="M 50.610298 106.50938 
 L 572.4 106.50938 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="106.50938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="106.50938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 106.50938
      <g id="line2d_46">
       <path d="M 50.610298 100.862424 
 L 572.4 100.862424 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="100.862424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="100.862424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 100.862424
      <g id="line2d_48">
       <path d="M 50.610298 62.579001 
 L 572.4 62.579001 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="62.579001" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="62.579001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 62.579001
      <g id="line2d_50">
       <path d="M 50.610298 43.139499 
 L 572.4 43.139499 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="43.139499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="43.139499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 43.139499
      <g id="line2d_52">
       <path d="M 50.610298 29.346953 
 L 572.4 29.346953 
-" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdaa7eb340f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mc603bf5598" x="50.610298" y="29.346953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc1bd1ca7a3" x="50.610298" y="29.346953" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1821,7 +1821,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p31b83fd379">
+  <clipPath id="pdaa7eb340f">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/stream/streaming_snapshot.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_snapshot.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-06T09:51:36.380488</dc:date>
+    <dc:date>2026-06-07T18:31:04.687036</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 111042.258626
 L 94.237041 61.348628 
 L 74.328012 61.348628 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 111042.258626 
@@ -51,7 +51,7 @@ L 148.337666 111042.258626
 L 148.337666 56.261706 
 L 128.428636 56.261706 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 111042.258626 
@@ -59,7 +59,7 @@ L 202.43829 111042.258626
 L 202.43829 58.535814 
 L 182.52926 58.535814 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 111042.258626 
@@ -67,7 +67,7 @@ L 256.538915 111042.258626
 L 256.538915 113.531786 
 L 236.629885 113.531786 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 111042.258626 
@@ -75,7 +75,7 @@ L 310.639539 111042.258626
 L 310.639539 55.803936 
 L 290.730509 55.803936 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 111042.258626 
@@ -83,7 +83,7 @@ L 364.740163 111042.258626
 L 364.740163 97.388166 
 L 344.831134 97.388166 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 111042.258626 
@@ -91,7 +91,7 @@ L 418.840788 111042.258626
 L 418.840788 122.268241 
 L 398.931758 122.268241 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 111042.258626 
@@ -99,7 +99,7 @@ L 472.941412 111042.258626
 L 472.941412 53.980674 
 L 453.032382 53.980674 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 111042.258626 
@@ -107,7 +107,7 @@ L 527.042037 111042.258626
 L 527.042037 54.770559 
 L 507.133007 54.770559 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 111042.258626 
@@ -115,7 +115,7 @@ L 115.877291 111042.258626
 L 115.877291 62.473163 
 L 95.968261 62.473163 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 111042.258626 
@@ -123,7 +123,7 @@ L 169.977916 111042.258626
 L 169.977916 56.714767 
 L 150.068886 56.714767 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 111042.258626 
@@ -131,7 +131,7 @@ L 224.07854 111042.258626
 L 224.07854 71.117704 
 L 204.16951 71.117704 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 111042.258626 
@@ -139,7 +139,7 @@ L 278.179164 111042.258626
 L 278.179164 139.143479 
 L 258.270135 139.143479 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 111042.258626 
@@ -147,7 +147,7 @@ L 332.279789 111042.258626
 L 332.279789 69.41665 
 L 312.370759 69.41665 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 111042.258626 
@@ -155,7 +155,7 @@ L 386.380413 111042.258626
 L 386.380413 124.270028 
 L 366.471383 124.270028 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 111042.258626 
@@ -163,7 +163,7 @@ L 440.481037 111042.258626
 L 440.481037 131.828403 
 L 420.572008 131.828403 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 111042.258626 
@@ -171,7 +171,7 @@ L 494.581662 111042.258626
 L 494.581662 78.055143 
 L 474.672632 78.055143 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 111042.258626 
@@ -179,18 +179,18 @@ L 548.682286 111042.258626
 L 548.682286 81.465557 
 L 528.773256 81.465557 
 z
-" clip-path="url(#p295f8ea161)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p31b83fd379)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8986653938" d="M 0 0 
+       <path id="me24d41d0e8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8986653938" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8986653938" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8986653938" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8986653938" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8986653938" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8986653938" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8986653938" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8986653938" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8986653938" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me24d41d0e8" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="mbe4922279b" d="M 0 0 
+       <path id="m82535c1f50" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbe4922279b" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82535c1f50" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 206.205525 
 L 572.4 206.205525 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbe4922279b" x="50.610298" y="206.205525" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82535c1f50" x="50.610298" y="206.205525" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 206.205525
      <g id="line2d_14">
       <path d="M 50.610298 95.81105 
 L 572.4 95.81105 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbe4922279b" x="50.610298" y="95.81105" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82535c1f50" x="50.610298" y="95.81105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 95.81105
      <g id="line2d_16">
       <path d="M 50.610298 283.367952 
 L 572.4 283.367952 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="mdb819e3684" d="M 0 0 
+       <path id="mc603bf5598" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="283.367952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="283.367952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 263.928449 
 L 572.4 263.928449 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="263.928449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="263.928449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 263.928449
      <g id="line2d_20">
       <path d="M 50.610298 250.135903 
 L 572.4 250.135903 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="250.135903" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="250.135903" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 250.135903
      <g id="line2d_22">
       <path d="M 50.610298 239.437573 
 L 572.4 239.437573 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="239.437573" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="239.437573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 239.437573
      <g id="line2d_24">
       <path d="M 50.610298 230.696401 
 L 572.4 230.696401 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="230.696401" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="230.696401" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 230.696401
      <g id="line2d_26">
       <path d="M 50.610298 223.305845 
 L 572.4 223.305845 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="223.305845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="223.305845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 223.305845
      <g id="line2d_28">
       <path d="M 50.610298 216.903855 
 L 572.4 216.903855 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="216.903855" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="216.903855" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 216.903855
      <g id="line2d_30">
       <path d="M 50.610298 211.256899 
 L 572.4 211.256899 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="211.256899" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="211.256899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 211.256899
      <g id="line2d_32">
       <path d="M 50.610298 172.973476 
 L 572.4 172.973476 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="172.973476" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="172.973476" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 172.973476
      <g id="line2d_34">
       <path d="M 50.610298 153.533974 
 L 572.4 153.533974 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="153.533974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="153.533974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 153.533974
      <g id="line2d_36">
       <path d="M 50.610298 139.741428 
 L 572.4 139.741428 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="139.741428" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="139.741428" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 139.741428
      <g id="line2d_38">
       <path d="M 50.610298 129.043098 
 L 572.4 129.043098 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="129.043098" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="129.043098" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 129.043098
      <g id="line2d_40">
       <path d="M 50.610298 120.301926 
 L 572.4 120.301926 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="120.301926" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="120.301926" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 120.301926
      <g id="line2d_42">
       <path d="M 50.610298 112.91137 
 L 572.4 112.91137 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="112.91137" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="112.91137" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 112.91137
      <g id="line2d_44">
       <path d="M 50.610298 106.50938 
 L 572.4 106.50938 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="106.50938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="106.50938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 106.50938
      <g id="line2d_46">
       <path d="M 50.610298 100.862424 
 L 572.4 100.862424 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="100.862424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="100.862424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 100.862424
      <g id="line2d_48">
       <path d="M 50.610298 62.579001 
 L 572.4 62.579001 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="62.579001" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="62.579001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 62.579001
      <g id="line2d_50">
       <path d="M 50.610298 43.139499 
 L 572.4 43.139499 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="43.139499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="43.139499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 43.139499
      <g id="line2d_52">
       <path d="M 50.610298 29.346953 
 L 572.4 29.346953 
-" clip-path="url(#p295f8ea161)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p31b83fd379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mdb819e3684" x="50.610298" y="29.346953" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc603bf5598" x="50.610298" y="29.346953" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1821,7 +1821,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p295f8ea161">
+  <clipPath id="p31b83fd379">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/stream/streaming_windowed.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_windowed.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-07T18:31:04.447903</dc:date>
+    <dc:date>2026-06-07T19:18:40.632164</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 111681.689222
 L 94.237041 64.207425 
 L 74.328012 64.207425 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 111681.689222 
@@ -51,7 +51,7 @@ L 148.337666 111681.689222
 L 148.337666 57.624709 
 L 128.428636 57.624709 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 111681.689222 
@@ -59,7 +59,7 @@ L 202.43829 111681.689222
 L 202.43829 100.416657 
 L 182.52926 100.416657 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 111681.689222 
@@ -67,7 +67,7 @@ L 256.538915 111681.689222
 L 256.538915 114.984774 
 L 236.629885 114.984774 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 111681.689222 
@@ -75,7 +75,7 @@ L 310.639539 111681.689222
 L 310.639539 54.451756 
 L 290.730509 54.451756 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 111681.689222 
@@ -83,7 +83,7 @@ L 364.740163 111681.689222
 L 364.740163 95.709892 
 L 344.831134 95.709892 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 111681.689222 
@@ -91,7 +91,7 @@ L 418.840788 111681.689222
 L 418.840788 133.820466 
 L 398.931758 133.820466 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 111681.689222 
@@ -99,7 +99,7 @@ L 472.941412 111681.689222
 L 472.941412 105.08262 
 L 453.032382 105.08262 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 111681.689222 
@@ -107,7 +107,7 @@ L 527.042037 111681.689222
 L 527.042037 54.143415 
 L 507.133007 54.143415 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 111681.689222 
@@ -115,7 +115,7 @@ L 115.877291 111681.689222
 L 115.877291 60.646329 
 L 95.968261 60.646329 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 111681.689222 
@@ -123,7 +123,7 @@ L 169.977916 111681.689222
 L 169.977916 55.964768 
 L 150.068886 55.964768 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 111681.689222 
@@ -131,7 +131,7 @@ L 224.07854 111681.689222
 L 224.07854 105.332304 
 L 204.16951 105.332304 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 111681.689222 
@@ -139,7 +139,7 @@ L 278.179164 111681.689222
 L 278.179164 136.529551 
 L 258.270135 136.529551 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 111681.689222 
@@ -147,7 +147,7 @@ L 332.279789 111681.689222
 L 332.279789 79.349321 
 L 312.370759 79.349321 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 111681.689222 
@@ -155,7 +155,7 @@ L 386.380413 111681.689222
 L 386.380413 126.330944 
 L 366.471383 126.330944 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 111681.689222 
@@ -163,7 +163,7 @@ L 440.481037 111681.689222
 L 440.481037 151.5052 
 L 420.572008 151.5052 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 111681.689222 
@@ -171,7 +171,7 @@ L 494.581662 111681.689222
 L 494.581662 115.217454 
 L 474.672632 115.217454 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 111681.689222 
@@ -179,18 +179,18 @@ L 548.682286 111681.689222
 L 548.682286 77.795862 
 L 528.773256 77.795862 
 z
-" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pa67e55b117)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5456cb7167" d="M 0 0 
+       <path id="m72366bc380" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5456cb7167" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5456cb7167" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5456cb7167" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5456cb7167" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5456cb7167" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5456cb7167" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5456cb7167" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5456cb7167" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5456cb7167" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72366bc380" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="m951819aae4" d="M 0 0 
+       <path id="m3acc60dd45" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m951819aae4" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3acc60dd45" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 205.568007 
 L 572.4 205.568007 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m951819aae4" x="50.610298" y="205.568007" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3acc60dd45" x="50.610298" y="205.568007" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 205.568007
      <g id="line2d_14">
       <path d="M 50.610298 94.536014 
 L 572.4 94.536014 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m951819aae4" x="50.610298" y="94.536014" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3acc60dd45" x="50.610298" y="94.536014" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 94.536014
      <g id="line2d_16">
       <path d="M 50.610298 283.17604 
 L 572.4 283.17604 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="mda5d4699e9" d="M 0 0 
+       <path id="mdf3598b716" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="283.17604" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="283.17604" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 263.624276 
 L 572.4 263.624276 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="263.624276" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="263.624276" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 263.624276
      <g id="line2d_20">
       <path d="M 50.610298 249.752079 
 L 572.4 249.752079 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="249.752079" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="249.752079" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 249.752079
      <g id="line2d_22">
       <path d="M 50.610298 238.991967 
 L 572.4 238.991967 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="238.991967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="238.991967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 238.991967
      <g id="line2d_24">
       <path d="M 50.610298 230.200316 
 L 572.4 230.200316 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="230.200316" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="230.200316" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 230.200316
      <g id="line2d_26">
       <path d="M 50.610298 222.76708 
 L 572.4 222.76708 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="222.76708" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="222.76708" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 222.76708
      <g id="line2d_28">
       <path d="M 50.610298 216.328119 
 L 572.4 216.328119 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="216.328119" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="216.328119" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 216.328119
      <g id="line2d_30">
       <path d="M 50.610298 210.648552 
 L 572.4 210.648552 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="210.648552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="210.648552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 210.648552
      <g id="line2d_32">
       <path d="M 50.610298 172.144046 
 L 572.4 172.144046 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="172.144046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="172.144046" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 172.144046
      <g id="line2d_34">
       <path d="M 50.610298 152.592283 
 L 572.4 152.592283 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="152.592283" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="152.592283" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 152.592283
      <g id="line2d_36">
       <path d="M 50.610298 138.720086 
 L 572.4 138.720086 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="138.720086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="138.720086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 138.720086
      <g id="line2d_38">
       <path d="M 50.610298 127.959974 
 L 572.4 127.959974 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="127.959974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="127.959974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 127.959974
      <g id="line2d_40">
       <path d="M 50.610298 119.168322 
 L 572.4 119.168322 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="119.168322" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="119.168322" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 119.168322
      <g id="line2d_42">
       <path d="M 50.610298 111.735087 
 L 572.4 111.735087 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="111.735087" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="111.735087" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 111.735087
      <g id="line2d_44">
       <path d="M 50.610298 105.296125 
 L 572.4 105.296125 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="105.296125" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="105.296125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 105.296125
      <g id="line2d_46">
       <path d="M 50.610298 99.616559 
 L 572.4 99.616559 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="99.616559" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="99.616559" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 99.616559
      <g id="line2d_48">
       <path d="M 50.610298 61.112053 
 L 572.4 61.112053 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="61.112053" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="61.112053" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 61.112053
      <g id="line2d_50">
       <path d="M 50.610298 41.56029 
 L 572.4 41.56029 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="41.56029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="41.56029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 41.56029
      <g id="line2d_52">
       <path d="M 50.610298 27.688093 
 L 572.4 27.688093 
-" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa67e55b117)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mda5d4699e9" x="50.610298" y="27.688093" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdf3598b716" x="50.610298" y="27.688093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1863,7 +1863,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pe9ba95517d">
+  <clipPath id="pa67e55b117">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>

--- a/BerlinMOD/benchmarks/stream/streaming_windowed.svg
+++ b/BerlinMOD/benchmarks/stream/streaming_windowed.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-06T09:51:36.187746</dc:date>
+    <dc:date>2026-06-07T18:31:04.447903</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 94.237041 111681.689222
 L 94.237041 64.207425 
 L 74.328012 64.207425 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 128.428636 111681.689222 
@@ -51,7 +51,7 @@ L 148.337666 111681.689222
 L 148.337666 57.624709 
 L 128.428636 57.624709 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 182.52926 111681.689222 
@@ -59,7 +59,7 @@ L 202.43829 111681.689222
 L 202.43829 100.416657 
 L 182.52926 100.416657 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 236.629885 111681.689222 
@@ -67,7 +67,7 @@ L 256.538915 111681.689222
 L 256.538915 114.984774 
 L 236.629885 114.984774 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 290.730509 111681.689222 
@@ -75,7 +75,7 @@ L 310.639539 111681.689222
 L 310.639539 54.451756 
 L 290.730509 54.451756 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 344.831134 111681.689222 
@@ -83,7 +83,7 @@ L 364.740163 111681.689222
 L 364.740163 95.709892 
 L 344.831134 95.709892 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 398.931758 111681.689222 
@@ -91,7 +91,7 @@ L 418.840788 111681.689222
 L 418.840788 133.820466 
 L 398.931758 133.820466 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 453.032382 111681.689222 
@@ -99,7 +99,7 @@ L 472.941412 111681.689222
 L 472.941412 105.08262 
 L 453.032382 105.08262 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 507.133007 111681.689222 
@@ -107,7 +107,7 @@ L 527.042037 111681.689222
 L 527.042037 54.143415 
 L 507.133007 54.143415 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 95.968261 111681.689222 
@@ -115,7 +115,7 @@ L 115.877291 111681.689222
 L 115.877291 60.646329 
 L 95.968261 60.646329 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 150.068886 111681.689222 
@@ -123,7 +123,7 @@ L 169.977916 111681.689222
 L 169.977916 55.964768 
 L 150.068886 55.964768 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 204.16951 111681.689222 
@@ -131,7 +131,7 @@ L 224.07854 111681.689222
 L 224.07854 105.332304 
 L 204.16951 105.332304 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 258.270135 111681.689222 
@@ -139,7 +139,7 @@ L 278.179164 111681.689222
 L 278.179164 136.529551 
 L 258.270135 136.529551 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 312.370759 111681.689222 
@@ -147,7 +147,7 @@ L 332.279789 111681.689222
 L 332.279789 79.349321 
 L 312.370759 79.349321 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 366.471383 111681.689222 
@@ -155,7 +155,7 @@ L 386.380413 111681.689222
 L 386.380413 126.330944 
 L 366.471383 126.330944 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 420.572008 111681.689222 
@@ -163,7 +163,7 @@ L 440.481037 111681.689222
 L 440.481037 151.5052 
 L 420.572008 151.5052 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 474.672632 111681.689222 
@@ -171,7 +171,7 @@ L 494.581662 111681.689222
 L 494.581662 115.217454 
 L 474.672632 115.217454 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 528.773256 111681.689222 
@@ -179,18 +179,18 @@ L 548.682286 111681.689222
 L 548.682286 77.795862 
 L 528.773256 77.795862 
 z
-" clip-path="url(#p8358c3e818)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe9ba95517d)" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0ceff75a5e" d="M 0 0 
+       <path id="m5456cb7167" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0ceff75a5e" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="95.102651" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -246,7 +246,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="149.203276" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -286,7 +286,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="203.3039" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -334,7 +334,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="257.404525" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -369,7 +369,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="311.505149" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -410,7 +410,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="365.605773" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -456,7 +456,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="419.706398" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -482,7 +482,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="473.807022" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -537,7 +537,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0ceff75a5e" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5456cb7167" x="527.907646" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1002,16 +1002,16 @@ z
      <g id="line2d_10">
       <path d="M 50.610298 316.6 
 L 572.4 316.6 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="m2ef52f2589" d="M 0 0 
+       <path id="m951819aae4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2ef52f2589" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m951819aae4" x="50.610298" y="316.6" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1050,11 +1050,11 @@ z
      <g id="line2d_12">
       <path d="M 50.610298 205.568007 
 L 572.4 205.568007 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m2ef52f2589" x="50.610298" y="205.568007" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m951819aae4" x="50.610298" y="205.568007" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1070,11 +1070,11 @@ L 572.4 205.568007
      <g id="line2d_14">
       <path d="M 50.610298 94.536014 
 L 572.4 94.536014 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2ef52f2589" x="50.610298" y="94.536014" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m951819aae4" x="50.610298" y="94.536014" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1090,16 +1090,16 @@ L 572.4 94.536014
      <g id="line2d_16">
       <path d="M 50.610298 283.17604 
 L 572.4 283.17604 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <defs>
-       <path id="m925ae40f1d" d="M 0 0 
+       <path id="mda5d4699e9" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="283.17604" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="283.17604" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1107,11 +1107,11 @@ L -2 0
      <g id="line2d_18">
       <path d="M 50.610298 263.624276 
 L 572.4 263.624276 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="263.624276" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="263.624276" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1119,11 +1119,11 @@ L 572.4 263.624276
      <g id="line2d_20">
       <path d="M 50.610298 249.752079 
 L 572.4 249.752079 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="249.752079" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="249.752079" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1131,11 +1131,11 @@ L 572.4 249.752079
      <g id="line2d_22">
       <path d="M 50.610298 238.991967 
 L 572.4 238.991967 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="238.991967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="238.991967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1143,11 +1143,11 @@ L 572.4 238.991967
      <g id="line2d_24">
       <path d="M 50.610298 230.200316 
 L 572.4 230.200316 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="230.200316" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="230.200316" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1155,11 +1155,11 @@ L 572.4 230.200316
      <g id="line2d_26">
       <path d="M 50.610298 222.76708 
 L 572.4 222.76708 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="222.76708" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="222.76708" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1167,11 +1167,11 @@ L 572.4 222.76708
      <g id="line2d_28">
       <path d="M 50.610298 216.328119 
 L 572.4 216.328119 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="216.328119" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="216.328119" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1179,11 +1179,11 @@ L 572.4 216.328119
      <g id="line2d_30">
       <path d="M 50.610298 210.648552 
 L 572.4 210.648552 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="210.648552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="210.648552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1191,11 +1191,11 @@ L 572.4 210.648552
      <g id="line2d_32">
       <path d="M 50.610298 172.144046 
 L 572.4 172.144046 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="172.144046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="172.144046" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1203,11 +1203,11 @@ L 572.4 172.144046
      <g id="line2d_34">
       <path d="M 50.610298 152.592283 
 L 572.4 152.592283 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="152.592283" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="152.592283" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1215,11 +1215,11 @@ L 572.4 152.592283
      <g id="line2d_36">
       <path d="M 50.610298 138.720086 
 L 572.4 138.720086 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="138.720086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="138.720086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1227,11 +1227,11 @@ L 572.4 138.720086
      <g id="line2d_38">
       <path d="M 50.610298 127.959974 
 L 572.4 127.959974 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="127.959974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="127.959974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1239,11 +1239,11 @@ L 572.4 127.959974
      <g id="line2d_40">
       <path d="M 50.610298 119.168322 
 L 572.4 119.168322 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="119.168322" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="119.168322" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1251,11 +1251,11 @@ L 572.4 119.168322
      <g id="line2d_42">
       <path d="M 50.610298 111.735087 
 L 572.4 111.735087 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="111.735087" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="111.735087" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1263,11 +1263,11 @@ L 572.4 111.735087
      <g id="line2d_44">
       <path d="M 50.610298 105.296125 
 L 572.4 105.296125 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="105.296125" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="105.296125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1275,11 +1275,11 @@ L 572.4 105.296125
      <g id="line2d_46">
       <path d="M 50.610298 99.616559 
 L 572.4 99.616559 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="99.616559" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="99.616559" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1287,11 +1287,11 @@ L 572.4 99.616559
      <g id="line2d_48">
       <path d="M 50.610298 61.112053 
 L 572.4 61.112053 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="61.112053" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="61.112053" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1299,11 +1299,11 @@ L 572.4 61.112053
      <g id="line2d_50">
       <path d="M 50.610298 41.56029 
 L 572.4 41.56029 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="41.56029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="41.56029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1311,11 +1311,11 @@ L 572.4 41.56029
      <g id="line2d_52">
       <path d="M 50.610298 27.688093 
 L 572.4 27.688093 
-" clip-path="url(#p8358c3e818)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pe9ba95517d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m925ae40f1d" x="50.610298" y="27.688093" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda5d4699e9" x="50.610298" y="27.688093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1863,7 +1863,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8358c3e818">
+  <clipPath id="pe9ba95517d">
    <rect x="50.610298" y="25.8" width="521.789702" height="290.8"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
The stream benchmark corpus is the canonical BerlinMOD instants at scale factor 0.005 — the same dataset as the batch benchmark — sourced from berlinmod-3db-canonical/instants.csv (SRID 3857 EWKB), reprojected EPSG:3857→EPSG:4326 at load. Timing cells are cleared pending re-benchmark on this corpus.