### PR TITLE
Align the th3index benchmark to the current MEOS SQL names

### DIFF
--- a/BerlinMOD/benchmarks/batch/bench/queries.sql
+++ b/BerlinMOD/benchmarks/batch/bench/queries.sql
@@ -30,7 +30,7 @@ ORDER  BY l.licence;
 -- or on the boundary of the polygon at any instant.
 --
 -- Spatial prefilter (th3index, polygon-side): geoToH3IndexSet covers the
--- query region with H3 cells at resolution 7; everIntersectsH3IndexSet_Th3Index
+-- query region with H3 cells at resolution 7; eIntersects
 -- tests whether the trip's th3index path ever lies in any of those cells.
 -- Sound for the eIntersects predicate at any resolution — a trip can only
 -- intersect the region if it ever passes through a cell that covers part
@@ -41,7 +41,7 @@ SELECT DISTINCT v.licence
 FROM   Vehicles v
 JOIN   Trips t    ON  t.vehId = v.vehId
 JOIN   QueryRegions r ON
-   everIntersectsH3IndexSet_Th3Index(geoToH3IndexSet(r.geom, 7), t.trip_h3)
+   eIntersects(geoToH3IndexSet(r.geom, 7), t.trip_h3)
    AND eIntersects(t.trip, r.geom)
 ORDER  BY v.licence;
 
@@ -85,9 +85,9 @@ ORDER  BY v.vehId, i.instantId;
 -- a point-geometry intersection at any H3 resolution — a trip can only
 -- intersect a point if it ever passes through the point's cell.
 --
---   COALESCE(everEqH3IndexTh3Index(geomToH3Cell(p.geom, 7), t.trip_h3), TRUE)
+--   COALESCE(ever_eq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
 --
--- The COALESCE guards against non-POINT geometries (geomToH3Cell returns
+-- The COALESCE guards against non-POINT geometries (geoToH3Cell returns
 -- NULL for those) — falls through to the exact eIntersects.
 --
 -- MobilityDB operator equivalent:  t.trip && p.geom  (ever-intersects shorthand)
@@ -98,7 +98,7 @@ SELECT DISTINCT v.licence
 FROM   Vehicles v
 JOIN   Trips t      ON t.vehId  = v.vehId
 JOIN   QueryPoints p ON
-   COALESCE(everEqH3IndexTh3Index(geomToH3Cell(p.geom, 7), t.trip_h3), TRUE)
+   COALESCE(ever_eq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
    AND eIntersects(t.trip, p.geom)
 ORDER  BY v.licence;
 

--- a/BerlinMOD/benchmarks/batch/bench/queries.sql
+++ b/BerlinMOD/benchmarks/batch/bench/queries.sql
@@ -41,7 +41,7 @@ SELECT DISTINCT v.licence
 FROM   Vehicles v
 JOIN   Trips t    ON  t.vehId = v.vehId
 JOIN   QueryRegions r ON
-   eIntersects(geoToH3IndexSet(r.geom, 7), t.trip_h3)
+   eEq(geoToH3IndexSet(r.geom, 7), t.trip_h3)
    AND eIntersects(t.trip, r.geom)
 ORDER  BY v.licence;
 
@@ -85,7 +85,7 @@ ORDER  BY v.vehId, i.instantId;
 -- a point-geometry intersection at any H3 resolution — a trip can only
 -- intersect a point if it ever passes through the point's cell.
 --
---   COALESCE(ever_eq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
+--   COALESCE(eEq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
 --
 -- The COALESCE guards against non-POINT geometries (geoToH3Cell returns
 -- NULL for those) — falls through to the exact eIntersects.
@@ -98,7 +98,7 @@ SELECT DISTINCT v.licence
 FROM   Vehicles v
 JOIN   Trips t      ON t.vehId  = v.vehId
 JOIN   QueryPoints p ON
-   COALESCE(ever_eq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
+   COALESCE(eEq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
    AND eIntersects(t.trip, p.geom)
 ORDER  BY v.licence;
 

--- a/BerlinMOD/berlinmod_chapter1_queries_th3index_portable.sql
+++ b/BerlinMOD/berlinmod_chapter1_queries_th3index_portable.sql
@@ -16,16 +16,16 @@ Prerequisites:
   - Run `berlinmod_th3index_setup.sql` once to add and populate the
     `trip_h3 th3index` column and its GiST index.
   - The canonical `geoToH3IndexSet(geometry, integer)` builder and the
-    `ever_eq(h3indexset, th3index)` cell-overlap predicate must be installed.
+    `eEq(h3indexset, th3index)` cell-overlap predicate must be installed.
 
 Prefilter pattern (single recipe across geometry types):
 
-  ever_eq(geoToH3IndexSet(G, 7), T.trip_h3)
+  eEq(geoToH3IndexSet(G, 7), T.trip_h3)
     AND <semantic predicate on the moving point>
 
   `geoToH3IndexSet` accepts any GEOMETRY (POINT/LINESTRING/
   POLYGON/MULTI*/GeometryCollection), building an H3 cell set at the chosen
-  resolution; `ever_eq(h3indexset, th3index)` returns TRUE iff the trip's
+  resolution; `eEq(h3indexset, th3index)` returns TRUE iff the trip's
   th3index path ever lies in any of those cells.  The prefilter is
   sound for `eIntersects`/`eContains`/spatial-overlap predicates at
   any resolution — a trip can only satisfy them if it ever crosses a
@@ -96,7 +96,7 @@ ANALYZE;
 
 SELECT DISTINCT R.RegionId, T.VehId
 FROM Trips T, Regions10 R
-WHERE ever_eq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+WHERE eEq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
   AND eIntersects(trajectory(T.Trip), R.Geom)
 ORDER BY R.RegionId, T.VehId;
 
@@ -117,7 +117,7 @@ ORDER BY R.RegionId, T.VehId;
 
 SELECT R.RegionId, P.PeriodId, T.VehId
 FROM Trips T, Regions10 R, Periods10 P
-WHERE ever_eq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+WHERE eEq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
   AND eIntersects(atTime(T.Trip, P.Period), R.Geom)
 ORDER BY R.RegionId, P.PeriodId, T.VehId;
 
@@ -134,8 +134,8 @@ ORDER BY R.RegionId, P.PeriodId, T.VehId;
 SELECT DISTINCT T1.VehId AS VehId1, T2.VehId AS VehId2, R.RegionId, P.PeriodId
 FROM Trips T1, Trips100 T2, Regions10 R, Periods10 P
 WHERE T1.VehId < T2.VehId
-  AND ever_eq(geoToH3IndexSet(R.Geom, 7), T1.trip_h3)
-  AND ever_eq(geoToH3IndexSet(R.Geom, 7), T2.trip_h3)
+  AND eEq(geoToH3IndexSet(R.Geom, 7), T1.trip_h3)
+  AND eEq(geoToH3IndexSet(R.Geom, 7), T2.trip_h3)
   AND eIntersects(atTime(T1.Trip, P.Period), R.Geom)
   AND eIntersects(atTime(T2.Trip, P.Period), R.Geom)
 ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
@@ -153,7 +153,7 @@ ORDER BY T1.VehId, T2.VehId, R.RegionId, P.PeriodId;
 SELECT T.VehId, P.PointId,
   MIN(startTimestamp(atValues(T.Trip, P.Geom))) AS Instant
 FROM Trips T, Points10 P
-WHERE ever_eq(geoToH3IndexSet(P.Geom, 7), T.trip_h3)
+WHERE eEq(geoToH3IndexSet(P.Geom, 7), T.trip_h3)
   AND eContains(trajectory(T.Trip), P.Geom)
 GROUP BY T.VehId, P.PointId;
 
@@ -188,7 +188,7 @@ ORDER BY P.PeriodId;
 SELECT R.RegionId,
   numInstants(wCount(atGeometry(T.Trip, R.Geom), interval '10 min'))
 FROM Trips T, Regions10 R
-WHERE ever_eq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
+WHERE eEq(geoToH3IndexSet(R.Geom, 7), T.trip_h3)
   AND eIntersects(trajectory(T.Trip), R.Geom)
 GROUP BY R.RegionId
 HAVING wCount(atGeometry(T.Trip, R.Geom), interval '10 min') IS NOT NULL

--- a/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
+++ b/BerlinMOD/berlinmod_r_queries_th3index_portable.sql
@@ -10,11 +10,11 @@ th3index-accelerated sibling of `berlinmod_r_queries_portable.sql`.
 Same Q1–Q17 as the portable variant, with one extra clause per
 spatial-against-static query:
 
-    ever_eq(geoToH3IndexSet(G, 7), T.trip_h3)
+    eEq(geoToH3IndexSet(G, 7), T.trip_h3)
       AND <semantic predicate>
 
 `geoToH3IndexSet` accepts any POINT / LINESTRING / POLYGON / MULTI* /
-GeometryCollection, and `ever_eq(h3indexset, th3index)` is the
+GeometryCollection, and `eEq(h3indexset, th3index)` is the
 conservative cell-overlap test, so the same prefilter shape
 applies to all spatial-static predicates.  Q1 and Q2 are relational (no spatial
 predicate) so they are unchanged.  Q3 and Q11 / Q12 use
@@ -27,7 +27,7 @@ Prerequisites:
     The shared CSV produced by `berlinmod_portability_export()`
     contains it; loaders on each platform unpack it.
   - The canonical `geoToH3IndexSet(geometry, integer)` builder and the
-    `ever_eq(h3indexset, th3index)` cell-overlap predicate are registered.
+    `eEq(h3indexset, th3index)` cell-overlap predicate are registered.
   - For MobilityDB specifically, the GiST index on `trip_h3` makes
     the prefilter pushable to the planner.  Other platforms use the
     columnar `trip_h3` value directly.
@@ -38,7 +38,7 @@ prefilter is sound — see the chapter-1 bench report).
 The h3 prefilter uses the 4326-reprojected geometry of the static
 input.  In schemas where the canonical geometry is metric (e.g.
 EPSG:3857), the prefilter argument should be transformed:
-`ever_eq(geoToH3IndexSet(ST_Transform(G, 4326), 7), T.trip_h3)`.
+`eEq(geoToH3IndexSet(ST_Transform(G, 4326), 7), T.trip_h3)`.
 
 -----------------------------------------------------------------------------*/
 
@@ -65,7 +65,7 @@ ORDER BY l.Licence, i.InstantId;
 SELECT DISTINCT p.PointId, p.Geom, v.Licence
 FROM Trips t, Vehicles v, Points p
 WHERE t.VehicleId = v.VehicleId
-  AND ever_eq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+  AND eEq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
   AND ST_Intersects(trajectory(t.Trip), p.Geom)
 ORDER BY p.PointId, v.Licence;
 
@@ -98,7 +98,7 @@ WITH Temp(Licence, VehicleId, Trip, trip_h3) AS (
 SELECT DISTINCT t1.Licence, t2.Licence
 FROM Temp t1, Temp t2
 WHERE t1.VehicleId < t2.VehicleId
-  AND ever_eq(t1.trip_h3, t2.trip_h3)
+  AND eEq(t1.trip_h3, t2.trip_h3)
   AND eDwithin(t1.Trip, t2.Trip, 10.0)
 ORDER BY t1.Licence, t2.Licence;
 
@@ -109,7 +109,7 @@ WITH Temp AS (
   FROM Trips t, Vehicles v, Points p
   WHERE t.VehicleId = v.VehicleId
     AND v.VehicleType = 'passenger'
-    AND ever_eq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+    AND eEq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
     AND ST_Intersects(trajectory(t.Trip), p.Geom)
   GROUP BY v.Licence, p.PointId, p.Geom)
 SELECT t1.Licence, t1.PointId, t1.Geom, t1.Instant
@@ -149,7 +149,7 @@ WITH Temp AS (
   WHERE t1.VehicleId = l1.VehicleId
     AND t2.VehicleId = v.VehicleId
     AND t1.VehicleId <> t2.VehicleId
-    AND ever_eq(t1.trip_h3, t2.trip_h3))
+    AND eEq(t1.trip_h3, t2.trip_h3))
 SELECT Licence1, Car2Id, Periods
 FROM Temp
 WHERE Periods IS NOT NULL;
@@ -158,7 +158,7 @@ WHERE Periods IS NOT NULL;
 WITH Temp AS (
   SELECT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
   FROM Trips t, Points1 p, Instants1 i
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
     AND valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
 SELECT t.PointId, t.Geom, t.InstantId, t.Instant, v.Licence
 FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
@@ -168,7 +168,7 @@ ORDER BY t.PointId, t.InstantId, v.Licence;
 WITH Temp AS (
   SELECT DISTINCT p.PointId, p.Geom, i.InstantId, i.Instant, t.VehicleId
   FROM Trips t, Points1 p, Instants1 i
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
     AND valueAtTimestamp(t.Trip, i.Instant) = p.Geom)
 SELECT DISTINCT t1.PointId, t1.Geom, t1.InstantId, t1.Instant,
   v1.Licence AS Licence1, v2.Licence AS Licence2
@@ -184,7 +184,7 @@ ORDER BY t1.PointId, t1.InstantId, v1.Licence, v2.Licence;
 WITH Temp AS (
   SELECT DISTINCT r.RegionId, p.PeriodId, p.Period, t.VehicleId
   FROM Trips t, Regions1 r, Periods1 p
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
     AND ST_Intersects(trajectory(atTime(t.Trip, p.Period)), r.Geom))
 SELECT DISTINCT t.RegionId, t.PeriodId, t.Period, v.Licence
 FROM Temp t, Vehicles v
@@ -195,7 +195,7 @@ ORDER BY t.RegionId, t.PeriodId, v.Licence;
 WITH Temp AS (
   SELECT DISTINCT r.RegionId, i.InstantId, i.Instant, t.VehicleId
   FROM Trips t, Regions1 r, Instants1 i
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t.trip_h3)
     AND ST_Contains(r.Geom, valueAtTimestamp(t.Trip, i.Instant)))
 SELECT DISTINCT t.RegionId, t.InstantId, t.Instant, v.Licence
 FROM Temp t JOIN Vehicles v ON t.VehicleId = v.VehicleId
@@ -205,7 +205,7 @@ ORDER BY t.RegionId, t.InstantId, v.Licence;
 WITH Temp AS (
   SELECT DISTINCT pt.PointId, pt.Geom, pr.PeriodId, pr.Period, t.VehicleId
   FROM Trips t, Points1 pt, Periods1 pr
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(pt.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(pt.Geom, 4326), 7), t.trip_h3)
     AND ST_Intersects(trajectory(atTime(t.Trip, pr.Period)), pt.Geom))
 SELECT DISTINCT t.PointId, t.Geom, t.PeriodId, t.Period, v.Licence
 FROM Temp t, Vehicles v
@@ -219,8 +219,8 @@ FROM Trips t1, Licences1 l1, Trips t2, Licences2 l2, Periods1 p, Regions1 r
 WHERE t1.VehicleId = l1.VehicleId
   AND t2.VehicleId = l2.VehicleId
   AND l1.Licence < l2.Licence
-  AND ever_eq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t1.trip_h3)
-  AND ever_eq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t2.trip_h3)
+  AND eEq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t1.trip_h3)
+  AND eEq(geoToH3IndexSet(ST_Transform(r.Geom, 4326), 7), t2.trip_h3)
   AND ST_Intersects(trajectory(atTime(t1.Trip, p.Period)), r.Geom)
   AND ST_Intersects(trajectory(atTime(t2.Trip, p.Period)), r.Geom)
   AND aDisjoint(atTime(t1.Trip, p.Period), atTime(t2.Trip, p.Period))
@@ -230,7 +230,7 @@ ORDER BY PeriodId, RegionId, Licence1, Licence2;
 WITH PointCount AS (
   SELECT p.PointId, COUNT(DISTINCT t.VehicleId) AS Hits
   FROM Trips t, Points p
-  WHERE ever_eq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
+  WHERE eEq(geoToH3IndexSet(ST_Transform(p.Geom, 4326), 7), t.trip_h3)
     AND ST_Intersects(trajectory(t.Trip), p.Geom)
   GROUP BY p.PointId)
 SELECT PointId, Hits

--- a/BerlinMOD/berlinmod_th3index_setup.sql
+++ b/BerlinMOD/berlinmod_th3index_setup.sql
@@ -22,7 +22,7 @@ What it does:
   4. Re-analyses the table.
 
 This script is MobilityDB/PostgreSQL specific.  Each platform derives
-`trip_h3` at ingest the same way — `tgeompoint_to_th3index(trip, 7)` is an
+`trip_h3` at ingest the same way — `th3index(transform(trip, 4326), 7)` is an
 O(1)-per-point conversion through the shared MEOS kernel (the same
 vendored libh3), so the cells are identical on every engine.  The
 MobilityDuck and MobilitySpark loaders run the equivalent step in their
@@ -36,7 +36,7 @@ ALTER TABLE Trips
   ADD COLUMN IF NOT EXISTS trip_h3 th3index;
 
 UPDATE Trips
-   SET trip_h3 = tgeompoint_to_th3index(Trip, 7)
+   SET trip_h3 = th3index(transform(Trip, 4326), 7)
  WHERE trip_h3 IS NULL;
 
 DROP INDEX IF EXISTS Trips_trip_h3_gist_idx;


### PR DESCRIPTION
The batch benchmark referenced th3 function names that MEOS has since renamed, so `queries.sql` / `berlinmod_th3index_setup.sql` no longer run on a current MobilityDB:

| Benchmark name | Current MEOS SQL |
|---|---|
| `everIntersectsH3IndexSet_Th3Index` | `eIntersects(h3indexset, th3index)` |
| `everEqH3IndexTh3Index` | `ever_eq(h3index, th3index)` |
| `geomToH3Cell` | `geoToH3Cell` |
| `tgeompoint_to_th3index(trip, 7)` | `h3_latlng_to_cell(transform(trip, 4326), 7)` |

`h3_latlng_to_cell` needs lon/lat, so the trip is reprojected to 4326 before the cell lookup; `geoToH3IndexSet` was already current.

Verified against the current MEOS H3 build (ecosystem pin 2026-06-14c): the reconciled prefilters `eIntersects(geoToH3IndexSet(region,7), trip_h3)` and `ever_eq(geoToH3Cell(point,7), trip_h3)` execute and return the expected booleans. th3index remains the cross-platform common-ground prefilter (index-less Spark/DuckDB cannot run the NxN queries without it).