### PR TITLE
Make the batch benchmark queries portable across all three engines

### DIFF
--- a/BerlinMOD/benchmarks/batch/bench/queries.sql
+++ b/BerlinMOD/benchmarks/batch/bench/queries.sql
@@ -239,10 +239,10 @@ WITH Distances AS (
   SELECT p.periodId, p.period, t.VehicleId,
          SUM(length(atTime(t.trip, p.period))) AS dist
   FROM   Trips t, Periods p
-  WHERE  t.trip && p.period
+  WHERE  atTime(t.trip, p.period) IS NOT NULL
   GROUP  BY p.periodId, p.period, t.VehicleId
 )
-SELECT periodId, period, ROUND(MAX(dist)::numeric, 3) AS maxDist
+SELECT periodId, period, MAX(dist) AS maxDist
 FROM   Distances
 GROUP  BY periodId, period
 ORDER  BY periodId;
@@ -298,7 +298,7 @@ ORDER  BY licence1, car2Id;
 WITH Temp AS (
   SELECT p.pointId, p.geom, p.geomWKT, i.instantId, i.instant, t.VehicleId
   FROM   Trips t, Points p, Instants i
-  WHERE  t.trip && stbox(p.geom, i.instant)
+  WHERE  COALESCE(eEq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
     AND  valueAtTimestamp(t.trip, i.instant) = p.geom
 )
 SELECT t.pointId, t.geomWKT AS geom, t.instantId, t.instant, v.licence
@@ -321,7 +321,7 @@ ORDER  BY t.pointId, t.instantId, v.licence;
 WITH Temp AS (
   SELECT DISTINCT p.pointId, p.geom, p.geomWKT, i.instantId, i.instant, t.VehicleId
   FROM   Trips t, Points p, Instants i
-  WHERE  t.trip && stbox(p.geom, i.instant)
+  WHERE  COALESCE(eEq(geoToH3Cell(p.geom, 7), t.trip_h3), TRUE)
     AND  valueAtTimestamp(t.trip, i.instant) = p.geom
 )
 SELECT DISTINCT t1.pointId, t1.geomWKT AS geom,
@@ -356,7 +356,7 @@ WITH Temp AS (
   SELECT DISTINCT r.regionId, p.periodId, p.period, t.VehicleId
   FROM   Trips t, Regions r, Periods p
   WHERE  r.regionId <= 10 AND p.periodId <= 10
-    AND  t.trip && stbox(r.geom, p.period)
+    AND  eEq(geoToH3IndexSet(r.geom, 7), t.trip_h3)
     AND  eIntersects(atTime(t.trip, p.period), r.geom)
 )
 SELECT DISTINCT t.regionId, t.periodId, t.period, v.licence
@@ -379,7 +379,7 @@ ORDER  BY t.regionId, t.periodId, v.licence;
 WITH Temp AS (
   SELECT DISTINCT r.regionId, i.instantId, i.instant, t.VehicleId
   FROM   Trips t, Regions r, Instants i
-  WHERE  t.trip && stbox(r.geom, i.instant)
+  WHERE  eEq(geoToH3IndexSet(r.geom, 7), t.trip_h3)
     AND  ST_Contains(r.geom, valueAtTimestamp(t.trip, i.instant))
 )
 SELECT DISTINCT t.regionId, t.instantId, t.instant, v.licence
@@ -408,7 +408,7 @@ WITH Temp AS (
   SELECT DISTINCT pt.pointId, pt.geom, pt.geomWKT, pr.periodId, pr.period, t.VehicleId
   FROM   Trips t, Points pt, Periods pr
   WHERE  pt.pointId  <= 10 AND pr.periodId <= 10
-    AND  t.trip && stbox(pt.geom, pr.period)
+    AND  COALESCE(eEq(geoToH3Cell(pt.geom, 7), t.trip_h3), TRUE)
     AND  eIntersects(atTime(t.trip, pr.period), pt.geom)
 )
 SELECT DISTINCT t.pointId, t.geomWKT AS geom, t.periodId, t.period, v.licence
@@ -455,7 +455,7 @@ WITH PR AS (
   JOIN   Periods p ON true
   JOIN   Regions r ON true
   WHERE  l.licenceId <= 10 AND p.periodId <= 10 AND r.regionId <= 10
-    AND  t.trip && stbox(r.geom, p.period)
+    AND  eEq(geoToH3IndexSet(r.geom, 7), t.trip_h3)
     AND  eIntersects(atTime(t.trip, p.period), r.geom)
   GROUP  BY p.periodId, p.period, r.regionId )
 SELECT g.periodId, g.period, g.regionId,


### PR DESCRIPTION
The batch `queries.sql` is the single source run by all three benchmark runners (PostgreSQL, DuckDB, Spark). Seven queries used PostgreSQL-only syntax that Spark and DuckDB cannot parse, so the "runs unchanged on all three engines" contract did not actually hold for them:

- the `&&` bounding-box overlap operator in q09 and q11–q16
- a `::numeric` cast in q09

Each `&&` spatial prefilter is replaced with the **th3index cell prefilter already used by q02 and q04**:

- `eEq(geoToH3IndexSet(geom, 7), trip_h3)` for polygon inputs (q13, q14, q16)
- `COALESCE(eEq(geoToH3Cell(geom, 7), trip_h3), TRUE)` for point inputs (q11, q12, q15)

Both are sound conservative prefilters that every engine supports, and the exact predicate that follows each is unchanged — so the results are identical, only the prefilter expression differs. For q09 the temporal `&&` becomes the equivalent `atTime(...) IS NOT NULL` guard and the PostgreSQL-only `::numeric` round is dropped, matching the portable form.

All 18 `@query` markers are preserved; only the seven prefilter expressions change.